### PR TITLE
docs: add asyncmachine-go to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,5 @@ this selected list of featured projects using D2.
   - Cloud service emulator (46k stars)
 - [Queue Library](https://github.com/golang-queue/queue/tree/master/images)
   - Queue is a Golang library for spawning and managing a Goroutine pool
+- [asyncmachine-go](https://github.com/pancsta/asyncmachine-go/tree/main/tools/cmd/am-vis)
+  - Distributed workflow engine.


### PR DESCRIPTION
Add am-vis diagram generator of state machines graphs.

https://github.com/pancsta/asyncmachine-go/tree/main/tools/cmd/am-vis

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
