### PR TITLE
fix d2js concurrent request handling

### DIFF
--- a/d2js/js/CHANGELOG.md
+++ b/d2js/js/CHANGELOG.md
@@ -5,6 +5,7 @@ include changes to the main d2 project.**
 
 ## Next
 
+- Fix concurrent calls sharing a D2 instance
 - Fix TypeScript signatures
 - Fix theme-overrides not applying
 - Fix grids in ELK layouts

--- a/d2js/js/src/index.js
+++ b/d2js/js/src/index.js
@@ -2,34 +2,70 @@ import { createWorker, loadFile } from "./platform.js";
 
 export class D2 {
   constructor() {
+    this.nextRequestId = 0;
+    this.pendingRequests = new Map();
     this.ready = this.init();
   }
 
-  setupMessageHandler() {
-    const isNode = typeof window === "undefined";
+  setupMessageHandler(isNode = typeof window === "undefined") {
     return new Promise((resolve, reject) => {
+      let isReady = false;
+
+      const rejectPendingRequests = (error) => {
+        for (const request of this.pendingRequests.values()) {
+          request.reject(error);
+        }
+        this.pendingRequests.clear();
+      };
+
+      const handleWorkerError = (error) => {
+        const workerError =
+          error instanceof Error
+            ? error
+            : new Error(error?.message || "D2 worker encountered an error");
+        if (!isReady) reject(workerError);
+        rejectPendingRequests(workerError);
+        console.error(
+          `Worker${isNode ? " (node)" : ""} encountered an error:`,
+          workerError.message
+        );
+      };
+
+      const handleMessage = (data) => {
+        if (data.type === "ready") {
+          isReady = true;
+          resolve();
+          return;
+        }
+
+        if (data.type !== "result" && data.type !== "error") return;
+
+        if (data.id === undefined) {
+          if (data.type === "error") {
+            const error = new Error(data.error);
+            if (!isReady) reject(error);
+            rejectPendingRequests(error);
+          }
+          return;
+        }
+
+        const request = this.pendingRequests.get(data.id);
+        if (!request) return;
+
+        this.pendingRequests.delete(data.id);
+        if (data.type === "result") {
+          request.resolve(data.data);
+        } else {
+          request.reject(new Error(data.error));
+        }
+      };
+
       if (isNode) {
-        this.worker.on("message", (data) => {
-          if (data.type === "ready") resolve();
-          if (data.type === "error") reject(new Error(data.error));
-          if (data.type === "result" && this.currentResolve) {
-            this.currentResolve(data.data);
-          }
-          if (data.type === "error" && this.currentReject) {
-            this.currentReject(new Error(data.error));
-          }
-        });
+        this.worker.on("message", handleMessage);
+        this.worker.on("error", handleWorkerError);
       } else {
-        this.worker.onmessage = (e) => {
-          if (e.data.type === "ready") resolve();
-          if (e.data.type === "error") reject(new Error(e.data.error));
-          if (e.data.type === "result" && this.currentResolve) {
-            this.currentResolve(e.data.data);
-          }
-          if (e.data.type === "error" && this.currentReject) {
-            this.currentReject(new Error(e.data.error));
-          }
-        };
+        this.worker.onmessage = (e) => handleMessage(e.data);
+        this.worker.onerror = handleWorkerError;
       }
     });
   }
@@ -42,16 +78,6 @@ export class D2 {
     const wasmBinary = await loadFile("./d2.wasm");
 
     const messageHandler = this.setupMessageHandler();
-
-    if (isNode) {
-      this.worker.on("error", (error) => {
-        console.error("Worker (node) encountered an error:", error.message || error);
-      });
-    } else {
-      this.worker.onerror = (error) => {
-        console.error("Worker encountered an error:", error.message || error);
-      };
-    }
 
     this.worker.postMessage({
       type: "init",
@@ -67,9 +93,14 @@ export class D2 {
   async sendMessage(type, data) {
     await this.ready;
     return new Promise((resolve, reject) => {
-      this.currentResolve = resolve;
-      this.currentReject = reject;
-      this.worker.postMessage({ type, data });
+      const id = this.nextRequestId++;
+      this.pendingRequests.set(id, { resolve, reject });
+      try {
+        this.worker.postMessage({ id, type, data });
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        reject(error);
+      }
     });
   }
 

--- a/d2js/js/src/worker.browser.js
+++ b/d2js/js/src/worker.browser.js
@@ -10,7 +10,7 @@ export function setupMessageHandler(isNode, port, initWasm) {
   currentPort = port;
 
   const handleMessage = async (e) => {
-    const { type, data } = e;
+    const { id, type, data } = e;
 
     switch (type) {
       case "init":
@@ -30,9 +30,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = await d2.compile(JSON.stringify(data));
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -44,9 +44,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const decoded = new TextDecoder().decode(
             Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0))
           );
-          currentPort.postMessage({ type: "result", data: decoded });
+          currentPort.postMessage({ id, type: "result", data: decoded });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -55,9 +55,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.encode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -66,9 +70,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.decode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -77,9 +85,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.version();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -88,9 +96,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.jsVersion();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
     }

--- a/d2js/js/src/worker.js
+++ b/d2js/js/src/worker.js
@@ -12,7 +12,7 @@ export function setupMessageHandler(isNode, port, initWasm) {
   currentPort = port;
 
   const handleMessage = async (e) => {
-    const { type, data } = e;
+    const { id, type, data } = e;
 
     switch (type) {
       case "init":
@@ -32,9 +32,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = await d2.compile(JSON.stringify(data));
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -46,9 +46,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const decoded = new TextDecoder().decode(
             Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0))
           );
-          currentPort.postMessage({ type: "result", data: decoded });
+          currentPort.postMessage({ id, type: "result", data: decoded });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -57,9 +57,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.encode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -68,9 +72,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.decode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -79,9 +87,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.version();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -90,9 +98,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.jsVersion();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
     }

--- a/d2js/js/src/worker.node.js
+++ b/d2js/js/src/worker.node.js
@@ -12,7 +12,7 @@ export function setupMessageHandler(isNode, port, initWasm) {
   currentPort = port;
 
   const handleMessage = async (e) => {
-    const { type, data } = e;
+    const { id, type, data } = e;
 
     switch (type) {
       case "init":
@@ -32,9 +32,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = await d2.compile(JSON.stringify(data));
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -46,9 +46,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const decoded = new TextDecoder().decode(
             Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0))
           );
-          currentPort.postMessage({ type: "result", data: decoded });
+          currentPort.postMessage({ id, type: "result", data: decoded });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -57,9 +57,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.encode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -68,9 +72,13 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.decode(data);
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data.result });
+          currentPort.postMessage({
+            id,
+            type: "result",
+            data: response.data.result,
+          });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -79,9 +87,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.version();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
 
@@ -90,9 +98,9 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = d2.jsVersion();
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: response.data });
+          currentPort.postMessage({ id, type: "result", data: response.data });
         } catch (err) {
-          currentPort.postMessage({ type: "error", error: err.message });
+          currentPort.postMessage({ id, type: "error", error: err.message });
         }
         break;
     }

--- a/d2js/js/test/unit/concurrency.test.js
+++ b/d2js/js/test/unit/concurrency.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { D2 } from "../../dist/node-esm/index.js";
+import packageJson from "../../package.json" assert { type: "json" };
+
+class FakeNodeWorker {
+  constructor() {
+    this.handlers = new Map();
+    this.messages = [];
+  }
+
+  on(type, handler) {
+    this.handlers.set(type, handler);
+  }
+
+  postMessage(message) {
+    this.messages.push(message);
+  }
+
+  emitMessage(message) {
+    this.handlers.get("message")(message);
+  }
+}
+
+class FakeBrowserWorker {
+  constructor() {
+    this.messages = [];
+  }
+
+  postMessage(message) {
+    this.messages.push(message);
+  }
+
+  emitMessage(message) {
+    this.onmessage({ data: message });
+  }
+}
+
+function createD2(isNode) {
+  const worker = isNode ? new FakeNodeWorker() : new FakeBrowserWorker();
+  const d2 = new (class extends D2 {
+    init() {
+      this.worker = worker;
+      const ready = this.setupMessageHandler(isNode);
+      worker.emitMessage({ type: "ready" });
+      return ready;
+    }
+  })();
+  return { d2, worker };
+}
+
+async function waitForRequests(worker, count) {
+  while (worker.messages.length < count) {
+    await Promise.resolve();
+  }
+}
+
+for (const [name, isNode] of [
+  ["Node", true],
+  ["browser", false],
+]) {
+  describe(`${name} worker request correlation`, () => {
+    test("resolves overlapping requests that complete out of order", async () => {
+      const { d2, worker } = createD2(isNode);
+
+      const first = d2.compile("first");
+      const second = d2.version();
+      await waitForRequests(worker, 2);
+
+      const [firstRequest, secondRequest] = worker.messages;
+      expect(firstRequest.id).not.toBe(secondRequest.id);
+      expect(firstRequest.type).toBe("compile");
+      expect(secondRequest.type).toBe("version");
+
+      worker.emitMessage({
+        id: secondRequest.id,
+        type: "result",
+        data: "second result",
+      });
+      worker.emitMessage({
+        id: firstRequest.id,
+        type: "result",
+        data: "first result",
+      });
+
+      expect(await first).toBe("first result");
+      expect(await second).toBe("second result");
+      expect(d2.pendingRequests.size).toBe(0);
+    });
+
+    test("rejects only the request whose out-of-order response is an error", async () => {
+      const { d2, worker } = createD2(isNode);
+
+      const first = d2.render({ name: "first" });
+      const second = d2.decode("invalid");
+      const secondResult = second.then(
+        () => ({ resolved: true }),
+        (error) => ({ error })
+      );
+      await waitForRequests(worker, 2);
+
+      const [firstRequest, secondRequest] = worker.messages;
+      worker.emitMessage({
+        id: secondRequest.id,
+        type: "error",
+        error: "second failed",
+      });
+      worker.emitMessage({
+        id: firstRequest.id,
+        type: "result",
+        data: "first result",
+      });
+
+      expect(await first).toBe("first result");
+      expect((await secondResult).error.message).toBe("second failed");
+      expect(d2.pendingRequests.size).toBe(0);
+    });
+
+    test("cleans up a request when posting it fails", async () => {
+      const { d2, worker } = createD2(isNode);
+      worker.postMessage = () => {
+        throw new Error("post failed");
+      };
+
+      await expect(d2.version()).rejects.toThrow("post failed");
+      expect(d2.pendingRequests.size).toBe(0);
+    });
+  });
+}
+
+test("correlates every operation through the real worker", async () => {
+  const d2 = new D2();
+  const base = await d2.compile("base");
+  const encodedBase = await d2.encode("decoded result");
+
+  const [compiled, rendered, encoded, decoded, version, jsVersion] = await Promise.all([
+    d2.compile("compiled-result"),
+    d2.render(base.diagram),
+    d2.encode("encoded result"),
+    d2.decode(encodedBase),
+    d2.version(),
+    d2.jsVersion(),
+  ]);
+
+  expect(compiled.diagram.shapes[0].id).toBe("compiled-result");
+  expect(rendered).toContain("base");
+  expect(await d2.decode(encoded)).toBe("encoded result");
+  expect(decoded).toBe("decoded result");
+  expect(version).toMatch(/^v?\d+\.\d+\.\d+/);
+  expect(jsVersion).toBe(packageJson.version);
+  await d2.worker.terminate();
+}, 20000);


### PR DESCRIPTION
## Summary

- correlate each D2.js request and worker response with a unique ID
- keep independent pending callbacks so overlapping calls cannot overwrite each other
- reject and clean up the affected request on worker and postMessage errors
- cover both Node and browser message handlers plus every public worker operation

## Root cause

A D2 instance stored only one `currentResolve`/`currentReject` pair. Starting a second compile, render, encode, decode, or version call replaced the callbacks for the first call. Since worker handlers are asynchronous, the first response could then resolve the second promise and leave the first promise pending forever.

## User impact

Callers can safely overlap operations on one D2 instance, including `Promise.all`, without responses being delivered to the wrong promise.

## Validation

- fresh Go WASM build from this branch
- `bun test test/unit`: 39 pass
- `bun test test/integration`: 2 pass
- deterministic out-of-order success/error tests for Node and browser handlers
- end-to-end overlapping compile, render, encode, decode, version, and jsVersion calls
- Prettier 2.8.1 and `git diff --check`
