### PR TITLE
d2js: use UTF-16 columns for completions

### DIFF
--- a/d2js/d2wasm/functions.go
+++ b/d2js/d2wasm/functions.go
@@ -585,7 +585,7 @@ func GetCompletions(args []js.Value) (interface{}, error) {
 	line := args[1].Int()
 	column := args[2].Int()
 
-	completions, err := d2lsp.GetCompletionItems(text, line, column)
+	completions, err := d2lsp.GetCompletionItemsUTF16(text, line, column)
 	if err != nil {
 		return nil, &WASMError{Message: err.Error(), Code: 500}
 	}

--- a/d2js/js/CHANGELOG.md
+++ b/d2js/js/CHANGELOG.md
@@ -6,6 +6,7 @@ include changes to the main d2 project.**
 ## Next
 
 - Fix concurrent calls sharing a D2 instance
+- Fix completions after Unicode characters
 - Fix TypeScript signatures
 - Fix theme-overrides not applying
 - Fix grids in ELK layouts

--- a/d2lsp/completion.go
+++ b/d2lsp/completion.go
@@ -8,6 +8,7 @@ package d2lsp
 import (
 	"strings"
 	"unicode"
+	"unicode/utf16"
 
 	"github.com/d2lang/d2/d2ast"
 	"github.com/d2lang/d2/d2parser"
@@ -30,12 +31,27 @@ type CompletionItem struct {
 }
 
 func GetCompletionItems(text string, line, column int) ([]CompletionItem, error) {
-	ast, err := d2parser.Parse("", strings.NewReader(text), nil)
-	if err != nil {
-		ast, _ = d2parser.Parse("", strings.NewReader(getTextUntilPosition(text, line, column)), nil)
+	return getCompletionItems(text, line, column, false)
+}
+
+// GetCompletionItemsUTF16 returns completions for a position whose column is
+// measured in UTF-16 code units, as required by browser and LSP clients.
+func GetCompletionItemsUTF16(text string, line, column int) ([]CompletionItem, error) {
+	return getCompletionItems(text, line, column, true)
+}
+
+func getCompletionItems(text string, line, column int, utf16Pos bool) ([]CompletionItem, error) {
+	var parseOpts *d2parser.ParseOptions
+	if utf16Pos {
+		parseOpts = &d2parser.ParseOptions{UTF16Pos: true}
 	}
 
-	keyword := getKeywordContext(text, ast, line, column)
+	ast, err := d2parser.Parse("", strings.NewReader(text), parseOpts)
+	if err != nil {
+		ast, _ = d2parser.Parse("", strings.NewReader(getTextUntilPosition(text, line, column, utf16Pos)), parseOpts)
+	}
+
+	keyword := getKeywordContext(text, ast, line, column, utf16Pos)
 	switch keyword {
 	case "style", "style.":
 		return getStyleCompletions(), nil
@@ -82,7 +98,7 @@ func GetCompletionItems(text string, line, column int) ([]CompletionItem, error)
 	}
 }
 
-func getTextUntilPosition(text string, line, column int) string {
+func getTextUntilPosition(text string, line, column int, utf16Pos bool) string {
 	lines := strings.Split(text, "\n")
 	if line >= len(lines) {
 		return text
@@ -92,6 +108,7 @@ func getTextUntilPosition(text string, line, column int) string {
 	if len(result) > 0 {
 		result += "\n"
 	}
+	column = columnByteOffset(lines[line], column, utf16Pos)
 	if column > len(lines[line]) {
 		result += lines[line]
 	} else {
@@ -100,11 +117,15 @@ func getTextUntilPosition(text string, line, column int) string {
 	return result
 }
 
-func getKeywordContext(text string, m *d2ast.Map, line, column int) string {
+func getKeywordContext(text string, m *d2ast.Map, line, column int, utf16Pos bool) string {
 	if m == nil {
 		return ""
 	}
 	lines := strings.Split(text, "\n")
+	lineColumn := column
+	if line >= 0 && line < len(lines) {
+		lineColumn = columnByteOffset(lines[line], column, utf16Pos)
+	}
 
 	for _, n := range m.Nodes {
 		if n.MapKey == nil {
@@ -136,7 +157,8 @@ func getKeywordContext(text string, m *d2ast.Map, line, column int) string {
 					}
 					keyRange := n.MapKey.Range
 					lineText := lines[keyRange.End.Line]
-					if isHolderLast && isAfterDot(lineText, column) {
+					dotColumn := columnByteOffset(lineText, column, utf16Pos)
+					if isHolderLast && isAfterDot(lineText, dotColumn) {
 						return lastPart + "."
 					}
 				}
@@ -156,7 +178,7 @@ func getKeywordContext(text string, m *d2ast.Map, line, column int) string {
 
 		// Check nested map
 		if n.MapKey.Value.Map != nil && isPositionInMap(line, column, n.MapKey.Value.Map) {
-			if nested := getKeywordContext(text, n.MapKey.Value.Map, line, column); nested != "" {
+			if nested := getKeywordContext(text, n.MapKey.Value.Map, line, column, utf16Pos); nested != "" {
 				if isHolder {
 					// If we got a direct key completion from inside a holder's map,
 					// prefix it with the holder's name
@@ -191,7 +213,7 @@ func getKeywordContext(text string, m *d2ast.Map, line, column int) string {
 
 		lineText := lines[keyRange.End.Line]
 
-		if isAfterColon(lineText, column) {
+		if isAfterColon(lineText, lineColumn) {
 			if key != nil && len(key.Path) > 1 {
 				if isHolder && (firstPart == "source-arrowhead" || firstPart == "target-arrowhead") {
 					return firstPart + "." + lastPart + ":"
@@ -205,12 +227,34 @@ func getKeywordContext(text string, m *d2ast.Map, line, column int) string {
 			return firstPart + ":"
 		}
 
-		if isAfterDot(lineText, column) && isHolder {
+		if isAfterDot(lineText, lineColumn) && isHolder {
 			return firstPart
 		}
 	}
 
 	return ""
+}
+
+func columnByteOffset(text string, column int, utf16Pos bool) int {
+	if column <= 0 {
+		return 0
+	}
+	if !utf16Pos {
+		return column
+	}
+
+	units := 0
+	for byteOffset, r := range text {
+		if units >= column {
+			return byteOffset
+		}
+		runeUnits := utf16.RuneLen(r)
+		if units+runeUnits > column {
+			return byteOffset
+		}
+		units += runeUnits
+	}
+	return len(text)
 }
 
 func isAfterDot(text string, pos int) bool {

--- a/d2lsp/completion_test.go
+++ b/d2lsp/completion_test.go
@@ -358,6 +358,99 @@ layers: {
 	}
 }
 
+func TestGetCompletionItemsUTF16(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		column int
+		want   []CompletionItem
+	}{
+		{
+			name:   "shape after non-BMP key",
+			text:   "😀.shape:",
+			column: 9,
+			want:   getShapeCompletions(),
+		},
+		{
+			name:   "shape after multibyte BMP key",
+			text:   "é.shape:",
+			column: 8,
+			want:   getShapeCompletions(),
+		},
+		{
+			name:   "style after non-BMP key",
+			text:   "😀.style.",
+			column: 9,
+			want:   getStyleCompletions(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCompletionItemsUTF16(tt.text, 0, tt.column)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !equalCompletionSets(got, tt.want) {
+				t.Fatalf("GetCompletionItemsUTF16() got %d completions, want %d", len(got), len(tt.want))
+			}
+		})
+	}
+
+	got, err := GetCompletionItems("😀.shape:", 0, len("😀.shape:"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalCompletionSets(got, getShapeCompletions()) {
+		t.Fatalf("byte-based GetCompletionItems() got %d completions, want %d", len(got), len(getShapeCompletions()))
+	}
+}
+
+func TestColumnByteOffset(t *testing.T) {
+	text := "😀.x"
+	tests := []struct {
+		column int
+		want   int
+	}{{
+		column: 0,
+		want:   0,
+	}, {
+		column: 1,
+		want:   0,
+	}, {
+		column: 2,
+		want:   len("😀"),
+	}, {
+		column: 3,
+		want:   len("😀."),
+	}, {
+		column: 99,
+		want:   len(text),
+	}}
+
+	for _, tt := range tests {
+		if got := columnByteOffset(text, tt.column, true); got != tt.want {
+			t.Errorf("columnByteOffset(%q, %d, true) = %d, want %d", text, tt.column, got, tt.want)
+		}
+	}
+}
+
+func equalCompletionSets(a, b []CompletionItem) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	bm := make(map[string]CompletionItem, len(b))
+	for _, item := range b {
+		bm[item.Label] = item
+	}
+	for _, item := range a {
+		if item != bm[item.Label] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestGetArrowheadShapeCompletions(t *testing.T) {
 	got := getArrowheadShapeCompletions()
 


### PR DESCRIPTION
## Summary

- preserve the existing byte-column completion API for Go callers
- add a UTF-16 completion path for browser/LSP positions
- route the WebAssembly `getCompletions` export through the UTF-16 path
- cover BMP and non-BMP Unicode before dot/colon completions

## Why

JavaScript reports string columns in UTF-16 code units, while the completion code parsed and sliced them as UTF-8 byte offsets. Any multibyte character before the cursor could suppress or misclassify completions.

## Validation

- `go test ./d2lsp -run 'TestGetCompletionItems|TestColumnByteOffset' -count=20`
- `go test -race ./d2lsp -count=1`
- `go vet ./d2lsp`
- `GOOS=js GOARCH=wasm go test -c ./d2js/d2wasm`
- `go test ./e2etests -run '^TestE2E$' -count=1 -parallel=1`
- built `./d2js` for wasm and invoked `d2.getCompletions('😀.shape:', 0, 9)` through Go's `wasm_exec.js`; received all 25 shape completions
- `git diff --check`
