### PR TITLE
feat: add JSON output format for diagram export

### DIFF
--- a/d2cli/export.go
+++ b/d2cli/export.go
@@ -14,8 +14,9 @@ const PPTX exportExtension = ".pptx"
 const PDF exportExtension = ".pdf"
 const SVG exportExtension = ".svg"
 const TXT exportExtension = ".txt"
+const JSON exportExtension = ".json"
 
-var SUPPORTED_EXTENSIONS = []exportExtension{SVG, PNG, PDF, PPTX, GIF, TXT}
+var SUPPORTED_EXTENSIONS = []exportExtension{SVG, PNG, PDF, PPTX, GIF, TXT, JSON}
 
 var STDOUT_FORMAT_MAP = map[string]exportExtension{
 	"png":   PNG,
@@ -25,9 +26,10 @@ var STDOUT_FORMAT_MAP = map[string]exportExtension{
 	"pdf":   PDF,
 	"pptx":  PPTX,
 	"gif":   GIF,
+	"json":  JSON,
 }
 
-var SUPPORTED_STDOUT_FORMATS = []string{"png", "svg", "ascii", "txt", "pdf", "pptx", "gif"}
+var SUPPORTED_STDOUT_FORMATS = []string{"png", "svg", "ascii", "txt", "pdf", "pptx", "gif", "json"}
 
 func getOutputFormat(stdoutFormatFlag *string, outputPath string) (exportExtension, error) {
 	if stdoutFormatFlag != nil && *stdoutFormatFlag != "" {

--- a/d2cli/export_test.go
+++ b/d2cli/export_test.go
@@ -83,6 +83,23 @@ func TestOutputFormat(t *testing.T) {
 			requiresAnimationInterval: true,
 			requiresPngRender:         true,
 		},
+		{
+			stdoutFormatFlag:          "json",
+			outputPath:                "-",
+			extension:                 JSON,
+			supportsDarkTheme:         false,
+			supportsAnimation:         false,
+			requiresAnimationInterval: false,
+			requiresPngRender:         false,
+		},
+		{
+			outputPath:                "/out.json",
+			extension:                 JSON,
+			supportsDarkTheme:         false,
+			supportsAnimation:         false,
+			requiresAnimationInterval: false,
+			requiresPngRender:         false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -19,13 +19,13 @@ import (
 func help(ms *xmain.State) {
 	fmt.Fprintf(ms.Stdout, `%[1]s %[2]s
 Usage:
-  %[1]s [--watch=false] [--theme=0] file.d2 [file.svg | file.png | file.pdf | file.pptx | file.gif | file.txt]
+  %[1]s [--watch=false] [--theme=0] file.d2 [file.svg | file.png | file.pdf | file.pptx | file.gif | file.txt | file.json]
   %[1]s layout [name]
   %[1]s fmt file.d2 ...
   %[1]s play [--theme=0] [--sketch] file.d2
   %[1]s validate file.d2
 
-%[1]s compiles and renders file.d2 to file.svg | file.png | file.pdf | file.pptx | file.gif | file.txt
+%[1]s compiles and renders file.d2 to file.svg | file.png | file.pdf | file.pptx | file.gif | file.txt | file.json
 It defaults to file.svg if an output path is not provided.
 
 Use - to have d2 read from stdin or write to stdout.

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -105,7 +105,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	stdoutFormatFlag := ms.Opts.String("", "stdout-format", "", "", "output format when writing to stdout (svg, png, ascii, txt, pdf, pptx, gif). Usage: d2 input.d2 --stdout-format png - > output.png")
+	stdoutFormatFlag := ms.Opts.String("", "stdout-format", "", "", "output format when writing to stdout (svg, png, ascii, txt, pdf, pptx, gif, json). Usage: d2 input.d2 --stdout-format png - > output.png")
 	if err != nil {
 		return err
 	}
@@ -939,6 +939,18 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 			return ascii, err
 		}
 		return ascii, nil
+	}
+	if outputFormat == JSON {
+		jsonBytes, err := json.MarshalIndent(diagram, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		jsonBytes = append(jsonBytes, '\n')
+		err = Write(ms, outputPath, jsonBytes)
+		if err != nil {
+			return jsonBytes, err
+		}
+		return jsonBytes, nil
 	}
 	toPNG := outputFormat == PNG
 


### PR DESCRIPTION
Add .json as a supported export format that serializes the d2target.Diagram to pretty-printed JSON. This provides a structured, machine-readable representation of the rendered diagram including all shapes, connections, positions, and styling.

The JSON output skips SVG rendering entirely — it marshals the already-computed diagram after layout and export, making it the fastest output format.

Changes:
- d2cli/export.go: Register JSON extension (.json) in supported extensions, stdout format map, and supported stdout formats
- d2cli/main.go: Add JSON handling in _render() that marshals diagram via json.MarshalIndent and writes to output
- d2cli/help.go: Add file.json to usage and description text
- d2cli/export_test.go: Add test cases for file and stdout JSON output

Usage:
  d2 input.d2 output.json d2 --format json input.d2 -
