### PR TITLE
ci: build Windows MSI on GitHub

### DIFF
--- a/.github/workflows/windows-msi.yml
+++ b/.github/workflows/windows-msi.yml
@@ -1,0 +1,392 @@
+name: Windows MSI
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/windows-msi.yml
+      - ci/release/windows/**
+      - ci/release/build.sh
+      - ci/release/release.sh
+      - ci/release/README.md
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing release version to use as the Windows archive fixture
+        required: true
+        type: string
+        default: v0.7.1
+      upload_release:
+        description: Upload the verified MSI to the draft release
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-msi-${{ github.event.pull_request.number || inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 70
+    outputs:
+      archive_asset_id: ${{ steps.release.outputs.archive_asset_id }}
+      archive_digest: ${{ steps.release.outputs.archive_digest }}
+      checkout_commit: ${{ steps.release.outputs.checkout_commit }}
+      release_id: ${{ steps.release.outputs.release_id }}
+      tag_commit: ${{ steps.release.outputs.tag_commit }}
+      upload_release: ${{ steps.release.outputs.upload_release }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Pin release and Windows archive
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_UPLOAD: ${{ inputs.upload_release || false }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              version=v0.7.1
+              upload_release=false
+              ;;
+            push)
+              version=$GITHUB_REF_NAME
+              upload_release=true
+              ;;
+            workflow_dispatch)
+              version=$REQUESTED_VERSION
+              upload_release=$REQUESTED_UPLOAD
+              if [[ "$upload_release" == true && "$GITHUB_REF" != refs/heads/master ]]; then
+                echo "release uploads must be dispatched from master" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          if ! printf '%s\n' "$version" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'; then
+            echo "version must be a v-prefixed semantic version" >&2
+            exit 1
+          fi
+
+          attempts=1
+          if [[ "$GITHUB_EVENT_NAME" == push ]]; then
+            # The release script pushes the tag before it creates the draft release and
+            # uploads archives. Wait for all six without rebuilding them here.
+            attempts=240
+          fi
+
+          release_json=
+          archive_json=
+          expected_assets=$(jq -cn --arg version "$version" '[
+            "d2-\($version)-linux-amd64.tar.gz",
+            "d2-\($version)-linux-arm64.tar.gz",
+            "d2-\($version)-macos-amd64.tar.gz",
+            "d2-\($version)-macos-arm64.tar.gz",
+            "d2-\($version)-windows-amd64.tar.gz",
+            "d2-\($version)-windows-arm64.tar.gz"
+          ]')
+          for attempt in $(seq 1 "$attempts"); do
+            release_json=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$version" 2>/dev/null || true)
+            if [[ -n "$release_json" ]]; then
+              if printf '%s' "$release_json" | jq -e --argjson expected "$expected_assets" '
+                [.assets[] | select(.name as $name | $expected | index($name))] as $matches |
+                ($matches | length) == ($expected | length) and
+                all($expected[];
+                  . as $name | ([$matches[] | select(.name == $name)] | length) == 1) and
+                all($matches[];
+                  .state == "uploaded" and .size > 0 and
+                  ((.digest // "") | test("^sha256:[0-9a-f]{64}$")))
+              ' >/dev/null; then
+                archive="d2-$version-windows-amd64.tar.gz"
+                archive_json=$(printf '%s' "$release_json" | jq -c --arg archive "$archive" \
+                  '[.assets[] | select(.name == $archive)] | if length == 1 then .[0] else empty end')
+                break
+              fi
+            fi
+            if [[ "$attempt" -eq "$attempts" ]]; then
+              echo "$version does not have six complete release archives" >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+          release_id=$(printf '%s' "$release_json" | jq -er '.id')
+          release_tag=$(printf '%s' "$release_json" | jq -er '.tag_name')
+          release_draft=$(printf '%s' "$release_json" | jq -r '.draft')
+          archive_asset_id=$(printf '%s' "$archive_json" | jq -er '.id')
+          archive_digest=$(printf '%s' "$archive_json" | jq -r '.digest')
+          archive_size=$(printf '%s' "$archive_json" | jq -r '.size')
+
+          if [[ "$release_tag" != "$version" ]]; then
+            echo "release tag does not match $version" >&2
+            exit 1
+          fi
+          if [[ "$upload_release" == true && "$release_draft" != true ]]; then
+            echo "$version must remain a draft until its MSI is uploaded" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$archive_digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "Windows archive does not have a GitHub SHA-256 digest" >&2
+            exit 1
+          fi
+          if [[ "$archive_size" -le 0 ]]; then
+            echo "Windows archive is empty" >&2
+            exit 1
+          fi
+
+          tag_object=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$version")
+          tag_type=$(printf '%s' "$tag_object" | jq -er '.object.type')
+          tag_commit=$(printf '%s' "$tag_object" | jq -er '.object.sha')
+          for _ in 1 2 3 4 5; do
+            if [[ "$tag_type" == commit ]]; then
+              break
+            fi
+            if [[ "$tag_type" != tag ]]; then
+              echo "tag resolves to unsupported object type $tag_type" >&2
+              exit 1
+            fi
+            tag_object=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_commit")
+            tag_type=$(printf '%s' "$tag_object" | jq -er '.object.type')
+            tag_commit=$(printf '%s' "$tag_object" | jq -er '.object.sha')
+          done
+          if [[ "$tag_type" != commit || ! "$tag_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "unable to peel $version to a commit" >&2
+            exit 1
+          fi
+
+          checkout_commit=$GITHUB_SHA
+          if [[ "$upload_release" == true ]]; then
+            checkout_commit=$tag_commit
+          fi
+
+          {
+            echo "archive_asset_id=$archive_asset_id"
+            echo "archive_digest=$archive_digest"
+            echo "checkout_commit=$checkout_commit"
+            echo "release_id=$release_id"
+            echo "tag_commit=$tag_commit"
+            echo "upload_release=$upload_release"
+            echo "version=$version"
+          } >>"$GITHUB_OUTPUT"
+
+  build:
+    needs: validate
+    runs-on: windows-2022
+    timeout-minutes: 30
+    env:
+      ARCHIVE_ASSET_ID: ${{ needs.validate.outputs.archive_asset_id }}
+      ARCHIVE_DIGEST: ${{ needs.validate.outputs.archive_digest }}
+      VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.checkout_commit }}
+          persist-credentials: false
+
+      - name: Install pinned WiX toolset
+        shell: pwsh
+        run: |
+          dotnet --info
+          dotnet tool install --tool-path "$env:RUNNER_TEMP\wix" wix --version 4.0.0-preview.1
+          "$env:RUNNER_TEMP\wix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Download and verify release archive
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $archive = "$env:RUNNER_TEMP\d2-$env:VERSION-windows-amd64.tar.gz"
+          $headers = @{
+            Accept = 'application/octet-stream'
+            Authorization = "Bearer $env:GH_TOKEN"
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+          $downloadParameters = @{
+            Headers = $headers
+            Uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$env:ARCHIVE_ASSET_ID"
+            OutFile = $archive
+          }
+          Invoke-WebRequest @downloadParameters
+
+          $expected = $env:ARCHIVE_DIGEST.Substring('sha256:'.Length)
+          $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -cne $expected) {
+            throw "archive SHA-256 is $actual, expected $expected"
+          }
+
+      - name: Build and verify MSI
+        shell: pwsh
+        env:
+          ALLOW_FIXTURE_NOTICES: ${{ needs.validate.outputs.upload_release != 'true' && needs.validate.outputs.version == 'v0.7.1' }}
+        run: |
+          $parameters = @{
+            Version = $env:VERSION
+            ArchivePath = "$env:RUNNER_TEMP\d2-$env:VERSION-windows-amd64.tar.gz"
+            OutputDirectory = "$env:RUNNER_TEMP\windows-msi"
+          }
+          if ($env:ALLOW_FIXTURE_NOTICES -eq 'true') {
+            $parameters.AllowFixtureNotices = $true
+          }
+          ./ci/release/windows/build.ps1 @parameters
+
+      - name: Upload verified MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msi
+          path: ${{ runner.temp }}/windows-msi/*.msi
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  upload:
+    if: needs.validate.outputs.upload_release == 'true'
+    needs:
+      - validate
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      ARCHIVE_ASSET_ID: ${{ needs.validate.outputs.archive_asset_id }}
+      ARCHIVE_DIGEST: ${{ needs.validate.outputs.archive_digest }}
+      RELEASE_ID: ${{ needs.validate.outputs.release_id }}
+      TAG_COMMIT: ${{ needs.validate.outputs.tag_commit }}
+      VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-msi
+          path: ${{ runner.temp }}/windows-msi
+
+      - name: Revalidate release snapshot and upload MSI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          peel_tag() {
+            local tag_object tag_type tag_commit
+            tag_object=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION")
+            tag_type=$(printf '%s' "$tag_object" | jq -er '.object.type')
+            tag_commit=$(printf '%s' "$tag_object" | jq -er '.object.sha')
+            for _ in 1 2 3 4 5; do
+              if [[ "$tag_type" == commit ]]; then
+                break
+              fi
+              if [[ "$tag_type" != tag ]]; then
+                echo "tag resolves to unsupported object type $tag_type" >&2
+                return 1
+              fi
+              tag_object=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_commit")
+              tag_type=$(printf '%s' "$tag_object" | jq -er '.object.type')
+              tag_commit=$(printf '%s' "$tag_object" | jq -er '.object.sha')
+            done
+            if [[ "$tag_type" != commit || ! "$tag_commit" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "unable to peel $VERSION to a commit" >&2
+              return 1
+            fi
+            printf '%s\n' "$tag_commit"
+          }
+
+          release_json=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
+          if [[ "$(printf '%s' "$release_json" | jq -r '.id')" != "$RELEASE_ID" ||
+            "$(printf '%s' "$release_json" | jq -r '.draft')" != true ||
+            "$(printf '%s' "$release_json" | jq -r '.tag_name')" != "$VERSION" ]]; then
+            echo "$VERSION is no longer the expected draft release" >&2
+            exit 1
+          fi
+
+          archive="d2-$VERSION-windows-amd64.tar.gz"
+          archive_json=$(printf '%s' "$release_json" | jq -c --arg archive "$archive" \
+            '[.assets[] | select(.name == $archive)] | if length == 1 then .[0] else empty end')
+          if [[ -z "$archive_json" ||
+            "$(printf '%s' "$archive_json" | jq -r '.id')" != "$ARCHIVE_ASSET_ID" ||
+            "$(printf '%s' "$archive_json" | jq -r '.digest')" != "$ARCHIVE_DIGEST" ]]; then
+            echo "Windows archive changed after validation" >&2
+            exit 1
+          fi
+
+          if [[ "$(peel_tag)" != "$TAG_COMMIT" ]]; then
+            echo "$VERSION moved after validation" >&2
+            exit 1
+          fi
+
+          asset="d2-$VERSION-windows-amd64.msi"
+          msi="$RUNNER_TEMP/windows-msi/$asset"
+          test -s "$msi"
+          local_digest="sha256:$(sha256sum "$msi" | awk '{print $1}')"
+          local_size=$(stat -c %s "$msi")
+
+          existing=$(printf '%s' "$release_json" | jq -c --arg asset "$asset" \
+            '[.assets[] | select(.name == $asset)]')
+          existing_count=$(printf '%s' "$existing" | jq -r 'length')
+          case "$existing_count" in
+            0)
+              gh release upload "$VERSION" "$msi" --repo "$GITHUB_REPOSITORY"
+              ;;
+            1)
+              if [[ "$(printf '%s' "$existing" | jq -r '.[0].state')" != uploaded ||
+                "$(printf '%s' "$existing" | jq -r '.[0].size')" != "$local_size" ||
+                "$(printf '%s' "$existing" | jq -r '.[0].digest')" != "$local_digest" ]]; then
+                echo "$asset already exists with different bytes" >&2
+                exit 1
+              fi
+              echo "$asset is already attached with the verified digest"
+              ;;
+            *)
+              echo "draft release has duplicate $asset assets" >&2
+              exit 1
+              ;;
+          esac
+
+          for attempt in 1 2 3 4 5; do
+            final_release=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
+            if [[ "$(printf '%s' "$final_release" | jq -r '.id')" != "$RELEASE_ID" ||
+              "$(printf '%s' "$final_release" | jq -r '.draft')" != true ||
+              "$(printf '%s' "$final_release" | jq -r '.tag_name')" != "$VERSION" ]]; then
+              echo "$VERSION changed or was published during MSI upload" >&2
+              exit 1
+            fi
+            final_archive=$(printf '%s' "$final_release" | jq -c --arg archive "$archive" \
+              '[.assets[] | select(.name == $archive)] | if length == 1 then .[0] else empty end')
+            if [[ -z "$final_archive" ||
+              "$(printf '%s' "$final_archive" | jq -r '.id')" != "$ARCHIVE_ASSET_ID" ||
+              "$(printf '%s' "$final_archive" | jq -r '.digest')" != "$ARCHIVE_DIGEST" ]]; then
+              echo "Windows archive changed during MSI upload" >&2
+              exit 1
+            fi
+            if [[ "$(peel_tag)" != "$TAG_COMMIT" ]]; then
+              echo "$VERSION moved during MSI upload" >&2
+              exit 1
+            fi
+
+            uploaded=$(printf '%s' "$final_release" | jq -c --arg asset "$asset" \
+              '[.assets[] | select(.name == $asset)] | if length == 1 then .[0] else empty end')
+            if [[ -n "$uploaded" &&
+              "$(printf '%s' "$uploaded" | jq -r '.state')" == uploaded &&
+              "$(printf '%s' "$uploaded" | jq -r '.size')" == "$local_size" &&
+              "$(printf '%s' "$uploaded" | jq -r '.digest')" == "$local_digest" ]]; then
+              break
+            fi
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "uploaded MSI digest was not verified" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+          echo "Uploaded $asset ($local_digest) to draft release $VERSION"

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -49,6 +49,30 @@ it depends on from ../sub/lib.
 - ./release.sh is the top level script to generate a new release.
   Run with --help for usage.
 
+The first release-script run must leave the GitHub release as a draft. Pushing its tag
+starts the `Windows MSI` workflow, which waits for all six release archives and pins the
+exact Windows amd64 archive, builds the installer on GitHub's `windows-2022` runner,
+verifies its metadata and installed contents, and uploads
+`d2-<version>-windows-amd64.msi` to that same draft.
+
+Do not publish the release until the workflow is green and the MSI is present. Review and
+merge the release PR, then publish the draft on GitHub. The D2 wrapper rejects
+`release.sh --publish`, and it refuses any release-builder rerun after the MSI is attached.
+This prevents the shared helper from publishing while the asynchronous build is running or
+moving the tag after an MSI was built from it.
+It also rejects a legacy local MSI in the version's build directory so the shared asset
+uploader cannot attach an unverified installer.
+
+The workflow can also be dispatched manually with release upload disabled. `v0.7.1` is
+the continuity fixture; because that release predates notices in the archives, only this
+non-uploading fixture build packages the current notices file. Every production MSI
+requires `THIRD_PARTY_NOTICES.txt` from its pinned release archive. Re-run only a failed
+job: the workflow's Actions artifact is immutable within a run, and a full rerun fails
+closed instead of replacing it.
+
+The MSI remains unsigned. Authenticode signing is tracked separately in
+[issue #1078](https://github.com/d2lang/d2/issues/1078).
+
 ## build.sh
 
 - ./build.sh builds the release archives for each platform into ./build/<VERSION>/*.tar.gz
@@ -65,8 +89,8 @@ calls it or publishes Docker tags from a legacy AWS SSH builder.
 ### Production Docker publishing
 
 The manually dispatched `Publish Docker release` GitHub workflow is the production path
-for Docker Hub. It replaces only the Docker portion of the legacy AWS release path; the
-other release asset builders are unchanged.
+for Docker Hub. It replaces the Docker portion of the legacy AWS release path; the Windows
+MSI is built separately by the `Windows MSI` workflow described above.
 
 Run it from the protected `master` branch after the GitHub release is published. Enter the
 exact v-prefixed release version and leave `publish_latest` off unless this stable release

--- a/ci/release/aws/ensure.sh
+++ b/ci/release/aws/ensure.sh
@@ -57,14 +57,12 @@ main() {
   echo "export CI_D2_LINUX_ARM64=$CI_D2_LINUX_ARM64"
   echo "export CI_D2_MACOS_AMD64=$CI_D2_MACOS_AMD64"
   echo "export CI_D2_MACOS_ARM64=$CI_D2_MACOS_ARM64"
-  echo "export CI_D2_WINDOWS_AMD64=$CI_D2_WINDOWS_AMD64"
 }
 
 create_remote_hosts() {
   bigheader create_remote_hosts
 
   KEY_NAME=$(aws ec2 describe-key-pairs | jq -r .KeyPairs[0].KeyName)
-  KEY_NAME_WINDOWS=windows
   VPC_ID=$(aws ec2 describe-vpcs | jq -r .Vpcs[0].VpcId)
 
   JOBNAME=$JOBNAME/security-groups runjob_filter create_security_groups
@@ -72,7 +70,6 @@ create_remote_hosts() {
   JOBNAME=$JOBNAME/linux/arm64 runjob_filter create_linux_arm64
   JOBNAME=$JOBNAME/macos/amd64 runjob_filter create_macos_amd64
   JOBNAME=$JOBNAME/macos/arm64 runjob_filter create_macos_arm64
-  JOBNAME=$JOBNAME/windows/amd64 runjob_filter create_windows_amd64
 }
 
 create_security_groups() {
@@ -97,31 +94,6 @@ create_security_groups() {
       --cidr 0.0.0.0/0 >/dev/null
   fi
 
-  header windows-security-group
-  SG_ID=$(aws ec2 describe-security-groups --group-names windows 2>/dev/null \
-    | jq -r .SecurityGroups[0].GroupId)
-  if [ -z "$SG_ID" ]; then
-    SG_ID=$(sh_c aws ec2 create-security-group \
-      --group-name windows \
-      --description windows \
-      --vpc-id "$VPC_ID" | jq -r .GroupId)
-  fi
-
-  header windows-security-group-ingress
-  SG_RULES_COUNT=$(aws ec2 describe-security-groups --group-names windows \
-    | jq -r '.SecurityGroups[0].IpPermissions | length')
-  if [ "$SG_RULES_COUNT" -ne 2 ]; then
-    sh_c aws ec2 authorize-security-group-ingress \
-      --group-id "$SG_ID" \
-      --protocol tcp \
-      --port 22 \
-      --cidr 0.0.0.0/0 >/dev/null
-    sh_c aws ec2 authorize-security-group-ingress \
-      --group-id "$SG_ID" \
-      --protocol tcp \
-      --port 3389 \
-      --cidr 0.0.0.0/0 >/dev/null
-  fi
 }
 
 create_linux_amd64() {
@@ -234,30 +206,6 @@ create_macos_arm64() {
   export CI_D2_MACOS_ARM64=ec2-user@$ip
 }
 
-create_windows_amd64() {
-  header windows-amd64
-  REMOTE_NAME=ci-d2-windows-amd64
-  state=$(aws ec2 describe-instances --filters \
-    'Name=instance-state-name,Values=pending,running,stopping,stopped' "Name=tag:Name,Values=$REMOTE_NAME" \
-    | jq -r '.Reservations[].Instances[].State.Name')
-  if [ -z "$state" ]; then
-    # public AMIs are deprecated every few months so just search the latest Windows Server one for recreating
-    sh_c aws ec2 run-instances \
-      --image-id=ami-03ea14ccbeab7b2d5 \
-      --count=1 \
-      --instance-type=t3.medium \
-      --security-groups=windows \
-      "--key-name=$KEY_NAME_WINDOWS" \
-      --iam-instance-profile 'Name=AmazonSSMRoleForInstancesQuickSetup' \
-      --block-device-mappings '"DeviceName=/dev/sda1,Ebs={VolumeSize=64,VolumeType=gp3}"' \
-      --tag-specifications "'ResourceType=instance,Tags=[{Key=Name,Value=$REMOTE_NAME}]'" \
-        "'ResourceType=volume,Tags=[{Key=Name,Value=$REMOTE_NAME}]'" >/dev/null
-  fi
-  wait_remote_host_ip
-  log "CI_D2_WINDOWS_AMD64=Administrator@$ip"
-  export CI_D2_WINDOWS_AMD64=Administrator@$ip
-}
-
 wait_remote_host_ip() {
   while true; do
     ip=$(sh_c aws ec2 describe-instances \
@@ -295,10 +243,6 @@ init_remote_hosts() {
   JOBNAME=$JOBNAME/linux/arm64 runjob_filter REMOTE_HOST=$CI_D2_LINUX_ARM64 REMOTE_NAME=ci-d2-linux-arm64 init_remote_linux
   JOBNAME=$JOBNAME/macos/amd64 runjob_filter REMOTE_HOST=$CI_D2_MACOS_AMD64 REMOTE_NAME=ci-d2-macos-amd64 init_remote_macos
   JOBNAME=$JOBNAME/macos/arm64 runjob_filter REMOTE_HOST=$CI_D2_MACOS_ARM64 REMOTE_NAME=ci-d2-macos-arm64 init_remote_macos
-  JOBNAME=$JOBNAME/windows/amd64 runjob_filter REMOTE_HOST=$CI_D2_WINDOWS_AMD64 REMOTE_NAME=ci-d2-windows-amd64 init_remote_windows
-
-  # Windows and AWS SSM both defeated me.
-  FGCOLOR=3 bigheader "WARNING: WINDOWS INITIALIZATION MUST BE COMPLETED MANUALLY OVER RDP AND POWERSHELL!"
 }
 
 init_remote_linux() {
@@ -383,152 +327,6 @@ wait_remote_host() {
     fi
     sleep 5
   done
-}
-
-wait_remote_host_windows() {
-  instance_id=$(aws ec2 describe-instances \
-    --filters 'Name=instance-state-name,Values=pending,running,stopping,stopped' "Name=tag:Name,Values=$REMOTE_NAME" \
-    | jq -r '.Reservations[].Instances[].InstanceId')
-
-  while true; do
-    if sh_c aws ssm start-session --target "$instance_id" \
-    --document-name 'AWS-StartNonInteractiveCommand' \
-    --parameters "'{\"command\": [\"echo true\"]}'"; then
-      break
-    fi
-    sleep 5
-  done
-}
-
-init_remote_windows() {
-  header "$REMOTE_NAME"
-  wait_remote_host_windows
-
-  # rsync was broken in this script last ran on 4/10/24.
-  # had to upgrade with `pacman -Syyu rsync` after
-
-  init_ps1=$(cat <<EOF
-\$ProgressPreference = 'SilentlyContinue'
-
-# Bootstrap PowerShell v7
-if ((\$PSVersionTable.PSVersion).Major -eq 5) {
-  Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6 -OutFile .\microsoft.ui.xaml.2.8.6.zip
-  Expand-Archive -Force .\microsoft.ui.xaml.2.8.6.zip
-  Add-AppxPackage .\microsoft.ui.xaml.2.8.6\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.8.appx
-
-  Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.7.10861/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
-  Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.7.10861/30fe89a9836a4cfbbd3fedce72a58680_License1.xml -OutFile .\30fe89a9836a4cfbbd3fedce72a58680_License1.xml
-  Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
-  Add-AppxProvisionedPackage -online -PackagePath .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -LicensePath .\30fe89a9836a4cfbbd3fedce72a58680_License1.xml -DependencyPackagePath Microsoft.VCLibs.x64.14.00.Desktop.appx
-  Add-AppxPackage .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
-
-  winget install --silent --accept-package-agreements --accept-source-agreements Microsoft.DotNet.SDK.7
-  # Refresh env.
-  \$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-  dotnet tool install --global PowerShell --version 7.3.1
-  pwsh -c 'Enable-ExperimentalFeature PSNativeCommandErrorActionPreference'
-  pwsh .\Desktop\init.ps1
-  Exit
-}
-
-Set-StrictMode -Version Latest
-\$ErrorActionPreference = "Stop"
-\$PSNativeCommandUseErrorActionPreference = \$true
-
-if (-Not (Get-Command wix -errorAction SilentlyContinue)) {
-  dotnet tool install --global wix --version 4.0.0-preview.1
-}
-
-Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-Start-Service sshd
-Set-Service -Name sshd -StartupType 'Automatic'
-
-New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\msys64\usr\bin\bash.exe" -PropertyType String -Force
-
-ConvertFrom-Json -InputObject @'
-$(perl -pe 's#\n#\r\n#' "$ID_PUB_PATH" | jq -Rs .)
-'@ | Out-File -Encoding utf8 "\$env:ProgramData\ssh\administrators_authorized_keys"
-# utf8BOM -> utf8: https://stackoverflow.com/a/34969243/4283659
-\$null = New-Item -Force "\$env:ProgramData\ssh\administrators_authorized_keys" -Value (Get-Content -Path "\$env:ProgramData\ssh\administrators_authorized_keys" | Out-String)
-get-acl "\$env:ProgramData\ssh\ssh_host_rsa_key" | set-acl "\$env:ProgramData\ssh\administrators_authorized_keys"
-
-if (-Not (Test-Path -Path C:\msys64)) {
-  Invoke-WebRequest -Uri "https://github.com/msys2/msys2-installer/releases/download/2022-10-28/msys2-x86_64-20221028.exe" -OutFile "./msys2-x86_64.exe"
-  ./msys2-x86_64.exe install --default-answer --confirm-command --root C:\msys64
-}
-C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64 -c 'pacman -Sy --noconfirm base-devel vim rsync man'
-C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64 -c 'curl -fsSL https://d2lang.com/install.sh | sh -s -- --tala'
-C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64 -c 'd2 --version'
-
-\$path = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path).Path
-if (\$path -notlike '*C:\msys64\usr\bin*') {
-  \$path = "\$path;C:\msys64\usr\bin"
-  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value \$path
-}
-if (\$path -notlike '*C:\msys64\usr\local\bin*') {
-  \$path = "\$path;C:\msys64\usr\local\bin"
-  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value \$path
-}
-(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path).Path
-
-Restart-Computer
-EOF
-
-# To run a POSIX script:
-#   ssh "$CI_D2_WINDOWS_AMD64" sh -s -- <<EOF
-#   wix --version
-#   EOF
-# To run a command in a pure MSYS2 shell:
-#   ssh "$CI_D2_WINDOWS_AMD64" 'C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64 -c "\"d2 --version\""'
-# To run a pure MSYS2 shell:
-#   ssh -t "$CI_D2_WINDOWS_AMD64" 'C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64'
-
-# In case MSYS2 improves in the future and allows for noninteractive commands the
-# following will set the OpenSSH shell to MSYS2 instead of PowerShell.
-#
-# Right now, setting MSYS2 to the DefaultShell like this will make it start bash in
-# interactive mode always. Even for ssh "$CI_D2_WINDOWS_AMD64" echo hi. And so you'll end
-# up with a blank prompt on which to input commands instead of having it execute the
-# command you passed in via ssh.
-#
-# PowerShell as the default is better anyway as it gives us access to both the UNIX
-# userspace and Windows tools like wix/dotnet/winget.
-#
-# To set:
-#   <<EOF
-#   echo '@C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64' | Out-File C:\msys64\sshd_default_shell.cmd
-#   # utf8BOM -> utf8: https://stackoverflow.com/a/34969243/4283659
-#   \$null = New-Item -Force C:\msys64\sshd_default_shell.cmd -Value (Get-Content -Path C:\msys64\sshd_default_shell.cmd | Out-String)
-#   Set-ItemProperty -Path HKLM:\SOFTWARE\OpenSSH -Name DefaultShell -Value C:\msys64\sshd_default_shell.cmd
-#   EOF
-#
-# To undo:
-#   <<EOF
-#   Remove-ItemProperty -Path HKLM:\SOFTWARE\OpenSSH -Name DefaultShell
-#   rm C:\msys64\sshd_default_shell.cmd
-#   EOF
-)
-
-  gen_init_ps1=$(cat <<EOF
-ConvertFrom-Json -InputObject @'
-$(printf %s "$init_ps1" | perl -pe 'chomp if eof' | perl -pe 's#\n#\r\n#' | jq -Rs .)
-'@ | Out-File -Encoding utf8 C:\Users\Administrator\Desktop\init.ps1; C:\Users\Administrator\Desktop\init.ps1
-EOF
-)
-
-  # Windows and AWS SSM both defeated me.
-  # alixander: Step 3's output got mangled for me, so had to replace the line with `printf '%s\n' "$gen_init_ps1" > script` and then open it with vim
-  FGCOLOR=3 bigheader "WARNING: WINDOWS INITIALIZATION MUST BE COMPLETED MANUALLY OVER RDP AND POWERSHELL!"
-
-  warn '1. Obtain Windows RDP password with:'
-  echo "  aws ec2 get-password-data --instance-id \$(aws ec2 describe-instances --filters 'Name=instance-state-name,Values=pending,running,stopping,stopped' "Name=tag:Name,Values=$REMOTE_NAME" | jq -r '.Reservations[].Instances[].InstanceId') --priv-launch-key windows.pem | jq -r .PasswordData" >&2
-  warn "2. RDP into $REMOTE_HOST and open PowerShell."
-  warn '3. Generate and execute C:\Users\Administrator\Desktop\init.ps1 with:'
-  printf '%s\n' "$gen_init_ps1" >&2
-  warn '4. Run the following to be notified once installation is successful:'
-  cat <<EOF
-  until ssh $REMOTE_HOST d2 --version; do echo 'failed: retrying in 5s' && sleep 5; done && printf 'success\a\n'
-EOF
 }
 
 main "$@"

--- a/ci/release/aws/ssh.sh
+++ b/ci/release/aws/ssh.sh
@@ -37,7 +37,6 @@ main() {
   REMOTE_HOST=$CI_D2_LINUX_ARM64 && runjob linux-arm64 ssh "$REMOTE_HOST" "$@"
   REMOTE_HOST=$CI_D2_MACOS_AMD64 && runjob macos-amd64 ssh "$REMOTE_HOST" "$@"
   REMOTE_HOST=$CI_D2_MACOS_ARM64 && runjob macos-arm64 ssh "$REMOTE_HOST" "$@"
-  REMOTE_HOST=$CI_D2_WINDOWS_AMD64 && runjob windows-amd64 ssh "$REMOTE_HOST" "$@"
 }
 
 main "$@"

--- a/ci/release/build.sh
+++ b/ci/release/build.sh
@@ -123,9 +123,6 @@ main() {
   runjob windows/amd64 'OS=windows ARCH=amd64 build' &
   runjob windows/arm64 'OS=windows ARCH=arm64 build' &
   waitjobs
-
-  runjob windows/amd64/msi 'OS=windows ARCH=amd64 build_windows_msi' &
-  waitjobs
 }
 
 build() {
@@ -149,28 +146,6 @@ build_local() {
     ARCH \
     ARCHIVE
   sh_c ./ci/release/_build.sh
-}
-
-build_windows_msi() {
-  REMOTE_HOST=$CI_D2_WINDOWS_AMD64
-
-  ln -sf "../build/$VERSION/windows-amd64/d2-$VERSION/bin/d2.exe" ./ci/release/windows/d2.exe
-  ln -sf "../build/$VERSION/windows-amd64/d2-$VERSION/THIRD_PARTY_NOTICES.txt" ./ci/release/windows/THIRD_PARTY_NOTICES.txt
-  sh_c rsync --archive --human-readable --copy-links --delete ./ci/release/windows/ "'$REMOTE_HOST:windows/'"
-  if ! echo "$VERSION" | grep '[0-9]\.[0-9]\.[0-9]'; then
-    WIX_VERSION=0.0.0
-  else
-    WIX_VERSION=$VERSION
-  fi
-  sh_c ssh "$REMOTE_HOST" "'cd ./windows && wix build -arch x64 -d D2Version=$WIX_VERSION ./d2.wxs'"
-
-  # --files-from shouldn't be necessary but for some reason selecting d2.msi directly
-  # makes rsync error with:
-  # ERROR: rejecting unrequested file-list name: ./windows/d2.msi
-  # rsync error: requested action not supported (code 4) at flist.c(1027) [Receiver=3.2.7]
-  rsync_files=$(mktempd)/rsync-files
-  echo d2.msi >$rsync_files
-  sh_c rsync --archive --human-readable --files-from "$rsync_files" "'$REMOTE_HOST:windows/'" "./ci/release/build/$VERSION/d2-$VERSION-$OS-$ARCH.msi"
 }
 
 main "$@"

--- a/ci/release/release.sh
+++ b/ci/release/release.sh
@@ -3,4 +3,102 @@ set -eu
 cd -- "$(dirname "$0")/../.."
 . "./ci/sub/lib.sh"
 
-./ci/sub/release/release.sh "$@"
+if [ -n "${PUBLISH-}" ]; then
+  echo >&2 "the inherited PUBLISH flag is no longer supported"
+  echo >&2 "create the draft, wait for the Windows MSI workflow, then merge and publish it on GitHub"
+  exit 1
+fi
+unset PUBLISH
+
+VERSION_ARG=${VERSION-}
+scan_arguments() {
+  while flag_parse "$@"; do
+    case "$FLAG" in
+      h|help|rebuild|prerelease|dry-run|skip-build)
+        flag_noarg || return 1
+        ;;
+      publish)
+        flag_noarg || return 1
+        echo >&2 "release.sh no longer publishes a release directly"
+        echo >&2 "create the draft without --publish, wait for the Windows MSI workflow, then merge and publish the reviewed draft on GitHub"
+        return 1
+        ;;
+      version)
+        flag_nonemptyarg || return 1
+        VERSION_ARG=$FLAGARG
+        ;;
+      *)
+        flag_errusage "unrecognized flag $FLAGRAW"
+        return 1
+        ;;
+    esac
+    shift "$FLAGSHIFT"
+  done
+  shift "$FLAGSHIFT"
+  if [ $# -gt 0 ]; then
+    flag_errusage "no arguments are accepted"
+    return 1
+  fi
+}
+scan_arguments "$@"
+
+if [ -z "$VERSION_ARG" ]; then
+  VERSION_ARG=$(git describe 2>/dev/null || true)
+fi
+case "$VERSION_ARG" in
+  v*)
+    MSI_ASSET=d2-$VERSION_ARG-windows-amd64.msi
+    BUILD_DIRECTORY=ci/release/build/$VERSION_ARG
+    if [ -d "$BUILD_DIRECTORY" ]; then
+      LOCAL_MSI=$(find -L "$BUILD_DIRECTORY" -maxdepth 1 -type f -name '*.msi' -print -quit)
+      if [ -n "$LOCAL_MSI" ]; then
+        echo >&2 "legacy local MSI must not be uploaded: $LOCAL_MSI"
+        echo >&2 "remove it and let the Windows MSI workflow build the installer from the uploaded archive"
+        exit 1
+      fi
+    fi
+    REPOSITORY=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+    REPOSITORY_JSON=$(gh api "repos/$REPOSITORY")
+    if ! printf '%s' "$REPOSITORY_JSON" | jq -e \
+      '.permissions.push == true' >/dev/null; then
+      echo >&2 "the active GitHub API identity does not have push access to $REPOSITORY"
+      echo >&2 "cannot safely distinguish a missing release from a hidden draft release"
+      exit 1
+    fi
+    if RELEASE_RESPONSE=$(gh api --include \
+      "repos/$REPOSITORY/releases/tags/$VERSION_ARG" 2>&1); then
+      STATUS_CODE=$(printf '%s\n' "$RELEASE_RESPONSE" \
+        | sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p')
+      if [ "$STATUS_CODE" != 200 ]; then
+        echo >&2 "unexpected GitHub release lookup status: $STATUS_CODE"
+        exit 1
+      fi
+      RELEASE_JSON=$(printf '%s\n' "$RELEASE_RESPONSE" \
+        | awk 'body { print } /^\r?$/ { body = 1 }')
+      if ! printf '%s' "$RELEASE_JSON" | jq -e --arg version "$VERSION_ARG" \
+        'type == "object" and (.id | type == "number") and
+          .tag_name == $version and (.assets | type == "array")' >/dev/null; then
+        echo >&2 "GitHub returned malformed release metadata for $VERSION_ARG"
+        exit 1
+      fi
+      MSI_COUNT=$(printf '%s' "$RELEASE_JSON" | jq -r --arg asset "$MSI_ASSET" \
+        '[.assets[] | select(.name == $asset)] | length')
+    else
+      STATUS_CODE=$(printf '%s\n' "$RELEASE_RESPONSE" \
+        | sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p')
+      if [ "$STATUS_CODE" != 404 ]; then
+        printf '%s\n' "$RELEASE_RESPONSE" >&2
+        echo >&2 "unable to verify whether $VERSION_ARG already has an MSI"
+        exit 1
+      fi
+      MSI_COUNT=0
+    fi
+    if [ -n "$MSI_COUNT" ] && [ "$MSI_COUNT" -gt 0 ]; then
+      echo >&2 "$MSI_ASSET is already attached to the release"
+      echo >&2 "do not rerun the release builder or move its tag; merge the release PR and publish the reviewed draft on GitHub"
+      exit 1
+    fi
+    ;;
+esac
+
+exec ./ci/sub/release/release.sh "$@"

--- a/ci/release/windows/build.ps1
+++ b/ci/release/windows/build.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$')]
+    [string] $Version,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ArchivePath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $OutputDirectory,
+
+    [switch] $AllowFixtureNotices
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+function Get-MsiProperty {
+    param(
+        [Parameter(Mandatory = $true)] $Database,
+        [Parameter(Mandatory = $true)] [string] $Name
+    )
+
+    $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = '$Name'"
+    $view = $Database.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $Database, @($query))
+    $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null)
+    $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+    if ($null -eq $record) {
+        throw "MSI property $Name is missing"
+    }
+    return $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, 1)
+}
+
+if (-not (Test-Path -LiteralPath $ArchivePath -PathType Leaf)) {
+    throw "archive does not exist: $ArchivePath"
+}
+if (-not (Get-Command wix -ErrorAction SilentlyContinue)) {
+    throw 'wix is not installed or is not on PATH'
+}
+
+$workingDirectory = Join-Path $env:RUNNER_TEMP "windows-msi-$Version"
+$archiveDirectory = Join-Path $workingDirectory 'archive'
+$wixDirectory = Join-Path $workingDirectory 'wix'
+$extractDirectory = Join-Path $workingDirectory 'installed'
+Remove-Item -LiteralPath $workingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $archiveDirectory, $wixDirectory, $extractDirectory -Force | Out-Null
+
+$archiveEntries = @(& tar -tzf $ArchivePath)
+if ($LASTEXITCODE -ne 0 -or $archiveEntries.Count -eq 0) {
+    throw 'unable to list release archive'
+}
+$archiveRoot = "d2-$Version/"
+foreach ($entry in $archiveEntries) {
+    if (-not $entry.StartsWith($archiveRoot, [System.StringComparison]::Ordinal)) {
+        throw "release archive contains a path outside ${archiveRoot}: $entry"
+    }
+}
+
+& tar -xzf $ArchivePath -C $archiveDirectory
+if ($LASTEXITCODE -ne 0) {
+    throw 'unable to extract release archive'
+}
+
+$releaseDirectory = Join-Path $archiveDirectory "d2-$Version"
+$binaryPath = Join-Path $releaseDirectory 'bin/d2.exe'
+$noticesPath = Join-Path $releaseDirectory 'THIRD_PARTY_NOTICES.txt'
+if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+    throw "release archive does not contain $archiveRoot/bin/d2.exe"
+}
+if (-not (Test-Path -LiteralPath $noticesPath -PathType Leaf)) {
+    if (-not $AllowFixtureNotices) {
+        throw "release archive does not contain $archiveRoot/THIRD_PARTY_NOTICES.txt"
+    }
+
+    # v0.7.1 predates notices in release archives. Its published binary remains the
+    # continuity fixture, while current notices exercise the installer component.
+    $noticesPath = Join-Path $PSScriptRoot '../../../THIRD_PARTY_NOTICES.txt'
+    if (-not (Test-Path -LiteralPath $noticesPath -PathType Leaf)) {
+        throw 'fixture notices file is missing'
+    }
+}
+
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'd2.wxs') -Destination $wixDirectory
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'd2.ico') -Destination $wixDirectory
+Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $wixDirectory 'd2.exe')
+Copy-Item -LiteralPath $noticesPath -Destination (Join-Path $wixDirectory 'THIRD_PARTY_NOTICES.txt')
+
+Push-Location $wixDirectory
+try {
+    & wix build -arch x64 -d "D2Version=$Version" ./d2.wxs
+    if ($LASTEXITCODE -ne 0) {
+        throw "wix exited with status $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}
+
+$msiPath = Join-Path $wixDirectory 'd2.msi'
+if (-not (Test-Path -LiteralPath $msiPath -PathType Leaf)) {
+    throw 'wix did not produce d2.msi'
+}
+
+$installer = New-Object -ComObject WindowsInstaller.Installer
+$database = $installer.GetType().InvokeMember(
+    'OpenDatabase',
+    'InvokeMethod',
+    $null,
+    $installer,
+    @((Resolve-Path -LiteralPath $msiPath).Path, 0)
+)
+
+$expectedProperties = @{
+    ProductName = 'D2'
+    Manufacturer = 'D2'
+    UpgradeCode = '{AC84FEE7-EB67-4F5D-A08D-ADEF69538690}'
+}
+foreach ($property in $expectedProperties.Keys) {
+    $actual = Get-MsiProperty -Database $database -Name $property
+    if ($actual -cne $expectedProperties[$property]) {
+        throw "MSI $property is '$actual', expected '$($expectedProperties[$property])'"
+    }
+}
+
+$productVersion = Get-MsiProperty -Database $database -Name ProductVersion
+$versionWithoutPrefix = $Version.Substring(1)
+$versionCore = $versionWithoutPrefix.Split('-')[0]
+if ($productVersion -notin @($Version, $versionWithoutPrefix, $versionCore)) {
+    throw "MSI ProductVersion is '$productVersion', expected $Version"
+}
+
+$installArguments = "/a `"$msiPath`" /qn TARGETDIR=`"$extractDirectory`""
+$install = Start-Process -FilePath msiexec.exe -ArgumentList $installArguments -Wait -PassThru
+if ($install.ExitCode -notin @(0, 3010)) {
+    throw "administrative MSI extraction exited with status $($install.ExitCode)"
+}
+
+$installedBinaries = @(Get-ChildItem -LiteralPath $extractDirectory -Filter d2.exe -File -Recurse)
+$installedNotices = @(Get-ChildItem -LiteralPath $extractDirectory -Filter THIRD_PARTY_NOTICES.txt -File -Recurse)
+if ($installedBinaries.Count -ne 1 -or $installedNotices.Count -ne 1) {
+    throw 'MSI did not install exactly one binary and one notices file'
+}
+
+$sourceBinaryHash = (Get-FileHash -LiteralPath $binaryPath -Algorithm SHA256).Hash
+$installedBinaryHash = (Get-FileHash -LiteralPath $installedBinaries[0].FullName -Algorithm SHA256).Hash
+if ($sourceBinaryHash -cne $installedBinaryHash) {
+    throw 'installed d2.exe does not match the release archive'
+}
+$sourceNoticesHash = (Get-FileHash -LiteralPath $noticesPath -Algorithm SHA256).Hash
+$installedNoticesHash = (Get-FileHash -LiteralPath $installedNotices[0].FullName -Algorithm SHA256).Hash
+if ($sourceNoticesHash -cne $installedNoticesHash) {
+    throw 'installed THIRD_PARTY_NOTICES.txt does not match the release archive'
+}
+
+$versionOutput = (& $installedBinaries[0].FullName --version 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or $versionOutput -cne $Version) {
+    throw "installed d2.exe reported an unexpected version: $versionOutput"
+}
+
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+$outputPath = Join-Path $OutputDirectory "d2-$Version-windows-amd64.msi"
+Copy-Item -LiteralPath $msiPath -Destination $outputPath -Force
+
+$outputHash = (Get-FileHash -LiteralPath $outputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+Write-Host "Built $outputPath"
+Write-Host "SHA-256: $outputHash"

--- a/ci/release/windows/build.ps1
+++ b/ci/release/windows/build.ps1
@@ -25,7 +25,7 @@ function Get-MsiProperty {
 
     $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = '$Name'"
     $view = $Database.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $Database, @($query))
-    $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null)
+    $null = $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null)
     $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
     if ($null -eq $record) {
         throw "MSI property $Name is missing"

--- a/ci/release/windows/build.ps1
+++ b/ci/release/windows/build.ps1
@@ -97,9 +97,10 @@ Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'd2.ico') -Destination $wixDirec
 Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $wixDirectory 'd2.exe')
 Copy-Item -LiteralPath $noticesPath -Destination (Join-Path $wixDirectory 'THIRD_PARTY_NOTICES.txt')
 
+$msiVersion = $Version.Substring(1).Split('-')[0]
 Push-Location $wixDirectory
 try {
-    & wix build -arch x64 -d "D2Version=$Version" ./d2.wxs
+    & wix build -arch x64 -d "D2Version=$msiVersion" ./d2.wxs
     if ($LASTEXITCODE -ne 0) {
         throw "wix exited with status $LASTEXITCODE"
     }
@@ -135,10 +136,8 @@ foreach ($property in $expectedProperties.Keys) {
 }
 
 $productVersion = Get-MsiProperty -Database $database -Name ProductVersion
-$versionWithoutPrefix = $Version.Substring(1)
-$versionCore = $versionWithoutPrefix.Split('-')[0]
-if ($productVersion -notin @($Version, $versionWithoutPrefix, $versionCore)) {
-    throw "MSI ProductVersion is '$productVersion', expected $Version"
+if ($productVersion -cne $msiVersion) {
+    throw "MSI ProductVersion is '$productVersion', expected $msiVersion"
 }
 
 $installArguments = "/a `"$msiPath`" /qn TARGETDIR=`"$extractDirectory`""

--- a/ci/release/windows/build.ps1
+++ b/ci/release/windows/build.ps1
@@ -52,8 +52,18 @@ if ($LASTEXITCODE -ne 0 -or $archiveEntries.Count -eq 0) {
     throw 'unable to list release archive'
 }
 $archiveRoot = "d2-$Version/"
+$metadataRoot = "._d2-$Version"
 foreach ($entry in $archiveEntries) {
-    if (-not $entry.StartsWith($archiveRoot, [System.StringComparison]::Ordinal)) {
+    $normalizedEntry = $entry.Replace('\', '/')
+    if ($normalizedEntry.StartsWith('/', [System.StringComparison]::Ordinal) -or
+        $normalizedEntry -match '^[A-Za-z]:' -or
+        $normalizedEntry -match '(^|/)\.\.(/|$)') {
+        throw "release archive contains an unsafe path: $entry"
+    }
+    $isReleasePath = $normalizedEntry.StartsWith($archiveRoot, [System.StringComparison]::Ordinal)
+    $isMetadataPath = $normalizedEntry -eq $metadataRoot -or
+        $normalizedEntry.StartsWith("$metadataRoot/", [System.StringComparison]::Ordinal)
+    if (-not $isReleasePath -and -not $isMetadataPath) {
         throw "release archive contains a path outside ${archiveRoot}: $entry"
     }
 }


### PR DESCRIPTION
## Summary

- build and inspect the Windows MSI on a pinned GitHub-hosted `windows-2022` runner
- pin the release, tag commit, six archives, Windows asset ID, and GitHub SHA-256 before packaging
- fail closed on retries, tag/archive drift, existing installer bytes, stale local MSIs, and premature publication
- remove the legacy AWS Windows builder provisioning and SSH path

## Validation

- `actionlint .github/workflows/windows-msi.yml`
- YAML parse and embedded Bash syntax checks
- `sh -n` for changed shell scripts
- `git diff --check`
- live read-only validation against the published v0.7.1 release fixture
- independent release-integrity and retry-path review

The PR workflow performs the actual WiX/Windows continuity build without modifying the published v0.7.1 release.