### PR TITLE
docs: document native Go speedups

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -8,6 +8,10 @@
 - d2sketch: replace the embedded Rough.js runtime with the native Go rough-go port without changing sketch output
 - d2elk: replace the embedded JavaScript runtime with the native Go elk-go port, preserving layouts apart from sub-pixel floating-point rounding
 - d2latex: replace the embedded MathJax JavaScript runtime with the native Go mathjax-go port without changing rendered formulas
+- performance: native Go engine migrations substantially reduce median end-to-end D2-to-SVG conversion time in Apple M4 benchmarks:
+  - Dagre is 7–9× faster
+  - ELK is 40–53× faster
+  - LaTeX is 21.6× faster on a four-formula diagram
 - d2ascii:
   - sql_table and uml class shapes are supported [#2623](https://github.com/d2lang/d2/pull/2623)
   - newlines are handled [#2626](https://github.com/d2lang/d2/pull/2626)


### PR DESCRIPTION
## Summary

- document the native Go migration performance gains in the next release changelog
- record median end-to-end native CLI speedups of 7–9× for Dagre, 40–53× for ELK, and 21.6× for a four-formula LaTeX diagram
- qualify the results as Apple M4 benchmarks rather than hardware-independent guarantees

## Benchmark results

| Path | Workload | JavaScript + Goja | Pure Go | End-to-end speedup | D2 conversion speedup |
|---|---|---:|---:|---:|---:|
| Dagre | 50 shapes, 108 edges | 330.9 ms | 36.8 ms | 9.0× | 13.6× |
| Dagre | 151-shape nested graph | 380.3 ms | 54.7 ms | 7.0× | 9.2× |
| ELK | 50 shapes, 108 edges | 1,239.5 ms | 31.1 ms | 39.8× | 68.7× |
| ELK | 151-shape nested graph | 2,574.1 ms | 48.4 ms | 53.2× | 74.1× |
| LaTeX | four formulas, measured and rendered | 662.4 ms | 30.7 ms | 21.6× | 38.6× |

## Methodology

- Apple M4, macOS 26.5.2, Go 1.25.0, darwin/arm64
- exact first-parent versus merge-commit boundary for each native Go migration
- five warmups followed by 31 alternating before/after samples
- fresh D2 process per sample, SVG written to stdout and discarded; builds excluded
- every compared before/after SVG was byte-for-byte identical
- results cover the native CLI; browser/WASM performance was not measured

“End-to-end” measures process spawn through SVG completion. “D2 conversion” uses D2's internal conversion timer and excludes process startup.

## Checks

- `git diff --check`
