### PR TITLE
Remove unreachable code and stale WASM artifacts

### DIFF
--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -14,15 +14,12 @@ help() {
   fi
 
   cat <<EOF
-usage: $arg0 [-d|--dry-run] [--version vX.X.X] [--edge] [--method detect] [--prefix path]
+usage: $arg0 [-d|--dry-run] [--version vX.X.X] [--method detect] [--prefix path]
   [--tala latest] [--force] [--uninstall] [-x|--trace]
 
 install.sh automates the installation of D2 onto your system. It currently only supports
 the installation of standalone releases from GitHub and via Homebrew on macOS. See the
 docs for --detect below for more information
-
-If you pass --edge, it will clone the source, build a release and install from it.
---edge is incompatible with --tala and currently unimplemented.
 
 \$PREFIX in the docs below refers to the path set by --prefix. See docs on the --prefix
 flag below for the default.
@@ -37,19 +34,6 @@ Flags:
   Pass to have install.sh install the given version instead of the latest version.
   warn: The version may not be obeyed with package manager installations. Use
         --method=standalone to enforce the version.
-
---edge
-  Pass to build and install D2 from source. This will still use --method if set to detect
-  to install the release archive for your OS, whether it's apt, yum, brew or standalone
-  if an unsupported package manager is used.
-
-  To install from source like a dev would, use go install github.com/d2lang/d2@latest. There's
-  also ./ci/release/build.sh --install to build and install a proper standalone release
-  including manpages. The proper release will also ensure d2 --version shows the correct
-  version by embedding the commit hash into the binary.
-
-  note: currently unimplemented.
-  warn: incompatible with --tala as TALA is closed source.
 
 --method [detect | standalone | homebrew ]
   Pass to control the method by which to install. Right now we only support standalone
@@ -127,12 +111,6 @@ main() {
       tala)
         shift "$FLAGSHIFT"
         TALA=${FLAGARG:-latest}
-        ;;
-      edge)
-        flag_noarg && shift "$FLAGSHIFT"
-        EDGE=1
-        echoerr "$FLAGRAW is currently unimplemented"
-        return 1
         ;;
       method)
         flag_nonemptyarg && shift "$FLAGSHIFT"

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -55,7 +55,7 @@ func layoutCmd(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) error
 	} else if len(ms.Opts.Flags.Args()) == 2 {
 		return longLayoutHelp(ctx, ms, ps)
 	} else {
-		return pluginSubcommand(ctx, ms, ps)
+		return xmain.UsageErrorf("layout subcommand accepts at most one argument")
 	}
 }
 
@@ -141,20 +141,6 @@ The available options are: %s. For details on each option, run "d2 layout".
 
 For more information on setup, please visit https://github.com/d2lang/d2.`,
 		layout, strings.Join(names, ", "))
