### PR TITLE
go: use github.com/d2lang/util-go

### DIFF
--- a/cmd/d2plugin-dagre/main.go
+++ b/cmd/d2plugin-dagre/main.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2plugin"
 )

--- a/d2ast/d2ast.go
+++ b/d2ast/d2ast.go
@@ -35,7 +35,7 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 )
 
 // Node is the base interface implemented by all d2 AST nodes.

--- a/d2ast/d2ast_test.go
+++ b/d2ast/d2ast_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/xrand"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/xrand"
 
-	"oss.terrastruct.com/util-go/diff"
+	"github.com/d2lang/util-go/diff"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2chaos/d2chaos.go
+++ b/d2chaos/d2chaos.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2cli/fmt.go
+++ b/d2cli/fmt.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2format"
 	"oss.terrastruct.com/d2/d2parser"

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2plugin"
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/multierr"
 
-	"oss.terrastruct.com/util-go/go2"
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/go2"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2graph"

--- a/d2cli/play.go
+++ b/d2cli/play.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/d2lang/util-go/xbrowser"
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/lib/urlenc"
-	"oss.terrastruct.com/util-go/xbrowser"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 func playCmd(ctx context.Context, ms *xmain.State) error {

--- a/d2cli/validate.go
+++ b/d2cli/validate.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/d2lang/util-go/xdefer"
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/d2lib"
-	"oss.terrastruct.com/util-go/xdefer"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 func validateCmd(ctx context.Context, ms *xmain.State) (err error) {

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -21,11 +21,11 @@ import (
 	"github.com/coder/websocket/wsjson"
 	"github.com/fsnotify/fsnotify"
 
-	"oss.terrastruct.com/util-go/xbrowser"
+	"github.com/d2lang/util-go/xbrowser"
 
-	"oss.terrastruct.com/util-go/xhttp"
+	"github.com/d2lang/util-go/xhttp"
 
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2plugin"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -8,9 +8,9 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/mapfs"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/mapfs"
 
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2exporter/export.go
+++ b/d2exporter/export.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2graph"

--- a/d2exporter/export_test.go
+++ b/d2exporter/export_test.go
@@ -9,9 +9,9 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2exporter"

--- a/d2format/escape_test.go
+++ b/d2format/escape_test.go
@@ -3,7 +3,7 @@ package d2format_test
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2format/format_test.go
+++ b/d2format/format_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 
 	"oss.terrastruct.com/d2/d2format"
 	"oss.terrastruct.com/d2/d2parser"

--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2graph/d2graph_test.go
+++ b/d2graph/d2graph_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2parser"

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2target"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type SerializedGraph struct {

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2ir/compile_test.go
+++ b/d2ir/compile_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/mapfs"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/mapfs"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2ir"

--- a/d2ir/d2ir.go
+++ b/d2ir/d2ir.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2ir/d2ir_test.go
+++ b/d2ir/d2ir_test.go
@@ -3,7 +3,7 @@ package d2ir_test
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2ir"

--- a/d2ir/filter_test.go
+++ b/d2ir/filter_test.go
@@ -3,7 +3,7 @@ package d2ir_test
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 )
 
 func testCompileFilters(t *testing.T) {

--- a/d2ir/import_test.go
+++ b/d2ir/import_test.go
@@ -3,7 +3,7 @@ package d2ir_test
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 
 	"oss.terrastruct.com/d2/d2ir"
 )

--- a/d2ir/pattern_test.go
+++ b/d2ir/pattern_test.go
@@ -3,7 +3,7 @@ package d2ir_test
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 )
 
 func testCompilePatterns(t *testing.T) {

--- a/d2js/d2wasm/functions.go
+++ b/d2js/d2wasm/functions.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall/js"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2format"
@@ -31,7 +32,6 @@ import (
 	"oss.terrastruct.com/d2/lib/textmeasure"
 	"oss.terrastruct.com/d2/lib/urlenc"
 	"oss.terrastruct.com/d2/lib/version"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 const DEFAULT_INPUT_PATH = "index"

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -11,9 +11,9 @@ import (
 
 	"log/slog"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2target"

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -14,9 +14,9 @@ import (
 	"strconv"
 	"strings"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2target"

--- a/d2layouts/d2elklayout/wasm.go
+++ b/d2layouts/d2elklayout/wasm.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/d2lang/util-go/go2"
+	"github.com/d2lang/util-go/xdefer"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/label"
-	"oss.terrastruct.com/util-go/go2"
-	"oss.terrastruct.com/util-go/xdefer"
 )
 
 // This is mostly copy paste from Layout until elk.layout step

--- a/d2layouts/d2grid/layout.go
+++ b/d2layouts/d2grid/layout.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2target"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/label"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 const (

--- a/d2layouts/d2layouts.go
+++ b/d2layouts/d2layouts.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2grid"
 	"oss.terrastruct.com/d2/d2layouts/d2near"
@@ -15,7 +16,6 @@ import (
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/label"
 	"oss.terrastruct.com/d2/lib/log"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type DiagramType string

--- a/d2layouts/d2sequence/layout.go
+++ b/d2layouts/d2sequence/layout.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2target"

--- a/d2layouts/d2sequence/sequence_diagram.go
+++ b/d2layouts/d2sequence/sequence_diagram.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2target"

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2exporter"
@@ -19,7 +20,6 @@ import (
 	"oss.terrastruct.com/d2/d2target"
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/textmeasure"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type CompileOptions struct {

--- a/d2lsp/d2lsp_test.go
+++ b/d2lsp/d2lsp_test.go
@@ -4,9 +4,9 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/d2lang/util-go/assert"
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2lsp"
-	"oss.terrastruct.com/util-go/assert"
 )
 
 func TestGetFieldRanges(t *testing.T) {

--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"unicode"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 
-	"oss.terrastruct.com/util-go/xrand"
+	"github.com/d2lang/util-go/xrand"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2compiler"

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/go2"
-	"oss.terrastruct.com/util-go/mapfs"
-	"oss.terrastruct.com/util-go/xjson"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/go2"
+	"github.com/d2lang/util-go/mapfs"
+	"github.com/d2lang/util-go/xjson"
 
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2parser/parse.go
+++ b/d2parser/parse.go
@@ -14,8 +14,8 @@ import (
 	tunicode "golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2ast"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type ParseOptions struct {

--- a/d2parser/parse_test.go
+++ b/d2parser/parse_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
 
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2format"

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"oss.terrastruct.com/util-go/xdefer"
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xdefer"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
 	timelib "oss.terrastruct.com/d2/lib/time"

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -11,8 +11,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"oss.terrastruct.com/util-go/xexec"
-	"oss.terrastruct.com/util-go/xmain"
+	"github.com/d2lang/util-go/xexec"
+	"github.com/d2lang/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
 )

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 var DagrePlugin = dagrePlugin{}

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 var ELKPlugin = elkPlugin{}

--- a/d2plugin/serve.go
+++ b/d2plugin/serve.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/d2graph"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 // Serve returns a xmain.RunFunc that will invoke the plugin p as necessary to service the

--- a/d2renderers/d2fonts/d2fonts_test.go
+++ b/d2renderers/d2fonts/d2fonts_test.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
 	"oss.terrastruct.com/d2/lib/font"
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
 )
 
 func TestCutFont(t *testing.T) {

--- a/d2renderers/d2latex/latex_common.go
+++ b/d2renderers/d2latex/latex_common.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/d2lang/util-go/xdefer"
 	"oss.terrastruct.com/d2/lib/jsrunner"
-	"oss.terrastruct.com/util-go/xdefer"
 )
 
 var pxPerEx = 8

--- a/d2renderers/d2sketch/sketch.go
+++ b/d2renderers/d2sketch/sketch.go
@@ -9,6 +9,7 @@ import (
 
 	_ "embed"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2target"
 	"oss.terrastruct.com/d2/d2themes"
 	"oss.terrastruct.com/d2/lib/color"
@@ -16,7 +17,6 @@ import (
 	"oss.terrastruct.com/d2/lib/jsrunner"
 	"oss.terrastruct.com/d2/lib/label"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 //go:embed rough.js

--- a/d2renderers/d2sketch/sketch_test.go
+++ b/d2renderers/d2sketch/sketch_test.go
@@ -11,9 +11,9 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
 	"oss.terrastruct.com/d2/d2renderers/d2svg"
@@ -19,7 +20,6 @@ import (
 	"oss.terrastruct.com/d2/lib/color"
 	svglib "oss.terrastruct.com/d2/lib/svg"
 	"oss.terrastruct.com/d2/lib/textmeasure"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 //        ┌──────────────┐

--- a/d2renderers/d2svg/appendix/appendix_test.go
+++ b/d2renderers/d2svg/appendix/appendix_test.go
@@ -11,8 +11,8 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2ast"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
@@ -37,7 +38,6 @@ import (
 	"oss.terrastruct.com/d2/lib/svg"
 	"oss.terrastruct.com/d2/lib/textmeasure"
 	"oss.terrastruct.com/d2/lib/version"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 const (

--- a/d2renderers/d2svg/dark_theme/dark_theme_test.go
+++ b/d2renderers/d2svg/dark_theme/dark_theme_test.go
@@ -11,9 +11,9 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"

--- a/d2renderers/d2svg/table.go
+++ b/d2renderers/d2svg/table.go
@@ -5,12 +5,12 @@ import (
 	"html"
 	"io"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2target"
 	"oss.terrastruct.com/d2/d2themes"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/label"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // this func helps define a clipPath for shape class and sql_table to draw border-radius

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
 	"oss.terrastruct.com/d2/lib/color"

--- a/docs/examples/lib/1-d2lib/d2lib.go
+++ b/docs/examples/lib/1-d2lib/d2lib.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2lib"
@@ -12,7 +13,6 @@ import (
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/textmeasure"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // Remember to add if err != nil checks in production.

--- a/docs/examples/lib/1-d2lib/d2lib_test.go
+++ b/docs/examples/lib/1-d2lib/d2lib_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2lib"
@@ -11,8 +13,6 @@ import (
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/textmeasure"
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 func TestMain_(t *testing.T) {

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/coder/websocket"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/xmain"
-	"oss.terrastruct.com/util-go/xos"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/xmain"
+	"github.com/d2lang/util-go/xos"
 
 	"oss.terrastruct.com/d2/d2cli"
 	"oss.terrastruct.com/d2/lib/compression"

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -14,9 +14,9 @@ import (
 
 	trequire "github.com/stretchr/testify/require"
 
-	"oss.terrastruct.com/util-go/assert"
-	"oss.terrastruct.com/util-go/diff"
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/assert"
+	"github.com/d2lang/util-go/diff"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2graph"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/andybalholm/brotli v1.2.0
 	github.com/coder/websocket v1.8.12
+	github.com/d2lang/util-go v0.2.0
 	github.com/dop251/goja v0.0.0-20240927123429-241b342198c2
 	github.com/dsoprea/go-exif/v3 v3.0.1
 	github.com/dsoprea/go-png-image-structure/v2 v2.0.0-20210512210324-29b889a6093d
@@ -30,7 +31,6 @@ require (
 	golang.org/x/text v0.22.0
 	golang.org/x/tools v0.25.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
-	oss.terrastruct.com/util-go v0.0.0-20250213174338-243d8661088a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3C
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/d2lang/util-go v0.2.0 h1:X9+F4j2S0453cG3EpA5bm9KBEV4ZAanxH+5ELA2yPDk=
+github.com/d2lang/util-go v0.2.0/go.mod h1:9t8cKlmsQw6UlChU4HQE9tZr8efjKIGDHkDdDYUeJy0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -195,5 +197,3 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oss.terrastruct.com/util-go v0.0.0-20250213174338-243d8661088a h1:UXF/Z9i9tOx/wqGUOn/T12wZeez1Gg0sAVKKl7YUDwM=
-oss.terrastruct.com/util-go v0.0.0-20250213174338-243d8661088a/go.mod h1:eMWv0sOtD9T2RUl90DLWfuShZCYp4NrsqNpI8eqO6U4=

--- a/lib/color/color.go
+++ b/lib/color/color.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lucasb-eyer/go-colorful"
 	"github.com/mazznoer/csscolorparser"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 )
 
 var themeColorRegex = regexp.MustCompile(`^(N[1-7]|B[1-6]|AA[245]|AB[45])$`)

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -20,8 +20,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/d2lang/util-go/xdefer"
 	"oss.terrastruct.com/d2/lib/simplelog"
-	"oss.terrastruct.com/util-go/xdefer"
 )
 
 var imgCache sync.Map

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -14,9 +14,9 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/simplelog"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 //go:embed test_png.png

--- a/lib/shape/shape.go
+++ b/lib/shape/shape.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 const (

--- a/lib/shape/shape_c4_person.go
+++ b/lib/shape/shape_c4_person.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // Constants to match frontend implementation

--- a/lib/shape/shape_callout.go
+++ b/lib/shape/shape_callout.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeCallout struct {

--- a/lib/shape/shape_circle.go
+++ b/lib/shape/shape_circle.go
@@ -3,8 +3,8 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeCircle struct {

--- a/lib/shape/shape_class.go
+++ b/lib/shape/shape_class.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // Class is basically a rectangle

--- a/lib/shape/shape_cloud.go
+++ b/lib/shape/shape_cloud.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // The percentage values of the cloud's wide inner box

--- a/lib/shape/shape_code.go
+++ b/lib/shape/shape_code.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeCode struct {

--- a/lib/shape/shape_cylinder.go
+++ b/lib/shape/shape_cylinder.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeCylinder struct {

--- a/lib/shape/shape_diamond.go
+++ b/lib/shape/shape_diamond.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeDiamond struct {

--- a/lib/shape/shape_document.go
+++ b/lib/shape/shape_document.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeDocument struct {

--- a/lib/shape/shape_hexagon.go
+++ b/lib/shape/shape_hexagon.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeHexagon struct {

--- a/lib/shape/shape_image.go
+++ b/lib/shape/shape_image.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeImage struct {

--- a/lib/shape/shape_oval.go
+++ b/lib/shape/shape_oval.go
@@ -3,8 +3,8 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 const OVAL_AR_LIMIT = 3.

--- a/lib/shape/shape_package.go
+++ b/lib/shape/shape_package.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapePackage struct {

--- a/lib/shape/shape_page.go
+++ b/lib/shape/shape_page.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapePage struct {

--- a/lib/shape/shape_parallelogram.go
+++ b/lib/shape/shape_parallelogram.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeParallelogram struct {

--- a/lib/shape/shape_person.go
+++ b/lib/shape/shape_person.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapePerson struct {

--- a/lib/shape/shape_queue.go
+++ b/lib/shape/shape_queue.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeQueue struct {

--- a/lib/shape/shape_real_square.go
+++ b/lib/shape/shape_real_square.go
@@ -3,8 +3,8 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeRealSquare struct {

--- a/lib/shape/shape_square.go
+++ b/lib/shape/shape_square.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeSquare struct {

--- a/lib/shape/shape_step.go
+++ b/lib/shape/shape_step.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeStep struct {

--- a/lib/shape/shape_stored_data.go
+++ b/lib/shape/shape_stored_data.go
@@ -3,9 +3,9 @@ package shape
 import (
 	"math"
 
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/svg"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 type shapeStoredData struct {

--- a/lib/shape/shape_table.go
+++ b/lib/shape/shape_table.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // Table is basically a rectangle

--- a/lib/shape/shape_text.go
+++ b/lib/shape/shape_text.go
@@ -1,8 +1,8 @@
 package shape
 
 import (
+	"github.com/d2lang/util-go/go2"
 	"oss.terrastruct.com/d2/lib/geo"
-	"oss.terrastruct.com/util-go/go2"
 )
 
 // Text is basically a rectangle

--- a/lib/simplelog/simplelog.go
+++ b/lib/simplelog/simplelog.go
@@ -4,8 +4,8 @@ package simplelog
 import (
 	"context"
 
+	"github.com/d2lang/util-go/cmdlog"
 	"oss.terrastruct.com/d2/lib/log"
-	"oss.terrastruct.com/util-go/cmdlog"
 )
 
 type Logger interface {

--- a/lib/textmeasure/markdown.go
+++ b/lib/textmeasure/markdown.go
@@ -12,7 +12,7 @@ import (
 	goldmarkHtml "github.com/yuin/goldmark/renderer/html"
 	"golang.org/x/net/html"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
 )

--- a/lib/urlenc/urlenc.go
+++ b/lib/urlenc/urlenc.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"oss.terrastruct.com/util-go/xdefer"
+	"github.com/d2lang/util-go/xdefer"
 )
 
 // Encode takes a D2 script and encodes it as a compressed base64 string for embedding in URLs.

--- a/lib/urlenc/urlenc_test.go
+++ b/lib/urlenc/urlenc_test.go
@@ -3,7 +3,7 @@ package urlenc
 import (
 	"testing"
 
-	"oss.terrastruct.com/util-go/assert"
+	"github.com/d2lang/util-go/assert"
 )
 
 func TestBasic(t *testing.T) {

--- a/lib/xgif/xgif.go
+++ b/lib/xgif/xgif.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ericpauley/go-quantize/quantize"
 	"github.com/mxschmitt/playwright-go"
 
-	"oss.terrastruct.com/util-go/go2"
+	"github.com/d2lang/util-go/go2"
 )
 
 const INFINITE_LOOP = 0

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/d2lang/util-go/xmain"
 	"oss.terrastruct.com/d2/d2cli"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 func main() {


### PR DESCRIPTION
Move all D2 imports and its module dependency from oss.terrastruct.com/util-go to the released github.com/d2lang/util-go v0.2.0 module. Pin the shared CI formatter update and rebuild the tracked d2.js WASM artifact so it no longer embeds the retired util-go path.\n\nCompatibility is preserved by the frozen d2lang/util-go-legacy repository, the final old-path v0.1.0 release, and both source/destination vanity objects.\n\nValidation:\n- go mod tidy, go list -m all, and go mod graph show only github.com/d2lang/util-go v0.2.0\n- Go build, vet, package tests, CLI e2e, and renderer e2e passed under Go 1.25.0\n- d2.js build passed under Bun 1.3.14; 32 unit and 2 integration tests passed\n- tracked WASM contains the new util-go path and no old util-go path\n- git diff --check and a tracked-file old-path search passed