### PR TITLE
d2lib: preserve theme override precedence

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -41,6 +41,7 @@
 - d2svg: render one-stop gradients with finite SVG offsets
 - compiler: make suffix globs match only names with the requested suffix
 - d2svg: preserve connection links on LaTeX, Markdown, and code labels
+- d2lib: preserve caller-supplied light and dark theme overrides over source configuration
 - exports: pptx follows standards more closely, addressing warnings from some Powerpoint software [#2645](https://github.com/d2lang/d2/pull/2645)
 - d2sequence: fix edge case of invalid sequence diagrams [#2660](https://github.com/d2lang/d2/pull/2660)
 - d2svg: Text may overflow legend bounds when monospace font is used [#2674](https://github.com/d2lang/d2/pull/2674)

--- a/d2lib/config_test.go
+++ b/d2lib/config_test.go
@@ -1,0 +1,48 @@
+package d2lib
+
+import (
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestApplyConfigsThemeOverridePrecedence(t *testing.T) {
+	t.Parallel()
+
+	configLight := "#abcdef"
+	configDark := "#fedcba"
+	callerLight := "#112233"
+	callerDark := "#332211"
+	config := &d2target.Config{
+		ThemeOverrides:     &d2target.ThemeOverrides{B1: &configLight},
+		DarkThemeOverrides: &d2target.ThemeOverrides{B1: &configDark},
+	}
+
+	t.Run("caller options win", func(t *testing.T) {
+		renderOpts := &d2svg.RenderOpts{
+			ThemeOverrides:     &d2target.ThemeOverrides{B1: &callerLight},
+			DarkThemeOverrides: &d2target.ThemeOverrides{B1: &callerDark},
+		}
+		applyConfigs(config, &CompileOptions{}, renderOpts)
+
+		if got := *renderOpts.ThemeOverrides.B1; got != callerLight {
+			t.Fatalf("light theme override = %q, want caller value %q", got, callerLight)
+		}
+		if got := *renderOpts.DarkThemeOverrides.B1; got != callerDark {
+			t.Fatalf("dark theme override = %q, want caller value %q", got, callerDark)
+		}
+	})
+
+	t.Run("config fills absent options", func(t *testing.T) {
+		renderOpts := &d2svg.RenderOpts{}
+		applyConfigs(config, &CompileOptions{}, renderOpts)
+
+		if got := *renderOpts.ThemeOverrides.B1; got != configLight {
+			t.Fatalf("light theme override = %q, want config value %q", got, configLight)
+		}
+		if got := *renderOpts.DarkThemeOverrides.B1; got != configDark {
+			t.Fatalf("dark theme override = %q, want config value %q", got, configDark)
+		}
+	})
+}

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -240,8 +240,12 @@ func applyConfigs(config *d2target.Config, compileOpts *CompileOptions, renderOp
 	if renderOpts.Center == nil {
 		renderOpts.Center = config.Center
 	}
-	renderOpts.ThemeOverrides = config.ThemeOverrides
-	renderOpts.DarkThemeOverrides = config.DarkThemeOverrides
+	if renderOpts.ThemeOverrides == nil {
+		renderOpts.ThemeOverrides = config.ThemeOverrides
+	}
+	if renderOpts.DarkThemeOverrides == nil {
+		renderOpts.DarkThemeOverrides = config.DarkThemeOverrides
+	}
 }
 
 func applyDefaults(compileOpts *CompileOptions, renderOpts *d2svg.RenderOpts) {


### PR DESCRIPTION
## What changed

Apply source-defined light and dark theme overrides only when the caller did not already provide the corresponding render option.

## Why

`applyConfigs` documents that caller-supplied options take precedence and follows that rule for layout, theme IDs, sketch, padding, and centering. Theme override objects were the exception: they were assigned unconditionally, so source configuration silently replaced public Go API options.

## Validation

- Added focused tests proving caller precedence and config fallback for both light and dark overrides
- `go test ./d2lib -count=1`
- `go test -race ./d2lib -run '^TestApplyConfigsThemeOverridePrecedence$' -count=1`
- `go test ./e2etests -run '^TestE2E$' -count=1 -parallel=1`
- `git diff --check`
