### PR TITLE
d2svg: preserve links on rich connection labels

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -39,6 +39,7 @@
 
 - d2svg: render one-stop gradients with finite SVG offsets
 - compiler: make suffix globs match only names with the requested suffix
+- d2svg: preserve connection links on LaTeX, Markdown, and code labels
 - exports: pptx follows standards more closely, addressing warnings from some Powerpoint software [#2645](https://github.com/d2lang/d2/pull/2645)
 - d2sequence: fix edge case of invalid sequence diagrams [#2660](https://github.com/d2lang/d2/pull/2660)
 - d2svg: Text may overflow legend bounds when monospace font is used [#2674](https://github.com/d2lang/d2/pull/2674)

--- a/d2renderers/d2svg/connection_link_test.go
+++ b/d2renderers/d2svg/connection_link_test.go
@@ -1,0 +1,60 @@
+package d2svg_test
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2layouts/d2dagrelayout"
+	"github.com/d2lang/d2/d2lib"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/textmeasure"
+	"github.com/d2lang/util-go/assert"
+)
+
+func TestRichConnectionLabelsPreserveLinks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		language string
+		label    string
+	}{
+		{name: "latex", language: "latex", label: `x^2`},
+		{name: "markdown", language: "md", label: `**linked**`},
+		{name: "code", language: "go", label: `fmt.Println("linked")`},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			link := `https://example.com/?a=1&b=2`
+			script := fmt.Sprintf("a -> b: |%s\n  %s\n| {\n  link: %s\n}", tc.language, tc.label, link)
+			ruler, err := textmeasure.NewRuler()
+			assert.Success(t, err)
+
+			layoutResolver := func(string) (d2graph.LayoutGraph, error) {
+				return d2dagrelayout.DefaultLayout, nil
+			}
+			diagram, _, err := d2lib.Compile(log.WithTB(context.Background(), t), script, &d2lib.CompileOptions{
+				Ruler:          ruler,
+				LayoutResolver: layoutResolver,
+			}, nil)
+			assert.Success(t, err)
+
+			out, err := d2svg.Render(diagram, nil)
+			assert.Success(t, err)
+			var parsed any
+			assert.Success(t, xml.Unmarshal(out, &parsed))
+			svg := string(out)
+			want := `<a href="https://example.com/?a=1&amp;b=2" xlink:href="https://example.com/?a=1&amp;b=2">`
+			if !strings.Contains(svg, want) {
+				t.Fatalf("linked %s label missing anchor %q", tc.name, want)
+			}
+		})
+	}
+}

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -1157,6 +1157,10 @@ func drawConnection(writer io.Writer, diagramHash string, connection d2target.Co
 	}
 
 	if connection.Label != "" {
+		richLabelLink := connection.Link != "" && connection.Language != ""
+		if richLabelLink {
+			fmt.Fprintf(writer, `<a href="%s" xlink:href="%[1]s">`, svg.EscapeText(connection.Link))
+		}
 		if connection.Language == "latex" {
 			render, err := d2latex.Render(connection.Label)
 			if err != nil {
@@ -1292,6 +1296,9 @@ func drawConnection(writer io.Writer, diagramHash string, connection d2target.Co
 			if connection.Link != "" {
 				fmt.Fprintf(writer, "</a>")
 			}
+		}
+		if richLabelLink {
+			fmt.Fprint(writer, "</a>")
 		}
 	}
 


### PR DESCRIPTION
## What changed

Wrap LaTeX, Markdown, and syntax-highlighted connection labels in the same escaped SVG link used by plain connection labels.

## Why

Connections support `link`, but the renderer only emitted an anchor in its plain-text label branch. Rich labels rendered successfully while silently dropping the URL.

The change keeps the existing plain-label SVG unchanged and makes only the rich label content clickable.

## Validation

- Added compile-to-SVG regressions for LaTeX, Markdown, and Go code labels, including an escaped query-string URL and XML parsing
- `go test ./d2renderers/d2svg -count=1`
- `go test -race ./d2renderers/d2svg -run '^TestRichConnectionLabelsPreserveLinks$' -count=1`
- `go test ./e2etests -run '^TestE2E$' -count=1 -parallel=1`
- `git diff --check`
