### PR TITLE
docs: make source install command portable

### DIFF
--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -43,7 +43,7 @@ Flags:
   to install the release archive for your OS, whether it's apt, yum, brew or standalone
   if an unsupported package manager is used.
 
-  To install from source like a dev would, use go install github.com/d2lang/d2. There's
+  To install from source like a dev would, use go install github.com/d2lang/d2@latest. There's
   also ./ci/release/build.sh --install to build and install a proper standalone release
   including manpages. The proper release will also ensure d2 --version shows the correct
   version by embedding the commit hash into the binary.

--- a/install.sh
+++ b/install.sh
@@ -636,7 +636,7 @@ Flags:
   to install the release archive for your OS, whether it's apt, yum, brew or standalone
   if an unsupported package manager is used.
 
-  To install from source like a dev would, use go install github.com/d2lang/d2. There's
+  To install from source like a dev would, use go install github.com/d2lang/d2@latest. There's
   also ./ci/release/build.sh --install to build and install a proper standalone release
   including manpages. The proper release will also ensure d2 --version shows the correct
   version by embedding the commit hash into the binary.


### PR DESCRIPTION
## Summary
- add `@latest` to the Go source-install command in installer help
- regenerate the checked-in `install.sh` from its source

Without a version suffix, `go install github.com/d2lang/d2` only works from a module that already requires D2. The versioned form works from any directory.

## Validation
- `./ci/release/gen_install.sh`
- generated and source help text match
- `git diff --check`
- active D2 tree contains no `oss.terrastruct.com` references