### PR TITLE
ci: migrate npm package to d2lang

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -8,7 +8,6 @@ on:
         required: true
         type: string
         default: nightly
-
 permissions:
   contents: read
 
@@ -17,12 +16,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  stage:
+  pack:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,14 +50,116 @@ jobs:
           sudo cp "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}"/bin/* /usr/local/bin/
           wasm-opt --version
 
-      - name: Build and test package
+      - name: Build, test, and pack both package identities
+        env:
+          NPM_PACKAGE_TARGET: both
+          NPM_PACK_DIR: ${{ runner.temp }}/npm-packages
+          NPM_PUBLISH_MODE: pack
+          NPM_VERSION: ${{ inputs.version }}
         run: |
           CI_FORCE=1 CI_MAKE_ROOT=0 COLOR=1 ./make.sh js
           cd d2js/js
           bun test test/unit
 
-      - name: Stage package for review
+      - name: Upload immutable package tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm-packages
+          if-no-files-found: error
+          compression-level: 0
+
+  stage:
+    name: stage-${{ matrix.package }}
+    needs: pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - d2lang
+          - terrastruct
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install supported npm
+        run: |
+          npm install --global npm@12.0.2
+          npm --version
+
+      - name: Download immutable package tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm-packages
+
+      - name: Verify and stage package for review
         env:
-          NPM_PUBLISH_MODE: stage
-          NPM_VERSION: ${{ inputs.version }}
-        run: CI_FORCE=1 CI_MAKE_ROOT=0 COLOR=1 ./make.sh js
+          PACKAGE_KEY: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+
+          manifest="$RUNNER_TEMP/npm-packages/manifest.json"
+          case "$PACKAGE_KEY" in
+            d2lang) package_name=@d2lang/d2 ;;
+            terrastruct) package_name=@terrastruct/d2 ;;
+            *)
+              echo "unexpected package key: $PACKAGE_KEY" >&2
+              exit 1
+              ;;
+          esac
+
+          metadata=$(node - "$manifest" "$package_name" <<'NODE'
+          const fs = require('fs');
+          const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const packageName = process.argv[3];
+          const record = manifest.packages && manifest.packages[packageName];
+          if (manifest.schemaVersion !== 1 || !record) {
+            process.exit(1);
+          }
+          process.stdout.write([
+            manifest.version,
+            manifest.tag,
+            record.filename,
+            record.shasum,
+            record.integrity,
+          ].join('\t'));
+          NODE
+          )
+          IFS=$'\t' read -r version tag filename expected_shasum expected_integrity <<<"$metadata"
+          if [[ -z "$version" || -z "$tag" || -z "$filename" ||
+            "$filename" != "${filename##*/}" ]]; then
+            echo "invalid npm package manifest" >&2
+            exit 1
+          fi
+
+          tarball="$RUNNER_TEMP/npm-packages/$filename"
+          test -f "$tarball"
+          node - "$tarball" "$expected_shasum" "$expected_integrity" <<'NODE'
+          const crypto = require('crypto');
+          const fs = require('fs');
+          const bytes = fs.readFileSync(process.argv[2]);
+          const expectedShasum = process.argv[3];
+          const expectedIntegrity = process.argv[4];
+          const shasum = crypto.createHash('sha1').update(bytes).digest('hex');
+          const integrity = `sha512-${crypto.createHash('sha512').update(bytes).digest('base64')}`;
+          if (shasum !== expectedShasum || integrity !== expectedIntegrity) {
+            throw new Error('npm tarball integrity mismatch');
+          }
+          NODE
+          tar -xOzf "$tarball" package/package.json | jq -e \
+            --arg name "$package_name" \
+            --arg version "$version" \
+            '.name == $name and .version == $version and .publishConfig.access == "public"' \
+            >/dev/null
+
+          npm stage publish "$tarball" --tag "$tag"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![daily](https://github.com/d2lang/d2/actions/workflows/daily.yml/badge.svg)](https://github.com/d2lang/d2/actions/workflows/daily.yml)
 [![release](https://img.shields.io/github/v/release/d2lang/d2)](https://github.com/d2lang/d2/releases)
 [![changelog](https://img.shields.io/badge/changelog-read-blue)](./CHANGELOG.md)
-[![npm version](https://img.shields.io/npm/v/@terrastruct/d2)](https://www.npmjs.com/package/@terrastruct/d2)
+[![npm version](https://img.shields.io/npm/v/@d2lang/d2)](https://www.npmjs.com/package/@d2lang/d2)
 [![discord](https://img.shields.io/discord/1039184639652265985?label=discord)](https://discord.gg/NF6X8K4eDq)
 [![license](https://img.shields.io/github/license/d2lang/d2?color=9cf)](./LICENSE.txt)
 

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -1,5 +1,40 @@
 # release
 
+## npm publishing
+
+`@d2lang/d2` is the canonical JavaScript package. `@terrastruct/d2` is published from the
+same built files as a compatibility package during the namespace transition. The
+`npm-stage.yml` workflow stages both package names for review with npm trusted publishing;
+each staged package has its own stage ID and must be reviewed and approved separately. If
+one stage succeeds and the other fails, use GitHub's **Re-run failed jobs** action on the
+same workflow run. That preserves the original commit and reuses the same immutable
+package artifact; do not use **Re-run all jobs** or start a fresh workflow dispatch to
+recover only one identity.
+
+Before staging an official version, bump `d2js/js/package.json` and `package-lock.json` to
+that exact version in a signed commit. Nightly stages derive their prerelease version from
+the checked-in version automatically. `@d2lang/d2` must already exist and both packages
+must separately trust the `d2lang/d2` `npm-stage.yml` workflow for stage-only publishing.
+Each trusted publisher is restricted to the `npm-release` GitHub environment, whose
+deployment branch policy accepts only protected branches. The workflow itself also
+refuses to pack from any ref other than `refs/heads/master`.
+The canonical package was bootstrapped once from the existing `@terrastruct/d2@0.1.33`
+built artifacts because npm does not allow a brand-new package to use staged publishing.
+
+Direct publishing is retained only for local bootstrap or recovery. It requires a
+short-lived `NPM_TOKEN` that can publish every selected package and is not stored in GitHub.
+The script pre-packs and preflights every selected package before publishing; a retry skips
+an existing version only when its registry tarball integrity exactly matches the local
+artifact.
+
+After the workflow finishes, confirm both matrix stage jobs are green and inspect the two
+pending records with `npm stage list` and `npm stage view <stage-id>`. Approve each only
+after their package versions and artifacts from `npm stage download <stage-id>` match.
+Use `npm stage approve <stage-id>` for each identity. If the release is abandoned, reject
+every pending half with
+`npm stage reject <stage-id>` before starting another run. A pending stage reserves its
+package/version, so list pending stages before retrying any failed job.
+
 ## _install.sh
 
 The template for the install script in the root of the d2 repository.

--- a/ci/release/release-js.sh
+++ b/ci/release/release-js.sh
@@ -9,10 +9,10 @@ help() {
   cat <<EOF
 usage: $0 --version=<version>
 
-Publishes the d2.js to NPM.
+Dispatches the protected npm staging workflow for both d2.js package identities.
 
 Flags:
-  --version     Version to publish (e.g., "0.1.2" or "nightly"). Note this is the js version, not related to the d2 version. A non-nightly version will publish to latest.
+  --version     Version to stage (e.g., "0.1.2" or "nightly"). Note this is the js version, not related to the d2 version. A non-nightly version will use the latest tag after approval.
 EOF
 }
 
@@ -32,8 +32,20 @@ if [ -z "$VERSION" ]; then
   flag_errusage "--version is required"
 fi
 
-FGCOLOR=6 header "Publishing JavaScript package to NPM (version: $VERSION)"
+if ! command -v gh >/dev/null 2>&1; then
+  echoerr 'gh is required to dispatch the npm staging workflow'
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echoerr 'gh must be authenticated before dispatching the npm staging workflow'
+  exit 1
+fi
 
-sh_c "NPM_VERSION=$VERSION ./make.sh js"
+FGCOLOR=6 header "Staging JavaScript packages for npm review (version: $VERSION)"
 
-FGCOLOR=2 header 'NPM publish completed'
+gh workflow run npm-stage.yml \
+  --repo d2lang/d2 \
+  --ref master \
+  --field "version=$VERSION"
+
+FGCOLOR=2 header 'npm staging workflow dispatched; approve both package stages after every job succeeds'

--- a/d2js/js/README.md
+++ b/d2js/js/README.md
@@ -1,6 +1,6 @@
 # D2.js
 
-[![npm version](https://badge.fury.io/js/%40terrastruct%2Fd2.svg)](https://www.npmjs.com/package/@terrastruct/d2)
+[![npm version](https://badge.fury.io/js/%40d2lang%2Fd2.svg)](https://www.npmjs.com/package/@d2lang/d2)
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://mozilla.org/MPL/2.0/)
 
 D2.js is a JavaScript wrapper around D2, the modern diagram scripting language. It enables running D2 directly in browsers and Node environments through WebAssembly.
@@ -19,17 +19,20 @@ For an example of usage, see [https://play.d2lang.com](https://play.d2lang.com),
 
 ```bash
 # npm
-npm install @terrastruct/d2
+npm install @d2lang/d2
 
 # yarn
-yarn add @terrastruct/d2
+yarn add @d2lang/d2
 
 # pnpm
-pnpm add @terrastruct/d2
+pnpm add @d2lang/d2
 
 # bun
-bun add @terrastruct/d2
+bun add @d2lang/d2
 ```
+
+`@terrastruct/d2` remains available as a compatibility package and receives the same
+releases during the namespace transition. New installations should use `@d2lang/d2`.
 
 ### Nightly
 
@@ -38,7 +41,7 @@ Use the `@nightly` tag to get the version that is built by daily CI on the maste
 For example,
 
 ```bash
-yarn add @terrastruct/d2@nightly
+yarn add @d2lang/d2@nightly
 ```
 
 ## Usage
@@ -49,9 +52,9 @@ D2.js uses webworkers to call a WASM file.
 
 ```javascript
 // Same for Node or browser
-import { D2 } from '@terrastruct/d2';
+import { D2 } from '@d2lang/d2';
 // Or using a CDN
-// import { D2 } from 'https://esm.sh/@terrastruct/d2';
+// import { D2 } from 'https://esm.sh/@d2lang/d2';
 
 const d2 = new D2();
 
@@ -62,7 +65,7 @@ const svg = await d2.render(result.diagram, result.renderOptions);
 Configuring render options (see [CompileOptions](#compileoptions) for all available options):
 
 ```javascript
-import { D2 } from '@terrastruct/d2';
+import { D2 } from '@d2lang/d2';
 
 const d2 = new D2();
 
@@ -77,7 +80,7 @@ const svg = await d2.render(result.diagram, result.renderOptions);
 In order to support [imports](https://d2lang.com/tour/imports), a mapping of D2 file paths to their content can be passed to the compiler.
 
 ```javascript
-import { D2 } from '@terrastruct/d2';
+import { D2 } from '@d2lang/d2';
 
 const d2 = new D2();
 

--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -37,21 +37,75 @@ cd d2js/js
 sh_c bun build.js
 
 if [ -n "${NPM_VERSION:-}" ]; then
-  cp package.json package.json.bak
   PUBLISH_MODE="${NPM_PUBLISH_MODE:-publish}"
-  if [ "$PUBLISH_MODE" = stage ] && [ -f package-lock.json ]; then
-    cp package-lock.json package-lock.json.stage.bak
-    trap 'rm -f .npmrc; mv package.json.bak package.json; mv package-lock.json.stage.bak package-lock.json' EXIT
+  PACKAGE_TARGET="${NPM_PACKAGE_TARGET:-both}"
+  case "$PACKAGE_TARGET" in
+    both)
+      PACKAGE_NAMES="@d2lang/d2 @terrastruct/d2"
+      ;;
+    d2lang)
+      PACKAGE_NAMES="@d2lang/d2"
+      ;;
+    terrastruct)
+      PACKAGE_NAMES="@terrastruct/d2"
+      ;;
+    *)
+      echoerr "Unknown NPM_PACKAGE_TARGET: ${PACKAGE_TARGET}"
+      exit 1
+      ;;
+  esac
+
+  if [ -n "${NPM_PACK_DIR:-}" ]; then
+    case "$NPM_PACK_DIR" in
+      /*) ;;
+      *)
+        echoerr "NPM_PACK_DIR must be an absolute path"
+        exit 1
+        ;;
+    esac
+    PACK_DIR=$NPM_PACK_DIR
+    mkdir -p "$PACK_DIR"
+    PRESERVE_PACK_DIR=1
   else
-    trap 'rm -f .npmrc; mv package.json.bak package.json' EXIT
+    PACK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/d2-npm-publish.XXXXXX")
+    PRESERVE_PACK_DIR=0
   fi
 
+  restore_package_files() {
+    rm -f .npmrc
+    if [ -f package.json.bak ]; then
+      mv package.json.bak package.json
+    fi
+    if [ -f package-lock.json.bak ]; then
+      mv package-lock.json.bak package-lock.json
+    fi
+  }
+
+  cleanup_publish() {
+    restore_package_files
+    if [ "$PRESERVE_PACK_DIR" != 1 ]; then
+      rm -f "$PACK_DIR"/*.json "$PACK_DIR"/*.tgz
+      rmdir "$PACK_DIR" 2>/dev/null || true
+    fi
+  }
+  trap cleanup_publish EXIT
+
+  cp package.json package.json.bak
+  if [ -f package-lock.json ]; then
+    cp package-lock.json package-lock.json.bak
+  fi
+
+  CURRENT_NAME=$(node -p "require('./package.json').name")
+  CURRENT_VERSION=$(node -p "require('./package.json').version")
+  if [ "$CURRENT_NAME" != '@d2lang/d2' ]; then
+    echoerr "package.json must use the canonical @d2lang/d2 name before publishing"
+    exit 1
+  fi
   if [ "$NPM_VERSION" = "nightly" ]; then
     echo "Publishing nightly version to npm..."
 
     DATE_TAG=$(date +'%Y%m%d')
     COMMIT_SHORT=$(git rev-parse --short HEAD)
-    CURRENT_VERSION=$(node -p "require('./package.json').version")
     PUBLISH_VERSION="${CURRENT_VERSION}-nightly.${DATE_TAG}.${COMMIT_SHORT}"
     NPM_TAG="nightly"
 
@@ -64,18 +118,218 @@ if [ -n "${NPM_VERSION:-}" ]; then
     echo "Setting package version to ${PUBLISH_VERSION}"
   fi
 
-  # Update package.json with the new version
-  npm version "${PUBLISH_VERSION}" --no-git-tag-version
+  # Stable staged releases must be versioned in source before dispatch so the
+  # checked-in package state advances when the stages are approved.
+  if { [ "$PUBLISH_MODE" = stage ] || [ "$PUBLISH_MODE" = pack ]; } &&
+    [ "$NPM_VERSION" != nightly ] &&
+    [ "$CURRENT_VERSION" != "$PUBLISH_VERSION" ]; then
+    echoerr "Bump package.json and package-lock.json to ${PUBLISH_VERSION} before staging"
+    exit 1
+  fi
+
+  if [ "$CURRENT_VERSION" != "$PUBLISH_VERSION" ]; then
+    npm version "${PUBLISH_VERSION}" --no-git-tag-version
+  fi
+  if [ -f package-lock.json ]; then
+    LOCK_NAME=$(node -p "require('./package-lock.json').name")
+    LOCK_VERSION=$(node -p "require('./package-lock.json').version")
+    LOCK_ROOT_NAME=$(node -p "require('./package-lock.json').packages[''].name")
+    LOCK_ROOT_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+    if [ "$LOCK_NAME" != '@d2lang/d2' ] || [ "$LOCK_ROOT_NAME" != '@d2lang/d2' ]; then
+      echoerr "package-lock.json must use the canonical @d2lang/d2 name before publishing"
+      exit 1
+    fi
+    if [ "$LOCK_VERSION" != "$PUBLISH_VERSION" ] ||
+      [ "$LOCK_ROOT_VERSION" != "$PUBLISH_VERSION" ]; then
+      echoerr "package-lock.json versions do not match ${PUBLISH_VERSION}"
+      exit 1
+    fi
+  fi
+
+  set_package_name() {
+    package_name=$1
+    node - "$package_name" <<'NODE'
+const fs = require('fs');
+const packageName = process.argv[2];
+
+for (const filename of ['package.json', 'package-lock.json']) {
+  if (!fs.existsSync(filename)) {
+    continue;
+  }
+  const json = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  json.name = packageName;
+  if (json.packages && json.packages['']) {
+    json.packages[''].name = packageName;
+  }
+  fs.writeFileSync(filename, `${JSON.stringify(json, null, 2)}\n`);
+}
+NODE
+  }
+
+  prepare_package() {
+    package_name=$1
+    set_package_name "$package_name"
+    pack_json=$(npm pack --json --pack-destination "$PACK_DIR")
+    pack_metadata=$(printf '%s' "$pack_json" | node -e '
+      let input = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", chunk => { input += chunk; });
+      process.stdin.on("end", () => {
+        const parsed = JSON.parse(input);
+        const record = Array.isArray(parsed) ? parsed[0] : parsed[Object.keys(parsed)[0]];
+        process.stdout.write([record.filename, record.shasum, record.integrity].join("\t"));
+      });
+    ')
+    IFS="$(printf '\t')" read -r pack_filename pack_shasum pack_integrity <<EOF
+$pack_metadata
+EOF
+    if [ -z "$pack_filename" ] || [ -z "$pack_shasum" ] || [ -z "$pack_integrity" ] ||
+      [ ! -f "$PACK_DIR/$pack_filename" ]; then
+      echoerr "npm pack did not return complete metadata for ${package_name}"
+      exit 1
+    fi
+
+    case "$package_name" in
+      @d2lang/d2)
+        D2LANG_TARBALL="$PACK_DIR/$pack_filename"
+        D2LANG_SHASUM="$pack_shasum"
+        D2LANG_INTEGRITY="$pack_integrity"
+        ;;
+      @terrastruct/d2)
+        TERRASTRUCT_TARBALL="$PACK_DIR/$pack_filename"
+        TERRASTRUCT_SHASUM="$pack_shasum"
+        TERRASTRUCT_INTEGRITY="$pack_integrity"
+        ;;
+    esac
+  }
+
+  for package_name in $PACKAGE_NAMES; do
+    prepare_package "$package_name"
+  done
+
+  check_registry_version() {
+    package_name=$1
+    registry_path=$2
+    expected_shasum=$3
+    expected_integrity=$4
+    response_file=$5
+
+    if ! registry_http=$(curl -sS --retry 2 --retry-all-errors \
+      -o "$response_file" \
+      -w '%{http_code}' \
+      "https://registry.npmjs.org/${registry_path}/${ENCODED_PUBLISH_VERSION}"); then
+      echoerr "Unable to query npm registry for ${package_name}@${PUBLISH_VERSION}"
+      return 1
+    fi
+
+    case "$registry_http" in
+      404)
+        REGISTRY_STATE=absent
+        ;;
+      200)
+        registry_metadata=$(node - "$response_file" <<'NODE'
+const fs = require('fs');
+const metadata = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+process.stdout.write([
+  metadata.dist && metadata.dist.shasum || '',
+  metadata.dist && metadata.dist.integrity || '',
+].join('\t'));
+NODE
+        )
+        IFS="$(printf '\t')" read -r registry_shasum registry_integrity <<EOF
+$registry_metadata
+EOF
+        if [ "$registry_shasum" = "$expected_shasum" ] &&
+          [ "$registry_integrity" = "$expected_integrity" ]; then
+          REGISTRY_STATE=matching
+        else
+          REGISTRY_STATE=mismatch
+        fi
+        ;;
+      *)
+        echoerr "npm registry returned HTTP ${registry_http} for ${package_name}@${PUBLISH_VERSION}"
+        return 1
+        ;;
+    esac
+  }
+
+  package_details() {
+    package_name=$1
+    case "$package_name" in
+      @d2lang/d2)
+        PACKAGE_TARBALL=$D2LANG_TARBALL
+        PACKAGE_SHASUM=$D2LANG_SHASUM
+        PACKAGE_INTEGRITY=$D2LANG_INTEGRITY
+        PACKAGE_REGISTRY_PATH='%40d2lang%2Fd2'
+        PACKAGE_RESPONSE="$PACK_DIR/d2lang-registry.json"
+        ;;
+      @terrastruct/d2)
+        PACKAGE_TARBALL=$TERRASTRUCT_TARBALL
+        PACKAGE_SHASUM=$TERRASTRUCT_SHASUM
+        PACKAGE_INTEGRITY=$TERRASTRUCT_INTEGRITY
+        PACKAGE_REGISTRY_PATH='%40terrastruct%2Fd2'
+        PACKAGE_RESPONSE="$PACK_DIR/terrastruct-registry.json"
+        ;;
+    esac
+  }
+
+  ENCODED_PUBLISH_VERSION=$(node -p "encodeURIComponent(process.argv[1])" "$PUBLISH_VERSION")
 
   case "$PUBLISH_MODE" in
-    stage)
-      echo "Staging package on npm with tag '${NPM_TAG}'..."
-      if npm stage publish --tag "$NPM_TAG"; then
-        echo "Successfully staged @terrastruct/d2@${PUBLISH_VERSION} on npm with tag '${NPM_TAG}'"
-      else
-        echoerr "Failed to stage package on npm"
+    pack)
+      if [ "$PACKAGE_TARGET" != both ]; then
+        echoerr "Pack mode requires NPM_PACKAGE_TARGET=both"
         exit 1
       fi
+      node - "$PACK_DIR/manifest.json" \
+        "$PUBLISH_VERSION" "$NPM_TAG" \
+        "${D2LANG_TARBALL##*/}" "$D2LANG_SHASUM" "$D2LANG_INTEGRITY" \
+        "${TERRASTRUCT_TARBALL##*/}" "$TERRASTRUCT_SHASUM" "$TERRASTRUCT_INTEGRITY" <<'NODE'
+const fs = require('fs');
+const [
+  manifestPath,
+  version,
+  tag,
+  d2langFilename,
+  d2langShasum,
+  d2langIntegrity,
+  terrastructFilename,
+  terrastructShasum,
+  terrastructIntegrity,
+] = process.argv.slice(2);
+
+const manifest = {
+  schemaVersion: 1,
+  version,
+  tag,
+  packages: {
+    '@d2lang/d2': {
+      filename: d2langFilename,
+      shasum: d2langShasum,
+      integrity: d2langIntegrity,
+    },
+    '@terrastruct/d2': {
+      filename: terrastructFilename,
+      shasum: terrastructShasum,
+      integrity: terrastructIntegrity,
+    },
+  },
+};
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+      echo "Packed both npm package identities in $PACK_DIR"
+      ;;
+    stage)
+      if [ "$PACKAGE_TARGET" = both ]; then
+        echoerr "Stage one package identity at a time, or use npm-stage.yml"
+        exit 1
+      fi
+      for package_name in $PACKAGE_NAMES; do
+        package_details "$package_name"
+        echo "Staging ${package_name}@${PUBLISH_VERSION} with tag '${NPM_TAG}'..."
+        npm stage publish "$PACKAGE_TARBALL" --tag "$NPM_TAG"
+        echo "Successfully staged ${package_name}@${PUBLISH_VERSION} with tag '${NPM_TAG}'"
+      done
       ;;
     publish)
       if [ -z "${NPM_TOKEN-}" ]; then
@@ -83,29 +337,87 @@ if [ -n "${NPM_VERSION:-}" ]; then
         exit 1
       fi
 
-      # Create .npmrc file with auth token
+      # Create .npmrc file with auth token. Direct publishing is retained only
+      # for local bootstrap or recovery; GitHub Actions uses trusted publishing.
       echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 
-      echo "Publishing to npm with tag '${NPM_TAG}'..."
-      if npm publish --tag "$NPM_TAG"; then
-        echo "Successfully published @terrastruct/d2@${PUBLISH_VERSION} to npm with tag '${NPM_TAG}'"
+      # Preflight every target before publishing either one. A retry may skip a
+      # version only when the registry tarball exactly matches this run's pack.
+      for package_name in $PACKAGE_NAMES; do
+        package_details "$package_name"
+        check_registry_version "$package_name" "$PACKAGE_REGISTRY_PATH" \
+          "$PACKAGE_SHASUM" "$PACKAGE_INTEGRITY" "$PACKAGE_RESPONSE"
+        case "$REGISTRY_STATE" in
+          absent|matching)
+            ;;
+          mismatch)
+            echoerr "Refusing to reuse ${package_name}@${PUBLISH_VERSION}: registry integrity differs"
+            exit 1
+            ;;
+        esac
+        case "$package_name" in
+          @d2lang/d2) D2LANG_REGISTRY_STATE=$REGISTRY_STATE ;;
+          @terrastruct/d2) TERRASTRUCT_REGISTRY_STATE=$REGISTRY_STATE ;;
+        esac
+      done
 
-        # For official releases, bump the patch version
-        if [ "$NPM_VERSION" != "nightly" ]; then
-          # Restore original package.json first
-          mv package.json.bak package.json
-
-          echo "Bumping version to ${NPM_VERSION}"
-          npm version "${NPM_VERSION}" --no-git-tag-version
-          git add package.json
-          git commit -m "Bump version to ${NPM_VERSION} [skip ci]"
-
-          # Cancel the trap since we manually restored and don't want it to execute on exit
-          trap - EXIT
+      for package_name in $PACKAGE_NAMES; do
+        package_details "$package_name"
+        case "$package_name" in
+          @d2lang/d2) REGISTRY_STATE=$D2LANG_REGISTRY_STATE ;;
+          @terrastruct/d2) REGISTRY_STATE=$TERRASTRUCT_REGISTRY_STATE ;;
+        esac
+        if [ "$REGISTRY_STATE" = matching ]; then
+          echo "Verified existing ${package_name}@${PUBLISH_VERSION}; skipping publish."
+          continue
         fi
-      else
-        echoerr "Failed to publish package to npm"
-        exit 1
+
+        echo "Publishing ${package_name}@${PUBLISH_VERSION} with tag '${NPM_TAG}'..."
+        npm publish "$PACKAGE_TARBALL" --tag "$NPM_TAG"
+
+        published_verified=0
+        for verify_attempt in 1 2 3 4 5; do
+          if ! check_registry_version "$package_name" "$PACKAGE_REGISTRY_PATH" \
+            "$PACKAGE_SHASUM" "$PACKAGE_INTEGRITY" "$PACKAGE_RESPONSE"; then
+            if [ "$verify_attempt" != 5 ]; then
+              sleep 2
+              continue
+            fi
+            break
+          fi
+          if [ "$REGISTRY_STATE" = matching ]; then
+            published_verified=1
+            break
+          fi
+          if [ "$REGISTRY_STATE" = mismatch ]; then
+            break
+          fi
+          if [ "$verify_attempt" != 5 ]; then
+            sleep 2
+          fi
+        done
+        if [ "$published_verified" != 1 ]; then
+          echoerr "Could not verify ${package_name}@${PUBLISH_VERSION} after publishing"
+          exit 1
+        fi
+        echo "Successfully published and verified ${package_name}@${PUBLISH_VERSION} with tag '${NPM_TAG}'"
+      done
+
+      # For official direct releases, bump the checked-in canonical package
+      # version after restoring the canonical manifests.
+      if [ "$NPM_VERSION" != nightly ]; then
+        restore_package_files
+        CURRENT_VERSION=$(node -p "require('./package.json').version")
+        if [ "$CURRENT_VERSION" != "$NPM_VERSION" ]; then
+          npm version "$NPM_VERSION" --no-git-tag-version
+        fi
+        git add package.json
+        if [ -f package-lock.json ]; then
+          git add package-lock.json
+        fi
+        if ! git diff --cached --quiet; then
+          git commit -m "Bump version to ${NPM_VERSION} [skip ci]"
+        fi
       fi
       ;;
     *)

--- a/d2js/js/package-lock.json
+++ b/d2js/js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@terrastruct/d2",
+  "name": "@d2lang/d2",
   "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@terrastruct/d2",
+      "name": "@d2lang/d2",
       "version": "0.1.33",
       "license": "MPL-2.0",
       "dependencies": {

--- a/d2js/js/package.json
+++ b/d2js/js/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@terrastruct/d2",
-  "author": "Terrastruct, Inc.",
+  "name": "@d2lang/d2",
   "description": "D2.js is a wrapper around the WASM build of D2, the modern text-to-diagram language.",
   "version": "0.1.33",
   "repository": {


### PR DESCRIPTION
## Summary

- make `@d2lang/d2` the canonical JavaScript package while continuing identical compatibility releases to `@terrastruct/d2`
- build and pack both identities once, upload one immutable artifact, and stage each package in its own OIDC job
- restrict staging to protected `master` through the `npm-release` environment and stage-only trusted publishers
- make direct recovery idempotent by preflighting and verifying exact tarball integrity
- route the release helper through the protected staged-publishing workflow and document approval/recovery procedures

## Live migration completed

- bootstrapped public `@d2lang/d2@0.1.33` from the verified `@terrastruct/d2@0.1.33` artifacts
- configured stage-only trusted publishers for both package identities
- created the protected-branches-only GitHub `npm-release` environment

## Validation

- actionlint, YAML parse, embedded Bash syntax, `sh -n`, and `git diff --check`
- mocked publishing/recovery matrix: 11/11
- lock/name rejection matrix: 4/4
- release dispatcher matrix: 5/5
- public tarball byte-for-byte registry verification
- real install, compile, and render smoke test against `@d2lang/d2@0.1.33`
