### PR TITLE
compiler: anchor glob suffix matches

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -36,6 +36,7 @@
 #### Bugfixes ⛑️
 
 - d2svg: render one-stop gradients with finite SVG offsets
+- compiler: make suffix globs match only names with the requested suffix
 - exports: pptx follows standards more closely, addressing warnings from some Powerpoint software [#2645](https://github.com/d2lang/d2/pull/2645)
 - d2sequence: fix edge case of invalid sequence diagrams [#2660](https://github.com/d2lang/d2/pull/2660)
 - d2svg: Text may overflow legend bounds when monospace font is used [#2674](https://github.com/d2lang/d2/pull/2674)

--- a/d2ir/pattern.go
+++ b/d2ir/pattern.go
@@ -168,15 +168,24 @@ func matchPattern(s string, pattern []string) bool {
 
 	for i := 0; i < len(pattern); i++ {
 		if pattern[i] == "*" {
-			// * so match next.
-			if i != len(pattern)-1 {
-				j := strings.Index(strings.ToLower(s), strings.ToLower(pattern[i+1]))
-				if j == -1 {
-					return false
-				}
-				s = s[j+len(pattern[i+1]):]
-				i++
+			if i == len(pattern)-1 {
+				return true
 			}
+
+			next := strings.ToLower(pattern[i+1])
+			lowerS := strings.ToLower(s)
+			if i+1 == len(pattern)-1 {
+				return strings.HasSuffix(lowerS, next)
+			}
+
+			// Match the earliest occurrence so the remaining wildcards have the
+			// largest possible suffix to search.
+			j := strings.Index(lowerS, next)
+			if j == -1 {
+				return false
+			}
+			s = s[j+len(pattern[i+1]):]
+			i++
 		} else {
 			if !strings.HasPrefix(strings.ToLower(s), strings.ToLower(pattern[i])) {
 				return false
@@ -184,5 +193,5 @@ func matchPattern(s string, pattern []string) bool {
 			s = s[len(pattern[i]):]
 		}
 	}
-	return true
+	return s == ""
 }

--- a/d2ir/pattern_internal_test.go
+++ b/d2ir/pattern_internal_test.go
@@ -1,0 +1,31 @@
+package d2ir
+
+import "testing"
+
+func TestMatchPatternAnchors(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		pattern []string
+		want    bool
+	}{
+		{name: "exact", text: "animal", pattern: []string{"animal"}, want: true},
+		{name: "exact rejects trailing", text: "animals", pattern: []string{"animal"}, want: false},
+		{name: "prefix", text: "animal", pattern: []string{"an", "*"}, want: true},
+		{name: "suffix", text: "animal", pattern: []string{"*", "l"}, want: true},
+		{name: "repeated suffix", text: "lal", pattern: []string{"*", "l"}, want: true},
+		{name: "suffix rejects trailing", text: "jingle", pattern: []string{"*", "l"}, want: false},
+		{name: "prefix suffix repeated", text: "torr", pattern: []string{"t", "*", "r"}, want: true},
+		{name: "prefix suffix rejects trailing", text: "tinkerbell", pattern: []string{"t", "*", "r"}, want: false},
+		{name: "multiple wildcards", text: "abcbxc", pattern: []string{"a", "*", "b", "*", "c"}, want: true},
+		{name: "case insensitive suffix", text: "Animal", pattern: []string{"*", "AL"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchPattern(tt.text, tt.pattern); got != tt.want {
+				t.Fatalf("matchPattern(%q, %q) = %v, want %v", tt.text, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}

--- a/d2ir/pattern_test.go
+++ b/d2ir/pattern_test.go
@@ -64,11 +64,13 @@ Donkey Kong
 			run: func(t testing.TB) {
 				m, err := compile(t, `animal: meow
 jingle: loud
+lal: repeated
 *l: globbed`)
 				assert.Success(t, err)
-				assertQuery(t, m, 2, 0, nil, "")
+				assertQuery(t, m, 3, 0, nil, "")
 				assertQuery(t, m, 0, 0, "globbed", "animal")
-				assertQuery(t, m, 0, 0, "globbed", "jingle")
+				assertQuery(t, m, 0, 0, "loud", "jingle")
+				assertQuery(t, m, 0, 0, "globbed", "lal")
 			},
 		},
 		{

--- a/testdata/d2ir/TestCompile/patterns/suffix.exp.json
+++ b/testdata/d2ir/TestCompile/patterns/suffix.exp.json
@@ -12,7 +12,7 @@
       },
       "primary": {
         "value": {
-          "range": "TestCompile/patterns/suffix.d2,2:4:30-2:11:37",
+          "range": "TestCompile/patterns/suffix.d2,3:4:44-3:11:51",
           "value": [
             {
               "string": "globbed",
@@ -99,11 +99,11 @@
       },
       "primary": {
         "value": {
-          "range": "TestCompile/patterns/suffix.d2,2:4:30-2:11:37",
+          "range": "TestCompile/patterns/suffix.d2,1:8:21-1:12:25",
           "value": [
             {
-              "string": "globbed",
-              "raw_string": "globbed"
+              "string": "loud",
+              "raw_string": "loud"
             }
           ]
         }
@@ -163,6 +163,93 @@
                     {
                       "string": "loud",
                       "raw_string": "loud"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "due_to_glob": false,
+          "due_to_lazy_glob": false
+        }
+      ]
+    },
+    {
+      "name": {
+        "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+        "value": [
+          {
+            "string": "lal",
+            "raw_string": "lal"
+          }
+        ]
+      },
+      "primary": {
+        "value": {
+          "range": "TestCompile/patterns/suffix.d2,3:4:44-3:11:51",
+          "value": [
+            {
+              "string": "globbed",
+              "raw_string": "globbed"
+            }
+          ]
+        }
+      },
+      "references": [
+        {
+          "string": {
+            "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+            "value": [
+              {
+                "string": "lal",
+                "raw_string": "lal"
+              }
+            ]
+          },
+          "key_path": {
+            "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+            "path": [
+              {
+                "unquoted_string": {
+                  "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+                  "value": [
+                    {
+                      "string": "lal",
+                      "raw_string": "lal"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "context": {
+            "edge": null,
+            "key": {
+              "range": "TestCompile/patterns/suffix.d2,2:0:26-2:13:39",
+              "key": {
+                "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+                "path": [
+                  {
+                    "unquoted_string": {
+                      "range": "TestCompile/patterns/suffix.d2,2:0:26-2:3:29",
+                      "value": [
+                        {
+                          "string": "lal",
+                          "raw_string": "lal"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "primary": {},
+              "value": {
+                "unquoted_string": {
+                  "range": "TestCompile/patterns/suffix.d2,2:5:31-2:13:39",
+                  "value": [
+                    {
+                      "string": "repeated",
+                      "raw_string": "repeated"
                     }
                   ]
                 }


### PR DESCRIPTION
## What changed

Require glob patterns that end in a literal segment to consume the entire candidate name.

## Why

Suffix and prefix/suffix globs were effectively prefix matches because `matchPattern` returned success after matching the final literal without checking for trailing characters. For example, `*l` changed both `animal` and `jingle`, even though only `animal` ends in `l`.

Patterns that end in `*` retain their existing open-ended behavior.

## Validation

- `go test ./d2ir ./d2compiler -count=1`
- `go test -race ./d2ir -count=1`
- `go test ./e2etests -run '^TestE2E$' -count=1 -parallel=1`
- `git diff --check`