-}
-
-func pluginSubcommand(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) error {
-	layout := ms.Opts.Flags.Arg(1)
-	plugin, err := d2plugin.FindPlugin(ctx, ps, layout)
-	if err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return layoutNotFound(ctx, ps, layout)
-		}
-		return err
-	}
-
-	ms.Opts.Args = ms.Opts.Flags.Args()[2:]
-	return d2plugin.Serve(plugin)(ctx, ms)
 }
 
 func humanPath(fp string) string {

--- a/d2cli/help_test.go
+++ b/d2cli/help_test.go
@@ -1,0 +1,27 @@
+package d2cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/d2lang/util-go/xmain"
+	"github.com/d2lang/util-go/xos"
+)
+
+func TestLayoutCmdRejectsExtraArguments(t *testing.T) {
+	opts := xmain.NewOpts(xos.NewEnv(nil), []string{"layout", "dagre", "info"})
+	if err := opts.Flags.Parse(opts.Args); err != nil {
+		t.Fatal(err)
+	}
+
+	err := layoutCmd(context.Background(), &xmain.State{Opts: opts}, nil)
+	var usageErr xmain.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("layoutCmd() error = %v, want xmain.UsageError", err)
+	}
+	const want = "bad usage: layout subcommand accepts at most one argument"
+	if err.Error() != want {
+		t.Fatalf("layoutCmd() error = %q, want %q", err, want)
+	}
+}

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -52,7 +52,6 @@ type watcherOpts struct {
 	inputPath       string
 	outputPath      string
 	boardPath       string
-	pwd             string
 	bundle          bool
 	forceAppendix   bool
 	pw              png.Playwright

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -86,7 +86,6 @@ func compileIR(ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
 
 func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
 	ir = ir.Copy(nil).(*d2ir.Map)
-	// c.preprocessSeqDiagrams(ir)
 	c.compileMap(g.Root, ir)
 	c.setDefaultShapes(g)
 	if len(c.err.Errors) == 0 {
@@ -1375,130 +1374,6 @@ func init() {
 	FullToShortLanguageAliases = make(map[string]string, len(ShortToFullLanguageAliases))
 	for k, v := range ShortToFullLanguageAliases {
 		FullToShortLanguageAliases[v] = k
-	}
-}
-
-// Unused for now until shape: edge_group
-func (c *compiler) preprocessSeqDiagrams(m *d2ir.Map) {
-	for _, f := range m.Fields {
-		if f.Name.ScalarString() == "shape" && f.Name.IsUnquoted() && f.Primary_.Value.ScalarString() == d2target.ShapeSequenceDiagram {
-			c.preprocessEdgeGroup(m, m)
-			return
-		}
-		if f.Map() != nil {
-			c.preprocessSeqDiagrams(f.Map())
-		}
-	}
-}
-
-func (c *compiler) preprocessEdgeGroup(seqDiagram, m *d2ir.Map) {
-	// Any child of a sequence diagram can be either an actor, edge group or a span.
-	// 1. Actors are shapes without edges inside them defined at the top level scope of a
-	//    sequence diagram.
-	// 2. Spans are the children of actors. For our purposes we can ignore them.
-	// 3. Edge groups are defined as having at least one connection within them and also not
-	//    being connected to anything. All direct children of an edge group are either edge
-	//    groups or top level actors.
-
-	// Go through all the fields and hoist actors from edge groups while also processing
-	// the edge groups recursively.
-	for _, f := range m.Fields {
-		if isEdgeGroup(f) {
-			if f.Map() != nil {
-				c.preprocessEdgeGroup(seqDiagram, f.Map())
-			}
-		} else {
-			if m == seqDiagram {
-				// Ignore for root.
-				continue
-			}
-			hoistActor(seqDiagram, f)
-		}
-	}
-
-	// We need to adjust all edges recursively to point to actual actors instead.
-	for _, e := range m.Edges {
-		if isCrossEdgeGroupEdge(m, e) {
-			c.errorf(e.References[0].AST(), "illegal edge between edge groups")
-			continue
-		}
-
-		if m == seqDiagram {
-			// Root edges between actors directly do not require hoisting.
-			continue
-		}
-
-		srcParent := seqDiagram
-		for i, el := range e.ID.SrcPath {
-			f := srcParent.GetField(el)
-			if !isEdgeGroup(f) {
-				for j := 0; j < i+1; j++ {
-					e.ID.SrcPath = append([]d2ast.String{d2ast.FlatUnquotedString("_")}, e.ID.SrcPath...)
-					e.ID.DstPath = append([]d2ast.String{d2ast.FlatUnquotedString("_")}, e.ID.DstPath...)
-				}
-				break
-			}
-			srcParent = f.Map()
-		}
-	}
-}
-
-func hoistActor(seqDiagram *d2ir.Map, f *d2ir.Field) {
-	f2 := seqDiagram.GetField(f.Name)
-	if f2 == nil {
-		seqDiagram.Fields = append(seqDiagram.Fields, f.Copy(seqDiagram).(*d2ir.Field))
-	} else {
-		d2ir.OverlayField(f2, f)
-		d2ir.ParentMap(f).DeleteField(f.Name.ScalarString())
-	}
-}
-
-func isCrossEdgeGroupEdge(m *d2ir.Map, e *d2ir.Edge) bool {
-	srcParent := m
-	for _, el := range e.ID.SrcPath {
-		f := srcParent.GetField(el)
-		if f == nil {
-			// Hoisted already.
-			break
-		}
-		if isEdgeGroup(f) {
-			return true
-		}
-		srcParent = f.Map()
-	}
-
-	dstParent := m
-	for _, el := range e.ID.DstPath {
-		f := dstParent.GetField(el)
-		if f == nil {
-			// Hoisted already.
-			break
-		}
-		if isEdgeGroup(f) {
-			return true
-		}
-		dstParent = f.Map()
-	}
-
-	return false
-}
-
-func isEdgeGroup(n d2ir.Node) bool {
-	return n.Map().EdgeCountRecursive() > 0
-}
-
-func parentSeqDiagram(n d2ir.Node) *d2ir.Map {
-	for {
-		m := d2ir.ParentMap(n)
-		if m == nil {
-			return nil
-		}
-		for _, f := range m.Fields {
-			if f.Name.ScalarString() == "shape" && f.Name.IsUnquoted() && f.Primary_.Value.ScalarString() == d2target.ShapeSequenceDiagram {
-				return m
-			}
-		}
-		n = m
 	}
 }
 

--- a/d2js/js/.gitignore
+++ b/d2js/js/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .npm
 
 src/wasm-loader.browser.js
+/d2.wasm
 wasm/d2.wasm
 dist/
 

--- a/d2js/js/src/index.js
+++ b/d2js/js/src/index.js
@@ -37,10 +37,10 @@ export class D2 {
   async init() {
     this.worker = await createWorker();
 
-    const wasmExecContent = await loadFile("./wasm_exec.js");
+    const isNode = typeof window === "undefined";
+    const wasmExecContent = isNode ? await loadFile("./wasm_exec.js") : null;
     const wasmBinary = await loadFile("./d2.wasm");
 
-    const isNode = typeof window === "undefined";
     const messageHandler = this.setupMessageHandler();
 
     if (isNode) {
@@ -58,11 +58,6 @@ export class D2 {
       data: {
         wasm: wasmBinary,
         wasmExecContent: isNode ? wasmExecContent.toString() : null,
-        wasmExecUrl: isNode
-          ? null
-          : URL.createObjectURL(
-              new Blob([wasmExecContent], { type: "application/javascript" })
-            ),
       },
     });
 

--- a/d2js/js/src/platform.browser.js
+++ b/d2js/js/src/platform.browser.js
@@ -7,9 +7,6 @@ export async function loadFile(path) {
   if (path === "./d2.wasm") {
     return getWasmBinary();
   }
-  if (path === "./wasm_exec.js") {
-    return new TextEncoder().encode(wasmExecJs).buffer;
-  }
   return null;
 }
 

--- a/d2js/js/src/wasm-loader.node.js
+++ b/d2js/js/src/wasm-loader.node.js
@@ -1,8 +1,0 @@
-import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-export async function getWasmBinary() {
-  return readFile(resolve(__dirname, "./d2.wasm"));
-}

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -422,10 +422,6 @@ func (r *endpointResolver) resolve(edge *d2graph.Edge) (*d2graph.Object, *d2grap
 	return src, dst
 }
 
-func getEdgeEndpoints(g *d2graph.Graph, edge *d2graph.Edge) (*d2graph.Object, *d2graph.Object) {
-	return newEndpointResolver(g).resolve(edge)
-}
-
 type containerTopology struct {
 	container   *d2graph.Object
 	hasIncoming map[*d2graph.Object]bool
@@ -520,21 +516,6 @@ func (t *containerTopology) longestChainEndpoints() (*d2graph.Object, *d2graph.O
 
 func getLongestEdgeChainEndpoints(g *d2graph.Graph, container *d2graph.Object) (*d2graph.Object, *d2graph.Object) {
 	return newContainerTopology(g, container).longestChainEndpoints()
-}
-
-// getLongestEdgeChainHead finds the longest chain in a container and gets its head
-// If there are multiple chains of the same length, get the head closest to the center
-func getLongestEdgeChainHead(g *d2graph.Graph, container *d2graph.Object) *d2graph.Object {
-	head, _ := getLongestEdgeChainEndpoints(g, container)
-	return head
-}
-
-// getLongestEdgeChainTail gets the node at the end of the longest edge chain, because that will be the end of the container
-// and is what external connections should connect with.
-// If there are multiple of same length, get the one closest to the middle
-func getLongestEdgeChainTail(g *d2graph.Graph, container *d2graph.Object) *d2graph.Object {
-	_, tail := getLongestEdgeChainEndpoints(g, container)
-	return tail
 }
 
 func inContainer(obj, container *d2graph.Object) *d2graph.Object {
@@ -764,13 +745,6 @@ func shiftUp(g *d2graph.Graph, start, distance float64, isHorizontal bool) {
 			obj.TopLeft.Y -= distance
 		}
 	}
-}
-
-// shift down everything that is below start
-// shift all nodes that are reachable via an edge or being directly below a shifting node or expanding container
-// expand containers to wrap shifted nodes
-func shiftReachableDown(g *d2graph.Graph, obj *d2graph.Object, start, distance float64, isHorizontal, isMargin bool) map[*d2graph.Object]struct{} {
-	return shiftReachableDownIndexed(g, newCrossRankIndex(g), obj, start, distance, isHorizontal, isMargin)
 }
 
 type crossRankIndex struct {

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -3,8 +3,8 @@ package d2lib
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
-	"os"
 	"strings"
 
 	"github.com/d2lang/d2/d2ast"
@@ -12,7 +12,6 @@ import (
 	"github.com/d2lang/d2/d2exporter"
 	"github.com/d2lang/d2/d2graph"
 	"github.com/d2lang/d2/d2layouts"
-	"github.com/d2lang/d2/d2layouts/d2dagrelayout"
 	"github.com/d2lang/d2/d2parser"
 	"github.com/d2lang/d2/d2renderers/d2fonts"
 	"github.com/d2lang/d2/d2renderers/d2svg"
@@ -193,16 +192,13 @@ func compileBoard(ctx context.Context, g *d2graph.Graph, compileOpts *CompileOpt
 }
 
 func getLayout(opts *CompileOptions) (d2graph.LayoutGraph, error) {
-	if opts.Layout != nil {
-		return opts.LayoutResolver(*opts.Layout)
-	} else if os.Getenv("D2_LAYOUT") == "dagre" {
-		defaultLayout := func(ctx context.Context, g *d2graph.Graph) error {
-			return d2dagrelayout.Layout(ctx, g, nil)
-		}
-		return defaultLayout, nil
-	} else {
+	if opts.Layout == nil {
 		return nil, errors.New("no available layout")
 	}
+	if opts.LayoutResolver == nil {
+		return nil, fmt.Errorf("no layout resolver configured for layout engine %q", *opts.Layout)
+	}
+	return opts.LayoutResolver(*opts.Layout)
 }
 
 func getEdgeRouter(opts *CompileOptions) (d2graph.RouteEdges, error) {

--- a/d2lib/d2_test.go
+++ b/d2lib/d2_test.go
@@ -1,0 +1,30 @@
+package d2lib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/d2lang/d2/lib/textmeasure"
+)
+
+func TestGetLayoutDoesNotUseEnvironmentFallback(t *testing.T) {
+	t.Setenv("D2_LAYOUT", "dagre")
+
+	_, err := getLayout(&CompileOptions{})
+	if err == nil || err.Error() != "no available layout" {
+		t.Fatalf("getLayout() error = %v, want no available layout", err)
+	}
+}
+
+func TestCompileRequiresLayoutResolver(t *testing.T) {
+	ruler, err := textmeasure.NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Compile(context.Background(), "x", &CompileOptions{Ruler: ruler}, nil)
+	const want = `no layout resolver configured for layout engine "dagre"`
+	if err == nil || err.Error() != want {
+		t.Fatalf("Compile() error = %v, want %q", err, want)
+	}
+}

--- a/d2lsp/completion.go
+++ b/d2lsp/completion.go
@@ -375,15 +375,6 @@ func getTextTransformCompletions() []CompletionItem {
 	return items
 }
 
-func isOnEmptyLine(text string, line int) bool {
-	lines := strings.Split(text, "\n")
-	if line >= len(lines) {
-		return true
-	}
-
-	return strings.TrimSpace(lines[line]) == ""
-}
-
 func getLabelCompletions() []CompletionItem {
 	return []CompletionItem{{
 		Label:      "near",

--- a/d2lsp/completion_test.go
+++ b/d2lsp/completion_test.go
@@ -358,22 +358,6 @@ layers: {
 	}
 }
 
-// Helper function to compare CompletionItem slices
-func equalCompletions(a, b []CompletionItem) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i].Label != b[i].Label ||
-			a[i].Kind != b[i].Kind ||
-			a[i].Detail != b[i].Detail ||
-			a[i].InsertText != b[i].InsertText {
-			return false
-		}
-	}
-	return true
-}
-
 func TestGetArrowheadShapeCompletions(t *testing.T) {
 	got := getArrowheadShapeCompletions()
 

--- a/d2renderers/d2ascii/d2ascii.go
+++ b/d2renderers/d2ascii/d2ascii.go
@@ -22,11 +22,6 @@ const (
 	defaultScale      = 1.0
 )
 
-const (
-	maxRouteAttempts = asciiroute.MaxRouteAttempts
-	labelOffsetX     = asciiroute.LabelOffsetX
-)
-
 type ASCIIartist struct {
 	canvas  *asciicanvas.Canvas
 	FW      float64
@@ -412,10 +407,6 @@ func (a *ASCIIartist) calibrateXY(x, y float64) (float64, float64) {
 	xC := float64(math.Round((x / a.FW) * a.SCALE))
 	yC := float64(math.Round((y / a.FH) * a.SCALE))
 	return xC, yC
-}
-
-func absInt(a int) int {
-	return int(math.Abs(float64(a)))
 }
 
 func hasConnectionsAtRightEdge(shape d2target.Shape, connections []d2target.Connection, fontWidth float64) bool {

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -127,11 +127,11 @@ local.code -> aws.ec2: {
 			},
 		},
 		{
-			name: "flags-panic",
+			name: "layout-extra-args",
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
 				writeFile(t, dir, "hello-world.d2", `x -> y`)
 				err := runTestMain(t, ctx, dir, env, "layout", "dagre", "--dagre-nodesep", "50", "hello-world.d2")
-				assert.ErrorString(t, err, `failed to wait xmain test: e2etests-cli/d2: failed to unmarshal input to graph: `)
+				assert.ErrorString(t, err, `failed to wait xmain test: e2etests-cli/d2: bad usage: layout subcommand accepts at most one argument`)
 			},
 		},
 		{

--- a/install.sh
+++ b/install.sh
@@ -607,15 +607,12 @@ help() {
   fi
 
   cat <<EOF
-usage: $arg0 [-d|--dry-run] [--version vX.X.X] [--edge] [--method detect] [--prefix path]
+usage: $arg0 [-d|--dry-run] [--version vX.X.X] [--method detect] [--prefix path]
   [--tala latest] [--force] [--uninstall] [-x|--trace]
 
 install.sh automates the installation of D2 onto your system. It currently only supports
 the installation of standalone releases from GitHub and via Homebrew on macOS. See the
 docs for --detect below for more information
-
-If you pass --edge, it will clone the source, build a release and install from it.
---edge is incompatible with --tala and currently unimplemented.
 
 \$PREFIX in the docs below refers to the path set by --prefix. See docs on the --prefix
 flag below for the default.
@@ -630,19 +627,6 @@ Flags:
   Pass to have install.sh install the given version instead of the latest version.
   warn: The version may not be obeyed with package manager installations. Use
         --method=standalone to enforce the version.
-
---edge
-  Pass to build and install D2 from source. This will still use --method if set to detect
-  to install the release archive for your OS, whether it's apt, yum, brew or standalone
-  if an unsupported package manager is used.
-
-  To install from source like a dev would, use go install github.com/d2lang/d2@latest. There's
-  also ./ci/release/build.sh --install to build and install a proper standalone release
-  including manpages. The proper release will also ensure d2 --version shows the correct
-  version by embedding the commit hash into the binary.
-
-  note: currently unimplemented.
-  warn: incompatible with --tala as TALA is closed source.
 
 --method [detect | standalone | homebrew ]
   Pass to control the method by which to install. Right now we only support standalone
@@ -720,12 +704,6 @@ main() {
       tala)
         shift "$FLAGSHIFT"
         TALA=${FLAGARG:-latest}
-        ;;
-      edge)
-        flag_noarg && shift "$FLAGSHIFT"
-        EDGE=1
-        echoerr "$FLAGRAW is currently unimplemented"
-        return 1
         ;;
       method)
         flag_nonemptyarg && shift "$FLAGSHIFT"

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -118,8 +118,6 @@ func InitPlaywrightWithPrompt() (Playwright, error) {
 	return InitPlaywright()
 }
 
-const pngPrefix = "data:image/png;base64,"
-
 func MountSVG(page playwright.Page, svgMarkup string) error {
 	decompressed := compression.UnzipEmbeddedSVGImages([]byte(svgMarkup))
 	html := `<!doctype html><meta charset="utf-8">

--- a/lib/shape/shape.go
+++ b/lib/shape/shape.go
@@ -4,7 +4,6 @@ import (
 	"math"
 
 	"github.com/d2lang/d2/lib/geo"
-	"github.com/d2lang/d2/lib/svg"
 	"github.com/d2lang/util-go/go2"
 )
 
@@ -235,16 +234,6 @@ func TraceToShapeBorder(shape Shape, rectBorderPoint, prevPoint *geo.Point) *geo
 
 	closestPoint.TruncateFloat32()
 	return geo.NewPoint(math.Round(closestPoint.X), math.Round(closestPoint.Y))
-}
-
-func boxPath(box *geo.Box) *svg.SvgPathContext {
-	pc := svg.NewSVGPathContext(box.TopLeft, 1, 1)
-	pc.StartAt(pc.Absolute(0, 0))
-	pc.L(false, box.Width, 0)
-	pc.L(false, box.Width, box.Height)
-	pc.L(false, 0, box.Height)
-	pc.Z()
-	return pc
 }
 
 func LimitAR(width, height, aspectRatio float64) (float64, float64) {


### PR DESCRIPTION
## Summary

- delete the stale 24 MB `d2js/js/d2.wasm`; the active JS build generates and consumes `d2js/js/wasm/d2.wasm`
- remove dead browser loader plumbing and the orphan Node loader
- remove unreferenced compiler, Dagre, LSP, ASCII, PNG, shape, and watcher code
- remove the unreachable `D2_LAYOUT` fallback, undocumented plugin wire-command passthrough, and never-implemented installer `--edge` flag
- add regression coverage for extra layout arguments and missing layout resolvers

## Compatibility

- keeps exported plugin interfaces and generic external-plugin discovery intact
- extra `d2 layout` arguments now return a usage error instead of entering an undocumented wire path
- `Compile` without a layout resolver returns a clear error instead of calling a nil resolver

## Validation

- `CI=1 go test ./... -count=1 -timeout=30m`
- `go vet --composites=false ./...`
- `go build ./...`
- focused changed-package tests under `-race`
- Linux and Windows cross-builds
- Go WASM build plus D2.js browser/Node builds, 32 unit tests, and CJS/ESM integration tests
- installer syntax, regeneration, and removed-flag behavior checks
- `deadcode -test ./...`
- `git diff --check`