### PR TITLE
d2svg: fix one-stop gradient offsets

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -35,6 +35,7 @@
 
 #### Bugfixes ⛑️
 
+- d2svg: render one-stop gradients with finite SVG offsets
 - exports: pptx follows standards more closely, addressing warnings from some Powerpoint software [#2645](https://github.com/d2lang/d2/pull/2645)
 - d2sequence: fix edge case of invalid sequence diagrams [#2660](https://github.com/d2lang/d2/pull/2660)
 - d2svg: Text may overflow legend bounds when monospace font is used [#2674](https://github.com/d2lang/d2/pull/2674)

--- a/lib/color/gradient.go
+++ b/lib/color/gradient.go
@@ -136,11 +136,7 @@ func LinearGradientToSVG(gradient Gradient) string {
 
 	totalStops := len(gradient.ColorStops)
 	for i, cs := range gradient.ColorStops {
-		offset := cs.Position
-		if offset == "" {
-			offsetValue := float64(i) / float64(totalStops-1) * 100
-			offset = fmt.Sprintf("%.2f%%", offsetValue)
-		}
+		offset := gradientStopOffset(cs.Position, i, totalStops)
 		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, offset, cs.Color))
 		sb.WriteString("\n")
 	}
@@ -222,16 +218,22 @@ func RadialGradientToSVG(gradient Gradient) string {
 	sb.WriteString("\n")
 	totalStops := len(gradient.ColorStops)
 	for i, cs := range gradient.ColorStops {
-		offset := cs.Position
-		if offset == "" {
-			offsetValue := float64(i) / float64(totalStops-1) * 100
-			offset = fmt.Sprintf("%.2f%%", offsetValue)
-		}
+		offset := gradientStopOffset(cs.Position, i, totalStops)
 		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, offset, cs.Color))
 		sb.WriteString("\n")
 	}
 	sb.WriteString(`</radialGradient>`)
 	return sb.String()
+}
+
+func gradientStopOffset(position string, index, totalStops int) string {
+	if position != "" {
+		return position
+	}
+	if totalStops == 1 {
+		return "0.00%"
+	}
+	return fmt.Sprintf("%.2f%%", float64(index)/float64(totalStops-1)*100)
 }
 
 func UniqueGradientID(cssGradient string) string {

--- a/lib/color/gradient_test.go
+++ b/lib/color/gradient_test.go
@@ -1,0 +1,43 @@
+package color
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestOneStopGradientToSVG(t *testing.T) {
+	tests := []string{
+		"linear-gradient(red)",
+		"radial-gradient(red)",
+	}
+
+	for _, cssGradient := range tests {
+		t.Run(cssGradient, func(t *testing.T) {
+			gradient, err := ParseGradient(cssGradient)
+			if err != nil {
+				t.Fatalf("ParseGradient() error = %v", err)
+			}
+
+			svg := GradientToSVG(gradient)
+			if strings.Contains(svg, "NaN") || strings.Contains(svg, "Inf") {
+				t.Fatalf("GradientToSVG() produced a non-finite offset:\n%s", svg)
+			}
+
+			var parsed struct {
+				Stops []struct {
+					Offset string `xml:"offset,attr"`
+				} `xml:"stop"`
+			}
+			if err := xml.Unmarshal([]byte(svg), &parsed); err != nil {
+				t.Fatalf("GradientToSVG() produced invalid XML: %v\n%s", err, svg)
+			}
+			if len(parsed.Stops) != 1 {
+				t.Fatalf("GradientToSVG() produced %d stops, want 1", len(parsed.Stops))
+			}
+			if got, want := parsed.Stops[0].Offset, "0.00%"; got != want {
+				t.Fatalf("stop offset = %q, want %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- assign an unpositioned one-stop gradient a `0.00%` SVG offset
- share the offset calculation between linear and radial gradient rendering
- add focused XML-parsing regressions for both gradient types
- document the bugfix in the next changelog

## Why

D2 already accepts one-stop gradient values, but automatic stop spacing divided the stop index by `totalStops - 1`. For a single stop that is `0 / 0`, so generated SVG contained `offset="NaN%"`.

Changing validation would break previously accepted D2 input. SVG 2 defines a one-stop gradient as solid-color paint, so keeping one stop at the gradient start preserves that accepted input while producing finite, valid SVG. Multi-stop gradients and explicit stop positions are unchanged.

## Validation

- `go test ./lib/color -count=1`
- `go test -race ./lib/color -count=1`
- `go vet ./lib/color ./d2renderers/d2svg`
- `go test ./d2renderers/d2svg -count=1`
- `go test ./e2etests -run '^TestE2E$' -count=1 -parallel=1`
- manual CLI reproduction now emits `<stop offset="0.00%" stop-color="red" />`
