### PR TITLE
fix PPTX XML escaping

### DIFF
--- a/lib/pptx/pptx.go
+++ b/lib/pptx/pptx.go
@@ -13,9 +13,11 @@ import (
 	"archive/zip"
 	"bytes"
 	_ "embed"
+	"encoding/xml"
 	"fmt"
 	"image/png"
 	"os"
+	"strings"
 	"text/template"
 )
 
@@ -511,9 +513,18 @@ func addFileFromTemplate(zipFile *zip.Writer, filePath, templateContent string, 
 		return err
 	}
 
-	tmpl, err := template.New(filePath).Parse(templateContent)
+	tmpl, err := template.New(filePath).Funcs(template.FuncMap{
+		"xmlAttr": escapeXML,
+		"xmlText": escapeXML,
+	}).Parse(templateContent)
 	if err != nil {
 		return err
 	}
 	return tmpl.Execute(w, templateData)
+}
+
+func escapeXML(value any) (string, error) {
+	var escaped strings.Builder
+	err := xml.EscapeText(&escaped, []byte(fmt.Sprint(value)))
+	return escaped.String(), err
 }

--- a/lib/pptx/pptx_test.go
+++ b/lib/pptx/pptx_test.go
@@ -1,0 +1,191 @@
+package pptx
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPresentationEscapesXML(t *testing.T) {
+	t.Parallel()
+
+	special := `A & B < C > D "quoted" 'apostrophe'`
+	externalURL := `https://example.com/search?q=a%20b&next=%3Ctag%3E&quote=%22double%22&single=%27apostrophe%27`
+	p := NewPresentation(special, special, special, special, "1.2.3", true)
+
+	var pngContent bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.Black)
+	if err := png.Encode(&pngContent, img); err != nil {
+		t.Fatal(err)
+	}
+
+	slide, err := p.AddSlide(pngContent.Bytes(), []BoardTitle{{
+		Name:        special,
+		BoardID:     special,
+		LinkToSlide: 1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slide.AddLink(&Link{
+		ExternalUrl: externalURL,
+		Tooltip:     special,
+		Width:       1,
+		Height:      1,
+	})
+	slide.AddLink(&Link{
+		SlideIndex: 1,
+		Tooltip:    special,
+		Width:      1,
+		Height:     1,
+	})
+
+	path := filepath.Join(t.TempDir(), "A & B < C > D.pptx")
+	if err := p.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		if !strings.HasSuffix(file.Name, ".xml") && !strings.HasSuffix(file.Name, ".rels") {
+			continue
+		}
+		if _, err := parseXMLPart(file); err != nil {
+			t.Errorf("invalid XML in %s: %v", file.Name, err)
+		}
+	}
+
+	core := mustParseXMLPart(t, reader.File, "docProps/core.xml")
+	for _, element := range []string{"title", "subject", "creator", "description", "lastModifiedBy"} {
+		if !slices.Contains(core.text[element], special) {
+			t.Errorf("%s does not round-trip: %q", element, core.text[element])
+		}
+	}
+
+	app := mustParseXMLPart(t, reader.File, "docProps/app.xml")
+	if !slices.Contains(app.text["lpstr"], special) {
+		t.Errorf("slide title does not round-trip: %q", app.text["lpstr"])
+	}
+
+	slideXML := mustParseXMLPart(t, reader.File, "ppt/slides/slide1.xml")
+	if !slices.Contains(slideXML.text["t"], special) {
+		t.Errorf("board title does not round-trip: %q", slideXML.text["t"])
+	}
+	for _, attribute := range []string{"name", "descr", "tooltip"} {
+		if !slices.Contains(slideXML.attrs[attribute], special) {
+			t.Errorf("%s attribute does not round-trip: %q", attribute, slideXML.attrs[attribute])
+		}
+	}
+	if !slices.Contains(slideXML.attrs["action"], "ppaction://hlinksldjump") {
+		t.Errorf("internal slide action changed: %q", slideXML.attrs["action"])
+	}
+
+	rels := mustParseXMLPart(t, reader.File, "ppt/slides/_rels/slide1.xml.rels")
+	if !slices.Contains(rels.attrs["Target"], externalURL) {
+		t.Errorf("external URL does not round-trip: %q", rels.attrs["Target"])
+	}
+}
+
+type parsedXML struct {
+	text  map[string][]string
+	attrs map[string][]string
+}
+
+func TestParseXMLRejectsCharacterDataBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseXML(strings.NewReader(`&lt;?xml version="1.0"?> <root />`))
+	if err == nil {
+		t.Fatal("expected escaped XML declaration to be rejected")
+	}
+}
+
+func parseXMLPart(file *zip.File) (*parsedXML, error) {
+	r, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return parseXML(r)
+}
+
+func parseXML(r io.Reader) (*parsedXML, error) {
+	parsed := &parsedXML{
+		text:  make(map[string][]string),
+		attrs: make(map[string][]string),
+	}
+	decoder := xml.NewDecoder(r)
+	var elements []string
+	rootSeen := false
+	rootClosed := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			if !rootSeen || !rootClosed {
+				return nil, fmt.Errorf("missing or unclosed root element")
+			}
+			return parsed, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		switch token := token.(type) {
+		case xml.StartElement:
+			if rootClosed {
+				return nil, fmt.Errorf("multiple root elements")
+			}
+			rootSeen = true
+			elements = append(elements, token.Name.Local)
+			for _, attr := range token.Attr {
+				parsed.attrs[attr.Name.Local] = append(parsed.attrs[attr.Name.Local], attr.Value)
+			}
+		case xml.CharData:
+			if (!rootSeen || rootClosed) && strings.TrimSpace(string(token)) != "" {
+				return nil, fmt.Errorf("character data outside root element: %q", token)
+			}
+			if len(elements) > 0 {
+				value := strings.TrimSpace(string(token))
+				if value != "" {
+					name := elements[len(elements)-1]
+					parsed.text[name] = append(parsed.text[name], value)
+				}
+			}
+		case xml.EndElement:
+			elements = elements[:len(elements)-1]
+			if len(elements) == 0 {
+				rootClosed = true
+			}
+		}
+	}
+}
+
+func mustParseXMLPart(t *testing.T, files []*zip.File, name string) *parsedXML {
+	t.Helper()
+	for _, file := range files {
+		if file.Name != name {
+			continue
+		}
+		parsed, err := parseXMLPart(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsed
+	}
+	t.Fatalf("%s not found", name)
+	return nil
+}

--- a/lib/pptx/templates/app.xml
+++ b/lib/pptx/templates/app.xml
@@ -6,7 +6,7 @@
     <Application>D2</Application>
     <PresentationFormat>On-screen Show (16:9)</PresentationFormat>
     <Paragraphs>0</Paragraphs>
-    <Slides>{{.SlideCount}}</Slides>
+    <Slides>{{xmlText .SlideCount}}</Slides>
     <Notes>0</Notes>
     <HiddenSlides>0</HiddenSlides>
     <MMClips>0</MMClips>
@@ -29,17 +29,17 @@
                 <vt:lpstr>Slide Titles</vt:lpstr>
             </vt:variant>
             <vt:variant>
-                <vt:i4>{{.SlideCount}}</vt:i4>
+                <vt:i4>{{xmlText .SlideCount}}</vt:i4>
             </vt:variant>
         </vt:vector>
     </HeadingPairs>
     <TitlesOfParts>
-        <vt:vector size="{{.TitlesOfPartsCount}}" baseType="lpstr">
+        <vt:vector size="{{xmlAttr .TitlesOfPartsCount}}" baseType="lpstr">
             <vt:lpstr>Arial</vt:lpstr>
             <vt:lpstr>Calibri</vt:lpstr>
             <vt:lpstr>Office Theme</vt:lpstr>
             {{range .Titles}}
-            <vt:lpstr>{{.}}</vt:lpstr>
+            <vt:lpstr>{{xmlText .}}</vt:lpstr>
             {{end}}
         </vt:vector>
     </TitlesOfParts>
@@ -47,5 +47,5 @@
     <SharedDoc>false</SharedDoc>
     <HyperlinkBase></HyperlinkBase>
     <HyperlinksChanged>false</HyperlinksChanged>
-    <AppVersion>{{.D2Version}}</AppVersion>
+    <AppVersion>{{xmlText .D2Version}}</AppVersion>
 </Properties>

--- a/lib/pptx/templates/content_types.xml
+++ b/lib/pptx/templates/content_types.xml
@@ -55,7 +55,7 @@
         PartName="/ppt/slideMasters/slideMaster1.xml"
         ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml" />
         {{range .FileNames}}
-        <Override PartName="/ppt/slides/{{.}}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml" />
+        <Override PartName="/ppt/slides/{{xmlAttr .}}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml" />
         {{end}} 
         <Override PartName="/ppt/tableStyles.xml"
         ContentType="application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml" />

--- a/lib/pptx/templates/core.xml
+++ b/lib/pptx/templates/core.xml
@@ -4,12 +4,12 @@
     xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
     xmlns:dcmitype="http://purl.org/dc/dcmitype/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <dc:title>{{.Title}}</dc:title>
-    <dc:subject>{{.Subject}}</dc:subject>
-    <dc:creator>{{.Creator}}</dc:creator>
+    <dc:title>{{xmlText .Title}}</dc:title>
+    <dc:subject>{{xmlText .Subject}}</dc:subject>
+    <dc:creator>{{xmlText .Creator}}</dc:creator>
     <cp:keywords />
-    <dc:description>{{.Description}}</dc:description>
-    <cp:lastModifiedBy>{{.LastModifiedBy}}</cp:lastModifiedBy>
+    <dc:description>{{xmlText .Description}}</dc:description>
+    <cp:lastModifiedBy>{{xmlText .LastModifiedBy}}</cp:lastModifiedBy>
     <cp:revision>1</cp:revision>
     <cp:category />
 </cp:coreProperties>

--- a/lib/pptx/templates/presentation.xml
+++ b/lib/pptx/templates/presentation.xml
@@ -8,10 +8,10 @@
     </p:sldMasterIdLst>
     <p:sldIdLst>
         {{range .Slides}}
-        <p:sldId id="{{.ID}}" r:id="{{.RelationshipID}}" />
+        <p:sldId id="{{xmlAttr .ID}}" r:id="{{xmlAttr .RelationshipID}}" />
         {{end}}
     </p:sldIdLst>
-    <p:sldSz cx="{{.SlideWidth}}" cy="{{.SlideHeight}}" type="screen16x9" />
+    <p:sldSz cx="{{xmlAttr .SlideWidth}}" cy="{{xmlAttr .SlideHeight}}" type="screen16x9" />
     <p:notesSz cx="6858000" cy="9144000" />
     <p:defaultTextStyle>
         <a:defPPr>

--- a/lib/pptx/templates/rels_presentation.xml
+++ b/lib/pptx/templates/rels_presentation.xml
@@ -16,6 +16,6 @@
     Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster"
     Target="slideMasters/slideMaster1.xml" />
     {{range .Slides}}
-    <Relationship Id="{{.RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/{{.FileName}}.xml" />
+    <Relationship Id="{{xmlAttr .RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/{{xmlAttr .FileName}}.xml" />
     {{end}}
 </Relationships>

--- a/lib/pptx/templates/slide.xml
+++ b/lib/pptx/templates/slide.xml
@@ -19,22 +19,22 @@
             </p:grpSpPr>
             <p:pic>
                 <p:nvPicPr>
-                    <p:cNvPr id="2" name="{{.Description}}" descr="{{.Description}}" />
+                    <p:cNvPr id="2" name="{{xmlAttr .Description}}" descr="{{xmlAttr .Description}}" />
                     <p:cNvPicPr>
                         <a:picLocks noChangeAspect="1" />
                     </p:cNvPicPr>
                     <p:nvPr />
                 </p:nvPicPr>
                 <p:blipFill>
-                    <a:blip r:embed="{{.ImageID}}" />
+                    <a:blip r:embed="{{xmlAttr .ImageID}}" />
                     <a:stretch>
                         <a:fillRect />
                     </a:stretch>
                 </p:blipFill>
                 <p:spPr>
                     <a:xfrm>
-                        <a:off x="{{.ImageLeft}}" y="{{.ImageTop}}" />
-                        <a:ext cx="{{.ImageWidth}}" cy="{{.ImageHeight}}" />
+                        <a:off x="{{xmlAttr .ImageLeft}}" y="{{xmlAttr .ImageTop}}" />
+                        <a:ext cx="{{xmlAttr .ImageWidth}}" cy="{{xmlAttr .ImageHeight}}" />
                     </a:xfrm>
                     <a:prstGeom prst="rect">
                         <a:avLst />
@@ -44,14 +44,14 @@
             {{if gt .HeaderHeight 0}}
             <p:sp>
                 <p:nvSpPr>
-                    <p:cNvPr id="95" name="{{.Description}}" />
+                    <p:cNvPr id="95" name="{{xmlAttr .Description}}" />
                     <p:cNvSpPr txBox="1" />
                     <p:nvPr />
                 </p:nvSpPr>
                 <p:spPr>
                     <a:xfrm>
                         <a:off x="4001" y="6239" />
-                        <a:ext cx="9135998" cy="{{.HeaderHeight}}" />
+                        <a:ext cx="9135998" cy="{{xmlAttr .HeaderHeight}}" />
                     </a:xfrm>
                     <a:prstGeom prst="rect">
                         <a:avLst />
@@ -80,17 +80,17 @@
                         {{range .TitlePrefix}}
                         <a:r>
                             <a:rPr>
-                                <a:hlinkClick r:id="{{.RelationshipID}}" invalidUrl=""
+                                <a:hlinkClick r:id="{{xmlAttr .RelationshipID}}" invalidUrl=""
                                     action="ppaction://hlinksldjump" tgtFrame="" tooltip=""
                                     history="1" highlightClick="0" endSnd="0" />
                             </a:rPr>
-                            <a:t>{{.Name}}</a:t>
+                            <a:t>{{xmlText .Name}}</a:t>
                         </a:r>
                         <a:r><a:t>  /  </a:t></a:r>
                         {{end}}
                         <a:r>
                             <a:rPr b="1" />
-                            <a:t>{{.Title}}</a:t>
+                            <a:t>{{xmlText .Title}}</a:t>
                         </a:r>
                     </a:p>
                 </p:txBody>
@@ -99,8 +99,8 @@
             {{range .Links}}
             <p:sp>
                 <p:nvSpPr>
-                    <p:cNvPr id="{{.ID}}" name="{{.Name}}">
-                        <a:hlinkClick r:id="{{.RelationshipID}}" action="{{.Action}}" tooltip="{{.Name}}" history="1" invalidUrl=""
+                    <p:cNvPr id="{{xmlAttr .ID}}" name="{{xmlAttr .Name}}">
+                        <a:hlinkClick r:id="{{xmlAttr .RelationshipID}}" action="{{xmlAttr .Action}}" tooltip="{{xmlAttr .Name}}" history="1" invalidUrl=""
                             tgtFrame="" highlightClick="0" endSnd="0" />
                     </p:cNvPr>
                     <p:cNvSpPr />
@@ -108,8 +108,8 @@
                 </p:nvSpPr>
                 <p:spPr>
                     <a:xfrm>
-                        <a:off x="{{.Left}}" y="{{.Top}}" />
-                        <a:ext cx="{{.Width}}" cy="{{.Height}}" />
+                        <a:off x="{{xmlAttr .Left}}" y="{{xmlAttr .Top}}" />
+                        <a:ext cx="{{xmlAttr .Width}}" cy="{{xmlAttr .Height}}" />
                     </a:xfrm>
                     <a:prstGeom prst="rect">
                         <a:avLst />

--- a/lib/pptx/templates/slide.xml.rels
+++ b/lib/pptx/templates/slide.xml.rels
@@ -3,14 +3,14 @@
     <Relationship Id="rId1"
         Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"
         Target="../slideLayouts/slideLayout7.xml" />
-    <Relationship Id="{{.RelationshipID}}"
+    <Relationship Id="{{xmlAttr .RelationshipID}}"
         Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
-        Target="../media/{{.FileName}}.png" />
+        Target="../media/{{xmlAttr .FileName}}.png" />
     {{range .Links}}
     {{if .ExternalUrl}}
-    <Relationship Id="{{.RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{{.ExternalUrl}}" TargetMode="External" />
+    <Relationship Id="{{xmlAttr .RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{{xmlAttr .ExternalUrl}}" TargetMode="External" />
     {{else}}
-    <Relationship Id="{{.RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slide{{.SlideIndex}}.xml" />
+    <Relationship Id="{{xmlAttr .RelationshipID}}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slide{{xmlAttr .SlideIndex}}.xml" />
     {{end}}
     {{end}}
 </Relationships>


### PR DESCRIPTION
## Summary

- render generated OOXML with context-aware escaping
- preserve PowerPoint's internal `ppaction://` slide-link action
- cover metadata, board titles/descriptions, tooltips, and external relationship URLs
- parse every XML and relationship member in the generated PPTX during regression testing

## Root cause

PPTX XML files were rendered with `text/template`, so user-controlled text and attribute values were inserted verbatim. Characters such as `&`, `<`, and quotes could therefore produce malformed XML even though export reported success.

## Impact

PPTX exports now remain valid when output metadata, board names, tooltips, or external URLs contain XML-sensitive characters. External URLs with query parameters round-trip unchanged.

## Validation

- `go test ./lib/pptx -count=1`
- `go test -race ./lib/pptx -count=1`
- `go test ./lib/... -count=1`
- `go vet ./lib/pptx`
- `git diff --check`
- `xmllint --noout` on every generated `.xml` and `.rels` member
- original malformed-XML repro now parses successfully

`go test ./... -count=1` passed all PPTX and main e2e coverage, but the existing `e2etests-cli` GIF cases failed with `gif: must provide at least one image`; those same two cases also fail when rerun in isolation.
