### PR TITLE
Document Debian installation via the pkg.haus APT archive

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -99,6 +99,14 @@ All supported platforms:
 xbps-install d2
 ```
 
+### Debian
+
+Debian packages, built from source at release tags, are available from the pkg.haus APT archive for stable, testing and unstable on amd64 and arm64. Set up the archive per the instructions on https://pkg.haus, then install with:
+
+```sh
+sudo apt install d2
+```
+
 ## Standalone
 
 We publish standalone release archives for every release on Github.


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying d2 for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds a Debian subsection to docs/INSTALL.md next to the other distros.