### PR TITLE
Refresh release artifact branding

### DIFF
--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -263,4 +263,4 @@ See --omit-version
 .Sh SEE ALSO
 .Xr d2plugin-tala 1
 .Sh AUTHORS
-Terrastruct Inc.
+.An "D2 contributors"

--- a/ci/release/windows/d2.wxs
+++ b/ci/release/windows/d2.wxs
@@ -7,8 +7,8 @@ This file was pieced together from:
 3. Googling with trial and error
 -->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-    <Package Name="D2" UpgradeCode="ac84fee7-eb67-4f5d-a08d-adef69538690" Language="1033" Codepage="utf-8" Version="$(var.D2Version)" Manufacturer="Terrastruct, Inc." InstallerVersion="200">
-        <SummaryInformation Keywords="Installer" Description="The D2 Installer" Manufacturer="Terrastruct, Inc." Codepage="1252" />
+    <Package Name="D2" UpgradeCode="ac84fee7-eb67-4f5d-a08d-adef69538690" Language="1033" Codepage="utf-8" Version="$(var.D2Version)" Manufacturer="D2" InstallerVersion="200">
+        <SummaryInformation Keywords="Installer" Description="The D2 Installer" Manufacturer="D2" Codepage="1252" />
         <Icon Id="d2.ico" SourceFile="d2.ico" />
         <Property Id="ARPPRODUCTICON" Value="d2.ico" />
 


### PR DESCRIPTION
## What changed

- identify the Windows MSI publisher as `D2` instead of Terrastruct
- identify the man-page author as `D2 contributors` using the standard mdoc author macro

## Why

New D2 release artifacts should no longer present Terrastruct as the current publisher or author.

## Compatibility

The MSI product name, language, `UpgradeCode`, `MajorUpgrade` behavior, and component GUIDs are unchanged, so existing installer upgrade detection is preserved. Historical copyright notices are intentionally untouched.

## Validation

- `git diff --check`
- `xmllint --noout ci/release/windows/d2.wxs`
- `mandoc` renders `D2 contributors` and no longer reports an AUTHORS-section warning
- exact XML checks confirm both manufacturer fields are `D2` and the `UpgradeCode` is unchanged
- independent release-scope review found no blocker