### PR TITLE
compiler: reject non-finite opacity values

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -40,6 +40,7 @@
 - d2elk: route ancestor-to-descendant connections around intermediate containers
 - d2svg: render one-stop gradients with finite SVG offsets
 - compiler: make suffix globs match only names with the requested suffix
+- compiler: reject non-finite opacity values with a source diagnostic
 - d2svg: preserve connection links on LaTeX, Markdown, and code labels
 - d2lib: preserve caller-supplied light and dark theme overrides over source configuration
 - exports: pptx follows standards more closely, addressing warnings from some Powerpoint software [#2645](https://github.com/d2lang/d2/pull/2645)

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -18,6 +18,34 @@ import (
 	"github.com/d2lang/d2/d2target"
 )
 
+func TestOpacityValidation(t *testing.T) {
+	t.Parallel()
+
+	const wantErr = `opacity.d2:1:18: expected "opacity" to be a number between 0.0 and 1.0`
+	for _, value := range []string{
+		"NaN", "nan", "NAN",
+		"Inf", "+Inf", "-Inf",
+		"Infinity", "+Infinity", "-Infinity",
+	} {
+		value := value
+		t.Run("reject_"+value, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := d2compiler.Compile("opacity.d2", strings.NewReader("x.style.opacity: "+value), nil)
+			assert.ErrorString(t, err, wantErr)
+		})
+	}
+
+	for _, value := range []string{"0", "0.5", "1"} {
+		value := value
+		t.Run("accept_"+value, func(t *testing.T) {
+			t.Parallel()
+			g, _, err := d2compiler.Compile("opacity.d2", strings.NewReader("x.style.opacity: "+value), nil)
+			assert.Success(t, err)
+			assert.String(t, value, g.Objects[0].Style.Opacity.Value)
+		})
+	}
+}
+
 func TestCompile(t *testing.T) {
 	t.Parallel()
 

--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -319,7 +319,7 @@ func (s *Style) Apply(key, value string) error {
 			break
 		}
 		f, err := strconv.ParseFloat(value, 64)
-		if err != nil || (f < 0 || f > 1) {
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 || f > 1 {
 			return errors.New(`expected "opacity" to be a number between 0.0 and 1.0`)
 		}
 		s.Opacity.Value = value


### PR DESCRIPTION
## What changed

- reject non-finite `style.opacity` values at the existing style validation boundary
- preserve the existing source-located diagnostic for values outside 0.0–1.0
- cover case-insensitive `NaN`, signed `Inf`/`Infinity`, and valid 0, 0.5, and 1 controls
- document the bugfix in the next changelog

## Why

`strconv.ParseFloat` accepts `NaN`. The existing range check used only `f < 0 || f > 1`, and both comparisons are false for NaN. That allowed NaN into the exported target graph, where JSON marshaling failed later with `json: unsupported value: NaN` instead of reporting the invalid source value.

The validation now explicitly rejects NaN and infinities before storing the opacity.

## User impact

Invalid opacity values now fail at their D2 source location with the normal opacity diagnostic. Valid opacity values render exactly as before.

## Validation

- `go test ./d2graph ./d2compiler -count=1`
- `go test -race ./d2compiler -run '^TestOpacityValidation$' -count=1`
- `go vet ./d2graph ./d2compiler`
- `go test ./e2etests -run '^TestE2E$' -count=1`
- `git diff --check`
