### PR TITLE
release: harden standalone artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Verify representative release archive and size budget
+        run: ./ci/release/build.sh --rebuild --run=linux/amd64 --version=v0.0.0-ci
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/.github/workflows/release-archives.yml
+++ b/.github/workflows/release-archives.yml
@@ -1,0 +1,226 @@
+name: Release archives
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/release-archives.yml
+      - .github/workflows/ci.yml
+      - ci/release/**
+      - ci/sub
+      - install.sh
+      - go.mod
+      - go.sum
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-archives-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RELEASE_BUILD_SERIAL: "1"
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: ./go.mod
+          cache: true
+
+      - name: Select release version
+        id: version
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == push ]]; then
+            version=$GITHUB_REF_NAME
+            if ! printf '%s\n' "$version" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'; then
+              echo "release tag must be a v-prefixed semantic version" >&2
+              exit 1
+            fi
+          else
+            version="v0.0.0-pr.$PR_NUMBER"
+          fi
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Verify modules
+        env:
+          GOEXPERIMENT: ""
+          GOFLAGS: ""
+          GOTOOLCHAIN: local
+          GOWORK: "off"
+        run: go mod verify
+
+      - name: Build and verify all release archives
+        env:
+          RELEASE: "1"
+          RELEASE_BUILD_IN_CI: "1"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./ci/release/build.sh --rebuild --version="$VERSION"
+
+      - name: Prove archive reproducibility
+        env:
+          RELEASE: "1"
+          RELEASE_BUILD_IN_CI: "1"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cp "ci/release/build/$VERSION/SHA256SUMS" "$RUNNER_TEMP/first-SHA256SUMS"
+          ./ci/release/build.sh --rebuild --version="$VERSION"
+          diff -u "$RUNNER_TEMP/first-SHA256SUMS" "ci/release/build/$VERSION/SHA256SUMS"
+          git diff --exit-code
+
+      - name: Generate release SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          GOTOOLCHAIN=local GOWORK=off GOFLAGS= GOEXPERIMENT= \
+            go run -mod=readonly ./ci/release/releasetool sbom \
+              --binary "ci/release/build/$VERSION/linux-amd64/d2-$VERSION/bin/d2" \
+              --output "$RUNNER_TEMP/d2.spdx.json" \
+              --name "d2-$VERSION" \
+              --version "$VERSION" \
+              --epoch "$(git show -s --format=%ct HEAD)"
+
+      - name: Upload immutable release archives
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-archives
+          path: |
+            ci/release/build/${{ steps.version.outputs.version }}/*.tar.gz
+            ci/release/build/${{ steps.version.outputs.version }}/SHA256SUMS
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload release SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-sbom
+          path: ${{ runner.temp }}/d2.spdx.json
+          if-no-files-found: error
+          retention-days: 30
+
+  smoke:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            os: linux
+            arch: amd64
+            extension: ""
+          - runner: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+            extension: ""
+          - runner: macos-15-intel
+            os: macos
+            arch: amd64
+            extension: ""
+          - runner: macos-15
+            os: macos
+            arch: arm64
+            extension: ""
+          - runner: windows-2025
+            os: windows
+            arch: amd64
+            extension: .exe
+          - runner: windows-11-arm
+            os: windows
+            arch: arm64
+            extension: .exe
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-archives
+          path: ${{ runner.temp }}/release-archives
+
+      - name: Run native archive smoke test
+        shell: pwsh
+        env:
+          ARCH: ${{ matrix.arch }}
+          BINARY_EXTENSION: ${{ matrix.extension }}
+          OS: ${{ matrix.os }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP "release-archives/d2-$env:VERSION-$env:OS-$env:ARCH.tar.gz"
+          if (-not (Test-Path -LiteralPath $archive -PathType Leaf)) {
+            throw "missing $archive"
+          }
+          $destination = Join-Path $env:RUNNER_TEMP "d2-release-smoke"
+          New-Item -ItemType Directory -Force -Path $destination | Out-Null
+          tar -C $destination -xzf $archive
+          if ($LASTEXITCODE -ne 0) {
+            throw "unable to extract $archive"
+          }
+          $binary = Join-Path $destination "d2-$env:VERSION/bin/d2$env:BINARY_EXTENSION"
+          $actualVersion = (& $binary --version).Trim()
+          if ($LASTEXITCODE -ne 0 -or $actualVersion -cne $env:VERSION) {
+            throw "d2 --version returned '$actualVersion', expected '$env:VERSION'"
+          }
+          $inputFile = Join-Path $destination "smoke.d2"
+          $outputFile = Join-Path $destination "smoke.svg"
+          "x -> y" | Set-Content -LiteralPath $inputFile
+          & $binary $inputFile $outputFile
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $outputFile -PathType Leaf)) {
+            throw "d2 SVG smoke render failed"
+          }
+          if (-not (Select-String -LiteralPath $outputFile -Pattern '<svg' -Quiet)) {
+            throw "d2 SVG smoke render did not produce SVG"
+          }
+
+  attest:
+    if: github.event_name == 'push'
+    needs:
+      - build
+      - smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-archives
+          path: ${{ runner.temp }}/release-archives
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-sbom
+          path: ${{ runner.temp }}/release-sbom
+
+      - name: Attest archive build provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ runner.temp }}/release-archives/*.tar.gz
+
+      - name: Attest archive SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ runner.temp }}/release-archives/*.tar.gz
+          sbom-path: ${{ runner.temp }}/release-sbom/d2.spdx.json
+
+      - name: Attest checksum manifest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ runner.temp }}/release-archives/SHA256SUMS

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -79,7 +79,8 @@ requires `THIRD_PARTY_NOTICES.txt` from its pinned release archive. Re-run only 
 job: the workflow's Actions artifact is immutable within a run, and a full rerun fails
 closed instead of replacing it.
 
-Every release includes `SHA256SUMS`. To verify archive provenance and its checksum:
+Every release produced by this workflow includes `SHA256SUMS`. To verify archive
+provenance and its checksum:
 
 ```sh
 gh attestation verify d2-v0.0.0-linux-amd64.tar.gz --repo d2lang/d2

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -50,25 +50,41 @@ it depends on from ../sub/lib.
   Run with --help for usage.
 
 The first release-script run must leave the GitHub release as a draft. Pushing its tag
-starts the `Windows MSI` workflow, which waits for all six release archives and pins the
-exact Windows amd64 archive, builds the installer on GitHub's `windows-2022` runner,
-verifies its metadata and installed contents, and uploads
-`d2-<version>-windows-amd64.msi` to that same draft.
+starts two workflows:
+
+- `Release archives` builds all six archives twice from the exact tag commit with the
+  pinned Go toolchain and compares their SHA-256 digests. It strips and verifies each
+  binary, normalizes every archive, enforces size budgets, runs each archive on a native
+  GitHub-hosted runner, and generates signed build-provenance and SBOM attestations. The
+  release script waits for that exact successful workflow run, downloads its immutable
+  archive artifact, verifies `SHA256SUMS`, and uploads those same bytes to the draft.
+- `Windows MSI` waits for the six uploaded archives and pins the exact Windows amd64
+  archive, builds the installer on GitHub's `windows-2022` runner, verifies its metadata
+  and installed contents, and uploads `d2-<version>-windows-amd64.msi` to that same draft.
 
 Do not publish the release until the workflow is green and the MSI is present. Review and
 merge the release PR, then publish the draft on GitHub. The D2 wrapper rejects
 `release.sh --publish`, and it refuses any release-builder rerun after the MSI is attached.
 This prevents the shared helper from publishing while the asynchronous build is running or
-moving the tag after an MSI was built from it.
+moving the tag after an MSI was built from it. `release.sh --rebuild` is intentionally
+unsupported for CI-built archives. Re-run only failed jobs in the existing workflow run;
+a full rerun fails closed instead of replacing its immutable Actions artifacts.
 It also rejects a legacy local MSI in the version's build directory so the shared asset
 uploader cannot attach an unverified installer.
 
-The workflow can also be dispatched manually with release upload disabled. `v0.7.1` is
+The MSI workflow can also be dispatched manually with release upload disabled. `v0.7.1` is
 the continuity fixture; because that release predates notices in the archives, only this
 non-uploading fixture build packages the current notices file. Every production MSI
 requires `THIRD_PARTY_NOTICES.txt` from its pinned release archive. Re-run only a failed
 job: the workflow's Actions artifact is immutable within a run, and a full rerun fails
 closed instead of replacing it.
+
+Every release includes `SHA256SUMS`. To verify archive provenance and its checksum:
+
+```sh
+gh attestation verify d2-v0.0.0-linux-amd64.tar.gz --repo d2lang/d2
+sha256sum --check --ignore-missing SHA256SUMS
+```
 
 The MSI remains unsigned. Authenticode signing is tracked separately in
 [issue #1078](https://github.com/d2lang/d2/issues/1078).
@@ -86,7 +102,9 @@ manually dispatched builds fail closed when the variable is absent.
 - ./build.sh builds the release archives for each platform into ./build/<VERSION>/*.tar.gz
   Run with --help for usage.
 
-Use `--host-only` to build only the release for the host's `$OS-$ARCH` pair.
+Use `--host-only` to build only the release for the host's `$OS-$ARCH` pair. Local
+development invocations still build locally. The production release path instead downloads
+the exact archives produced by the tag-triggered `Release archives` workflow.
 
 ### Docker image helper
 

--- a/ci/release/_build.sh
+++ b/ci/release/_build.sh
@@ -14,16 +14,67 @@ sh_c VERSION="$VERSION" ./ci/release/template/README.md.sh \> "'$HW_BUILD_DIR/RE
 
 ensure_goos
 ensure_goarch
-sh_c mkdir -p "$HW_BUILD_DIR/bin"
-sh_c GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 go build -trimpath \
-  -ldflags "'-X github.com/d2lang/d2/lib/version.Version=$VERSION'" \
-  -o "$HW_BUILD_DIR/bin/d2" .
-
-if [ "$GOOS" = windows ]; then
-  sh_c mv "$HW_BUILD_DIR/bin/d2" "$HW_BUILD_DIR/bin/d2.exe"
+PINNED_GO_VERSION=go$(awk '$1 == "go" { print $2; exit }' go.mod)
+ACTUAL_GO_VERSION=$(GOTOOLCHAIN=local go env GOVERSION)
+if { [ -n "${RELEASE-}" ] || [ -n "${RELEASE_BUILD_IN_CI-}" ]; } &&
+  [ "$ACTUAL_GO_VERSION" != "$PINNED_GO_VERSION" ]; then
+  echo >&2 "release builds require $PINNED_GO_VERSION, got $ACTUAL_GO_VERSION"
+  exit 1
+fi
+EXPECTED_GO_VERSION=$ACTUAL_GO_VERSION
+REVISION=$(git rev-parse HEAD)
+SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)
+VCS_MODIFIED=false
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  VCS_MODIFIED=true
+fi
+if [ -n "${RELEASE-}" ] && [ "$VCS_MODIFIED" = true ]; then
+  echo >&2 "release builds require a clean tracked worktree"
+  exit 1
+fi
+if [ -z "${DRY_RUN-}" ] && { [ -z "${RELEASE_TOOL-}" ] || [ ! -x "$RELEASE_TOOL" ]; }; then
+  echo >&2 "RELEASE_TOOL must name the host release-tool binary"
+  exit 1
 fi
 
+GOTOOLCHAIN=local
+GOWORK=off
+GOFLAGS=
+GOEXPERIMENT=
+CGO_ENABLED=0
+unset GOAMD64 GOARM64
+case "$GOARCH" in
+  amd64) GOAMD64=v1; export GOAMD64 ;;
+  arm64) GOARM64=v8.0; export GOARM64 ;;
+esac
+export GOTOOLCHAIN GOWORK GOFLAGS GOEXPERIMENT CGO_ENABLED
+
+sh_c mkdir -p "$HW_BUILD_DIR/bin"
+BINARY="$HW_BUILD_DIR/bin/d2"
+if [ "$GOOS" = windows ]; then BINARY=$BINARY.exe; fi
+sh_c GOOS="$GOOS" GOARCH="$GOARCH" go build -mod=readonly -pgo=off \
+  -buildvcs=true -trimpath \
+  -ldflags "'-s -w -X github.com/d2lang/d2/lib/version.Version=$VERSION'" \
+  -o "$BINARY" .
+
+MAX_RELEASE_BINARY_BYTES=${MAX_RELEASE_BINARY_BYTES:-40000000}
+MAX_RELEASE_ARCHIVE_BYTES=${MAX_RELEASE_ARCHIVE_BYTES:-18000000}
+sh_c "$RELEASE_TOOL" verify-binary \
+  --path "'$BINARY'" \
+  --goos "$GOOS" \
+  --goarch "$GOARCH" \
+  --go-version "$EXPECTED_GO_VERSION" \
+  --revision "$REVISION" \
+  --vcs-modified "$VCS_MODIFIED" \
+  --max-size "$MAX_RELEASE_BINARY_BYTES"
+
 ARCHIVE=$PWD/$ARCHIVE
-cd "$(dirname "$HW_BUILD_DIR")"
-sh_c tar -czf "$ARCHIVE" "$(basename "$HW_BUILD_DIR")"
-cd ->/dev/null
+sh_c "$RELEASE_TOOL" archive \
+  --root "'$HW_BUILD_DIR'" \
+  --output "'$ARCHIVE'" \
+  --epoch "$SOURCE_DATE_EPOCH"
+sh_c "$RELEASE_TOOL" verify-archive \
+  --path "'$ARCHIVE'" \
+  --root "$(basename "$HW_BUILD_DIR")" \
+  --epoch "$SOURCE_DATE_EPOCH" \
+  --max-size "$MAX_RELEASE_ARCHIVE_BYTES"

--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -7,6 +7,10 @@ cd -- "$(dirname "$0")/../sub/lib"
 . ./release.sh
 cd - >/dev/null
 
+if [ -z "${D2_RELEASE_CHECKSUM-}" ]; then
+  . "$(dirname "$0")/checksum.sh"
+fi
+
 help() {
   arg0="$0"
   if [ "$0" = sh ]; then
@@ -312,7 +316,8 @@ install_d2_standalone() {
 
   ensure_version
   asset_url="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
-  fetch_gh "$asset_url" "$CACHE_DIR/$ARCHIVE" 'application/octet-stream'
+  fetch_verified_release_asset \
+    "$REPO" "$VERSION" "$ARCHIVE" "$asset_url" "$CACHE_DIR/$ARCHIVE"
 
   ensure_prefix_sh_c
   "$sh_c" mkdir -p "'$INSTALL_DIR'"

--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -316,7 +316,7 @@ install_d2_standalone() {
 
   ensure_version
   asset_url="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
-  fetch_verified_release_asset \
+  fetch_release_asset \
     "$REPO" "$VERSION" "$ARCHIVE" "$asset_url" "$CACHE_DIR/$ARCHIVE"
 
   ensure_prefix_sh_c

--- a/ci/release/build.sh
+++ b/ci/release/build.sh
@@ -29,8 +29,8 @@ Flags:
   so in a script you can read from stdout to get the path to the release archive.
 
 --run=regex
-  Use to run only the OS-ARCH jobs that match the given regex. e.g. --run=linux only runs
-  the linux jobs. --run=linux-amd64 only runs the linux-amd64 job.
+  Use to run only the OS/ARCH jobs that match the given regex. e.g. --run=linux only runs
+  the linux jobs. --run=linux/amd64 only runs the linux-amd64 job.
 
 --version vX.X.X
   Use to overwrite the version detected from git.
@@ -100,13 +100,19 @@ main() {
 
   VERSION=${VERSION:-$(git_describe_ref)}
   BUILD_DIR=ci/release/build/$VERSION
+  ensure_release_tool
   sh_c mkdir -p "$BUILD_DIR"
   sh_c rm -f ci/release/build/latest
   sh_c ln -s "$VERSION" ci/release/build/latest
+  if [ -n "${RELEASE-}" ] && [ -z "${RELEASE_BUILD_IN_CI-}" ]; then
+    download_ci_build
+    return
+  fi
   if [ -n "${HOST_ONLY-}" ]; then
     ensure_os
     ensure_arch
     runjob "$OS/$ARCH" "build"
+    write_checksums
 
     if [ -n "${INSTALL-}" ]; then
       sh_c make -sC "ci/release/build/$VERSION/$OS-$ARCH/d2-$VERSION" install
@@ -116,13 +122,146 @@ main() {
     return 0
   fi
 
-  runjob linux/amd64 'OS=linux ARCH=amd64 build' &
-  runjob linux/arm64 'OS=linux ARCH=arm64 build' &
-  runjob macos/amd64 'OS=macos ARCH=amd64 build' &
-  runjob macos/arm64 'OS=macos ARCH=arm64 build' &
-  runjob windows/amd64 'OS=windows ARCH=amd64 build' &
-  runjob windows/arm64 'OS=windows ARCH=arm64 build' &
-  waitjobs
+  if [ -n "${RELEASE_BUILD_SERIAL-}" ]; then
+    runjob linux/amd64 'OS=linux ARCH=amd64 build'
+    runjob linux/arm64 'OS=linux ARCH=arm64 build'
+    runjob macos/amd64 'OS=macos ARCH=amd64 build'
+    runjob macos/arm64 'OS=macos ARCH=arm64 build'
+    runjob windows/amd64 'OS=windows ARCH=amd64 build'
+    runjob windows/arm64 'OS=windows ARCH=arm64 build'
+  else
+    runjob linux/amd64 'OS=linux ARCH=amd64 build' &
+    runjob linux/arm64 'OS=linux ARCH=arm64 build' &
+    runjob macos/amd64 'OS=macos ARCH=amd64 build' &
+    runjob macos/arm64 'OS=macos ARCH=arm64 build' &
+    runjob windows/amd64 'OS=windows ARCH=amd64 build' &
+    runjob windows/arm64 'OS=windows ARCH=arm64 build' &
+    waitjobs
+  fi
+  write_checksums
+}
+
+ensure_release_tool() {
+  PINNED_GO_VERSION=go$(awk '$1 == "go" { print $2; exit }' go.mod)
+  ACTUAL_GO_VERSION=$(GOTOOLCHAIN=local go env GOVERSION)
+  if { [ -n "${RELEASE-}" ] || [ -n "${RELEASE_BUILD_IN_CI-}" ]; } &&
+    [ "$ACTUAL_GO_VERSION" != "$PINNED_GO_VERSION" ]; then
+    echo >&2 "release builds require $PINNED_GO_VERSION, got $ACTUAL_GO_VERSION"
+    return 1
+  fi
+  RELEASE_TOOL=$(mktempd)/release-tool
+  export RELEASE_TOOL
+  sh_c GOTOOLCHAIN=local GOWORK=off GOFLAGS= GOEXPERIMENT= \
+    go build -mod=readonly -pgo=off -trimpath \
+    -o "'$RELEASE_TOOL'" ./ci/release/releasetool
+}
+
+write_checksums() {
+  if [ -n "${DRY_RUN-}" ]; then
+    sh_c "$RELEASE_TOOL" checksums \
+      --output "'$BUILD_DIR/SHA256SUMS'" \
+      "'$BUILD_DIR/d2-$VERSION-<os>-<arch>.tar.gz'"
+    return
+  fi
+  set -- "$BUILD_DIR"/d2-"$VERSION"-*.tar.gz
+  if [ ! -e "$1" ]; then
+    echo >&2 "no release archives were built for $VERSION"
+    return 1
+  fi
+  EXPECTED_COUNT=$#
+  if [ -n "${RELEASE_BUILD_IN_CI-}" ] && [ "$EXPECTED_COUNT" -ne 6 ]; then
+    echo >&2 "CI release builds require six archives, got $EXPECTED_COUNT"
+    return 1
+  fi
+  sh_c "$RELEASE_TOOL" checksums \
+    --output "'$BUILD_DIR/SHA256SUMS'" \
+    "$@"
+  sh_c "$RELEASE_TOOL" verify-checksums \
+    --manifest "'$BUILD_DIR/SHA256SUMS'" \
+    --directory "'$BUILD_DIR'" \
+    --expected-count "$EXPECTED_COUNT"
+}
+
+download_ci_build() {
+  if [ -n "${REBUILD-}" ]; then
+    echo >&2 "release workflow artifacts are immutable and cannot be rebuilt locally"
+    echo >&2 "rerun failed jobs in the existing Release archives workflow instead"
+    return 1
+  fi
+  if [ -n "${DRY_RUN-}" ]; then
+    sh_c gh run download RELEASE_RUN_ID --name release-archives --dir "'$BUILD_DIR'"
+    return
+  fi
+
+  REPOSITORY=$(gh_repo)
+  TAG_COMMIT=$(git rev-parse "$VERSION^{commit}")
+  RUN_ID=
+  RUN_URL=
+  ATTEMPT=1
+  while [ "$ATTEMPT" -le 360 ]; do
+    RUNS=$(gh run list \
+      --repo "$REPOSITORY" \
+      --workflow release-archives.yml \
+      --commit "$TAG_COMMIT" \
+      --event push \
+      --limit 20 \
+      --json databaseId,status,conclusion,headBranch,headSha,createdAt,url)
+    RUN=$(printf '%s' "$RUNS" | jq -c \
+      --arg version "$VERSION" \
+      --arg commit "$TAG_COMMIT" \
+      '[.[] | select(.headBranch == $version and .headSha == $commit)] |
+       sort_by(.createdAt) | last // empty')
+    if [ -n "$RUN" ]; then
+      RUN_ID=$(printf '%s' "$RUN" | jq -r .databaseId)
+      RUN_URL=$(printf '%s' "$RUN" | jq -r .url)
+      RUN_STATUS=$(printf '%s' "$RUN" | jq -r .status)
+      RUN_CONCLUSION=$(printf '%s' "$RUN" | jq -r '.conclusion // ""')
+      if [ "$RUN_STATUS" = completed ]; then
+        if [ "$RUN_CONCLUSION" != success ]; then
+          echo >&2 "Release archives workflow failed: $RUN_URL"
+          echo >&2 "rerun its failed jobs, then rerun the release command"
+          return 1
+        fi
+        break
+      fi
+    fi
+    if [ "$ATTEMPT" -eq 360 ]; then
+      echo >&2 "timed out waiting for the Release archives workflow for $VERSION"
+      echo >&2 "last matching workflow: ${RUN_URL:-none}"
+      return 1
+    fi
+    sleep 10
+    ATTEMPT=$((ATTEMPT + 1))
+  done
+
+  DOWNLOAD_DIR=$(mktempd)/release-archives
+  sh_c mkdir -p "$DOWNLOAD_DIR"
+  sh_c gh run download "$RUN_ID" \
+    --repo "$REPOSITORY" \
+    --name release-archives \
+    --dir "'$DOWNLOAD_DIR'"
+  "$RELEASE_TOOL" verify-checksums \
+    --manifest "$DOWNLOAD_DIR/SHA256SUMS" \
+    --directory "$DOWNLOAD_DIR" \
+    --expected-count 6
+  for TARGET in \
+    linux-amd64 linux-arm64 \
+    macos-amd64 macos-arm64 \
+    windows-amd64 windows-arm64; do
+    if [ ! -f "$DOWNLOAD_DIR/d2-$VERSION-$TARGET.tar.gz" ]; then
+      echo >&2 "release workflow artifact is missing d2-$VERSION-$TARGET.tar.gz"
+      return 1
+    fi
+  done
+  FILE_COUNT=$(find "$DOWNLOAD_DIR" -maxdepth 1 -type f | wc -l | tr -d ' ')
+  if [ "$FILE_COUNT" -ne 7 ]; then
+    echo >&2 "release workflow artifact has $FILE_COUNT files, expected seven"
+    return 1
+  fi
+
+  sh_c rm -f "$BUILD_DIR"/d2-"$VERSION"-*.tar.gz "$BUILD_DIR/SHA256SUMS"
+  sh_c cp "$DOWNLOAD_DIR"/d2-"$VERSION"-*.tar.gz "$DOWNLOAD_DIR/SHA256SUMS" "$BUILD_DIR/"
+  log "downloaded verified release archives from $RUN_URL"
 }
 
 build() {

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Improvements 🧹
 
+- releases: strip native binaries, build and smoke-test all six archives in CI, produce reproducible archives with checksums, signed provenance, and SBOM attestations, and verify standalone downloads before extraction
 - plugins: make render post-processing optional and deprecate it for removal after one protocol compatibility cycle; legacy external `postprocess` commands remain supported during the transition
 - api: deprecate legacy layout-feature constants, raw-WASM ELK/object-order bridges, unused public wrappers, and test-only comparison, validation, and logging helpers; compatibility entry points remain callable for one release while in-repository callers use supported or internal replacements
 - maintenance: update the Go toolchain to 1.27.0 and refresh Go, d2.js, CI, release dependencies, and compression-sensitive snapshots

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,7 +4,7 @@
 
 #### Improvements 🧹
 
-- releases: strip native binaries, build and smoke-test all six archives in CI, produce reproducible archives with checksums, signed provenance, and SBOM attestations, and verify standalone downloads before extraction
+- releases: strip native binaries, build and smoke-test all six archives in CI, produce reproducible archives with checksums, signed provenance, and SBOM attestations, and verify standalone downloads when GitHub provides a digest
 - plugins: make render post-processing optional and deprecate it for removal after one protocol compatibility cycle; legacy external `postprocess` commands remain supported during the transition
 - api: deprecate legacy layout-feature constants, raw-WASM ELK/object-order bridges, unused public wrappers, and test-only comparison, validation, and logging helpers; compatibility entry points remain callable for one release while in-repository callers use supported or internal replacements
 - maintenance: update the Go toolchain to 1.27.0 and refresh Go, d2.js, CI, release dependencies, and compression-sensitive snapshots

--- a/ci/release/checksum.sh
+++ b/ci/release/checksum.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+if [ -n "${D2_RELEASE_CHECKSUM-}" ]; then
+  return 0
+fi
+D2_RELEASE_CHECKSUM=1
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{ print $NF }'
+  else
+    echo >&2 "sha256sum, shasum, or openssl is required to verify release downloads"
+    return 1
+  fi
+}
+
+release_asset_digest_from_json() {
+  ASSET_NAME=$1
+  awk -v asset="$ASSET_NAME" '
+    /^[[:space:]]*"name":[[:space:]]*/ {
+      value = $0
+      sub(/^[^:]*:[[:space:]]*"/, "", value)
+      sub(/"[,[:space:]]*$/, "", value)
+      found = value == asset
+      next
+    }
+    found && /^[[:space:]]*"digest":[[:space:]]*/ {
+      value = $0
+      original = value
+      sub(/^[^:]*:[[:space:]]*"sha256:/, "", value)
+      if (value == original) {
+        exit
+      }
+      sub(/"[,[:space:]]*$/, "", value)
+      print value
+      exit
+    }
+  '
+}
+
+release_asset_sha256() {
+  REPOSITORY=$1
+  RELEASE_VERSION=$2
+  ASSET_NAME=$3
+  RELEASE_INFO=$(mktempd)/release.json
+  RELEASE_INFO_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE_VERSION"
+  DRY_RUN= fetch_gh "$RELEASE_INFO_URL" "$RELEASE_INFO" 'application/vnd.github+json'
+  EXPECTED_SHA256=$(release_asset_digest_from_json "$ASSET_NAME" <"$RELEASE_INFO")
+  EXPECTED_SHA256=$(printf '%s' "$EXPECTED_SHA256" | tr '[:upper:]' '[:lower:]')
+  if ! printf '%s\n' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo >&2 "$ASSET_NAME does not have a valid GitHub SHA-256 digest"
+    return 1
+  fi
+  printf '%s\n' "$EXPECTED_SHA256"
+}
+
+verify_sha256() {
+  FILE=$1
+  EXPECTED_SHA256=$2
+  ACTUAL_SHA256=$(sha256_file "$FILE")
+  ACTUAL_SHA256=$(printf '%s' "$ACTUAL_SHA256" | tr '[:upper:]' '[:lower:]')
+  if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo >&2 "$FILE has SHA-256 $ACTUAL_SHA256, expected $EXPECTED_SHA256"
+    return 1
+  fi
+}
+
+fetch_verified_release_asset() {
+  REPOSITORY=$1
+  RELEASE_VERSION=$2
+  ASSET_NAME=$3
+  ASSET_URL=$4
+  DESTINATION=$5
+
+  if [ -n "${DRY_RUN-}" ]; then
+    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest"
+    return
+  fi
+
+  EXPECTED_SHA256=$(release_asset_sha256 "$REPOSITORY" "$RELEASE_VERSION" "$ASSET_NAME")
+  if [ -e "$DESTINATION" ]; then
+    if verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"; then
+      log "reusing verified $DESTINATION"
+      return
+    fi
+    warn "discarding cached $ASSET_NAME after checksum verification failed"
+    rm -f "$DESTINATION"
+  fi
+  fetch_gh "$ASSET_URL" "$DESTINATION" 'application/octet-stream'
+  verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"
+  log "verified $ASSET_NAME ($EXPECTED_SHA256)"
+}

--- a/ci/release/checksum.sh
+++ b/ci/release/checksum.sh
@@ -29,6 +29,10 @@ release_asset_digest_from_json() {
     }
     found && /^[[:space:]]*"digest":[[:space:]]*/ {
       value = $0
+      if (value ~ /^[^:]*:[[:space:]]*null[,[:space:]]*$/) {
+        print "unavailable"
+        exit
+      }
       original = value
       sub(/^[^:]*:[[:space:]]*"sha256:/, "", value)
       if (value == original) {
@@ -49,6 +53,9 @@ release_asset_sha256() {
   RELEASE_INFO_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE_VERSION"
   DRY_RUN= fetch_gh "$RELEASE_INFO_URL" "$RELEASE_INFO" 'application/vnd.github+json'
   EXPECTED_SHA256=$(release_asset_digest_from_json "$ASSET_NAME" <"$RELEASE_INFO")
+  if [ "$EXPECTED_SHA256" = unavailable ]; then
+    return 0
+  fi
   EXPECTED_SHA256=$(printf '%s' "$EXPECTED_SHA256" | tr '[:upper:]' '[:lower:]')
   if ! printf '%s\n' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
     echo >&2 "$ASSET_NAME does not have a valid GitHub SHA-256 digest"
@@ -68,7 +75,7 @@ verify_sha256() {
   fi
 }
 
-fetch_verified_release_asset() {
+fetch_release_asset() {
   REPOSITORY=$1
   RELEASE_VERSION=$2
   ASSET_NAME=$3
@@ -76,11 +83,16 @@ fetch_verified_release_asset() {
   DESTINATION=$5
 
   if [ -n "${DRY_RUN-}" ]; then
-    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest"
+    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest when available"
     return
   fi
 
   EXPECTED_SHA256=$(release_asset_sha256 "$REPOSITORY" "$RELEASE_VERSION" "$ASSET_NAME")
+  if [ -z "$EXPECTED_SHA256" ]; then
+    warn "GitHub does not provide a SHA-256 digest for $ASSET_NAME; continuing without checksum verification for compatibility with legacy releases"
+    fetch_gh "$ASSET_URL" "$DESTINATION" 'application/octet-stream'
+    return
+  fi
   if [ -e "$DESTINATION" ]; then
     if verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"; then
       log "reusing verified $DESTINATION"

--- a/ci/release/checksum_test.go
+++ b/ci/release/checksum_test.go
@@ -1,0 +1,84 @@
+package release_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseAssetDigestParser(t *testing.T) {
+	t.Parallel()
+	metadata := `{
+  "name": "v1.2.3",
+  "assets": [
+    {
+      "name": "other.tar.gz",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "name": "d2-v1.2.3-linux-amd64.tar.gz",
+      "uploader": {
+        "login": "example"
+      },
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ]
+}`
+	got := runChecksumFunction(t, metadata, "release_asset_digest_from_json", "d2-v1.2.3-linux-amd64.tar.gz")
+	want := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if got != want {
+		t.Fatalf("digest = %q, want %q", got, want)
+	}
+}
+
+func TestReleaseAssetDigestParserRejectsMissingDigest(t *testing.T) {
+	t.Parallel()
+	metadata := `{
+  "assets": [
+    {
+      "name": "d2-v1.2.3-linux-amd64.tar.gz",
+      "digest": null
+    }
+  ]
+}`
+	if got := runChecksumFunction(t, metadata, "release_asset_digest_from_json", "d2-v1.2.3-linux-amd64.tar.gz"); got != "" {
+		t.Fatalf("digest = %q, want empty", got)
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	t.Parallel()
+	file := filepath.Join(t.TempDir(), "asset")
+	if err := os.WriteFile(file, []byte("d2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const digest = "c66169a0e4913133cbebf50c3f71dabef7540b9a636cde9c80be6e39f7113fa5"
+	command := `. "$1"; verify_sha256 "$2" "$3"`
+	cmd := exec.Command("sh", "-c", command, "sh", "./checksum.sh", file, digest)
+	cmd.Dir = "."
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("verify_sha256 failed: %v\n%s", err, output)
+	}
+	cmd = exec.Command("sh", "-c", command, "sh", "./checksum.sh", file, strings.Repeat("0", 64))
+	cmd.Dir = "."
+	if err := cmd.Run(); err == nil {
+		t.Fatal("verify_sha256 accepted an incorrect digest")
+	}
+}
+
+func runChecksumFunction(t *testing.T, input, function string, args ...string) string {
+	t.Helper()
+	command := `. "$1"; shift; function=$1; shift; "$function" "$@"`
+	cmdArgs := []string{"-c", command, "sh", "./checksum.sh", function}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.Command("sh", cmdArgs...)
+	cmd.Dir = "."
+	cmd.Stdin = strings.NewReader(input)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", function, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/ci/release/checksum_test.go
+++ b/ci/release/checksum_test.go
@@ -33,7 +33,7 @@ func TestReleaseAssetDigestParser(t *testing.T) {
 	}
 }
 
-func TestReleaseAssetDigestParserRejectsMissingDigest(t *testing.T) {
+func TestReleaseAssetDigestParserReportsUnavailableDigest(t *testing.T) {
 	t.Parallel()
 	metadata := `{
   "assets": [
@@ -43,8 +43,60 @@ func TestReleaseAssetDigestParserRejectsMissingDigest(t *testing.T) {
     }
   ]
 }`
-	if got := runChecksumFunction(t, metadata, "release_asset_digest_from_json", "d2-v1.2.3-linux-amd64.tar.gz"); got != "" {
-		t.Fatalf("digest = %q, want empty", got)
+	if got := runChecksumFunction(t, metadata, "release_asset_digest_from_json", "d2-v1.2.3-linux-amd64.tar.gz"); got != "unavailable" {
+		t.Fatalf("digest = %q, want unavailable", got)
+	}
+}
+
+func TestFetchReleaseAssetAllowsLegacyReleaseWithoutDigest(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	metadataPath := filepath.Join(directory, "metadata.json")
+	metadata := `{
+  "assets": [
+    {
+      "name": "d2-v0.7.0-linux-amd64.tar.gz",
+      "digest": null
+    }
+  ]
+}`
+	if err := os.WriteFile(metadataPath, []byte(metadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(directory, "archive.tar.gz")
+	const payload = "legacy archive"
+	command := `
+. "$1"
+metadata=$2
+payload=$3
+destination=$4
+fixture_dir=$(dirname "$metadata")
+mktempd() { printf '%s\n' "$fixture_dir"; }
+fetch_gh() {
+  case "$1" in
+    https://api.github.com/*) cp "$metadata" "$2" ;;
+    *) printf '%s' "$payload" >"$2" ;;
+  esac
+}
+warn() { printf 'warning: %s\n' "$*" >&2; }
+log() { :; }
+fetch_release_asset d2lang/d2 v0.7.0 d2-v0.7.0-linux-amd64.tar.gz https://example.invalid/archive "$destination"
+`
+	cmd := exec.Command("sh", "-c", command, "sh", "./checksum.sh", metadataPath, payload, destination)
+	cmd.Dir = "."
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fetch_release_asset failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "continuing without checksum verification") {
+		t.Fatalf("fetch_release_asset did not warn:\n%s", output)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Fatalf("archive = %q, want %q", got, payload)
 	}
 }
 

--- a/ci/release/gen_install.sh
+++ b/ci/release/gen_install.sh
@@ -18,6 +18,7 @@ set -eu
 # - ./ci/sub/lib/log.sh
 # - ./ci/sub/lib/flag.sh
 # - ./ci/sub/lib/release.sh
+# - ./ci/release/checksum.sh
 # - ./ci/release/_install.sh
 #
 # The last of which implements the installation logic.
@@ -35,6 +36,7 @@ sh_c cat \
   ./ci/sub/lib/log.sh \
   ./ci/sub/lib/flag.sh \
   ./ci/sub/lib/release.sh \
+  ./ci/release/checksum.sh \
   \| sed "-e'/^\. /d'" \>\> ./install.sh
 sh_c cat ./ci/release/_install.sh \
   \| sed -n "'/cd -- \"\$(dirname/,/cd -/!p'" \>\> install.sh

--- a/ci/release/releasetool/main.go
+++ b/ci/release/releasetool/main.go
@@ -1,0 +1,819 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"debug/buildinfo"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mainModule = "github.com/d2lang/d2"
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "release-tool:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("expected archive, checksums, sbom, verify-checksums, verify-binary, or verify-archive")
+	}
+	switch args[0] {
+	case "archive":
+		return archiveCommand(args[1:])
+	case "checksums":
+		return checksumsCommand(args[1:])
+	case "sbom":
+		return sbomCommand(args[1:])
+	case "verify-checksums":
+		return verifyChecksumsCommand(args[1:])
+	case "verify-binary":
+		return verifyBinaryCommand(args[1:])
+	case "verify-archive":
+		return verifyArchiveCommand(args[1:])
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func sbomCommand(args []string) error {
+	fs := flag.NewFlagSet("sbom", flag.ContinueOnError)
+	binary := fs.String("binary", "", "release binary to inspect")
+	output := fs.String("output", "", "output SPDX JSON path")
+	name := fs.String("name", "", "document name")
+	version := fs.String("version", "", "release version")
+	epoch := fs.Int64("epoch", -1, "creation Unix timestamp")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *binary == "" || *output == "" || *name == "" || *version == "" || *epoch < 0 {
+		return errors.New("sbom requires --binary, --output, --name, --version, and a non-negative --epoch")
+	}
+	return writeSBOM(*binary, *output, *name, *version, time.Unix(*epoch, 0).UTC())
+}
+
+func archiveCommand(args []string) error {
+	fs := flag.NewFlagSet("archive", flag.ContinueOnError)
+	root := fs.String("root", "", "release directory to archive")
+	output := fs.String("output", "", "output .tar.gz path")
+	epoch := fs.Int64("epoch", -1, "normalized Unix timestamp")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *root == "" || *output == "" || *epoch < 0 {
+		return errors.New("archive requires --root, --output, and a non-negative --epoch")
+	}
+	return writeArchive(*root, *output, time.Unix(*epoch, 0).UTC())
+}
+
+func checksumsCommand(args []string) error {
+	fs := flag.NewFlagSet("checksums", flag.ContinueOnError)
+	output := fs.String("output", "", "output checksum manifest")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *output == "" || fs.NArg() == 0 {
+		return errors.New("checksums requires --output and at least one file")
+	}
+	return writeChecksums(*output, fs.Args())
+}
+
+func verifyChecksumsCommand(args []string) error {
+	fs := flag.NewFlagSet("verify-checksums", flag.ContinueOnError)
+	manifest := fs.String("manifest", "", "checksum manifest")
+	directory := fs.String("directory", "", "directory containing manifest subjects")
+	expectedCount := fs.Int("expected-count", -1, "required number of manifest entries")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *manifest == "" || *directory == "" {
+		return errors.New("verify-checksums requires --manifest and --directory")
+	}
+	return verifyChecksums(*manifest, *directory, *expectedCount)
+}
+
+func verifyBinaryCommand(args []string) error {
+	fs := flag.NewFlagSet("verify-binary", flag.ContinueOnError)
+	binary := fs.String("path", "", "binary path")
+	goos := fs.String("goos", "", "expected GOOS")
+	goarch := fs.String("goarch", "", "expected GOARCH")
+	goVersion := fs.String("go-version", "", "expected Go toolchain version")
+	revision := fs.String("revision", "", "expected VCS revision")
+	vcsModified := fs.String("vcs-modified", "false", "expected vcs.modified setting")
+	maxSize := fs.Int64("max-size", 0, "maximum binary size in bytes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *binary == "" || *goos == "" || *goarch == "" || *goVersion == "" || *revision == "" || *maxSize <= 0 {
+		return errors.New("verify-binary requires --path, --goos, --goarch, --go-version, --revision, and a positive --max-size")
+	}
+	if *vcsModified != "true" && *vcsModified != "false" {
+		return errors.New("verify-binary --vcs-modified must be true or false")
+	}
+	return verifyBinary(*binary, *goos, *goarch, *goVersion, *revision, *vcsModified, *maxSize)
+}
+
+func verifyArchiveCommand(args []string) error {
+	fs := flag.NewFlagSet("verify-archive", flag.ContinueOnError)
+	archive := fs.String("path", "", "archive path")
+	root := fs.String("root", "", "expected top-level directory")
+	epoch := fs.Int64("epoch", -1, "expected normalized Unix timestamp")
+	maxSize := fs.Int64("max-size", 0, "maximum archive size in bytes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *archive == "" || *root == "" || *epoch < 0 || *maxSize <= 0 {
+		return errors.New("verify-archive requires --path, --root, a non-negative --epoch, and a positive --max-size")
+	}
+	return verifyArchive(*archive, *root, time.Unix(*epoch, 0).UTC(), *maxSize)
+}
+
+type archiveEntry struct {
+	fullPath string
+	name     string
+	info     fs.FileInfo
+	link     string
+}
+
+func writeArchive(root, output string, stamp time.Time) (retErr error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	output, err = filepath.Abs(output)
+	if err != nil {
+		return err
+	}
+	rootInfo, err := os.Stat(root)
+	if err != nil {
+		return err
+	}
+	if !rootInfo.IsDir() {
+		return fmt.Errorf("archive root %q is not a directory", root)
+	}
+	rootName := filepath.Base(root)
+	if rootName == "." || rootName == string(filepath.Separator) || rootName == "" {
+		return fmt.Errorf("unsafe archive root %q", root)
+	}
+	if rel, err := filepath.Rel(root, output); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New("archive output must not be inside its input tree")
+	}
+
+	var entries []archiveEntry
+	err = filepath.WalkDir(root, func(fullPath string, dirEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := dirEntry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&(os.ModeDevice|os.ModeNamedPipe|os.ModeSocket) != 0 {
+			return fmt.Errorf("unsupported file type in release archive: %s", fullPath)
+		}
+		rel, err := filepath.Rel(filepath.Dir(root), fullPath)
+		if err != nil {
+			return err
+		}
+		name := filepath.ToSlash(rel)
+		if strings.ContainsAny(name, "\\\x00") {
+			return fmt.Errorf("unsafe archive path %q", name)
+		}
+		var link string
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err = os.Readlink(fullPath)
+			if err != nil {
+				return err
+			}
+			link = filepath.ToSlash(link)
+			if err := validateSymlink(name, link, rootName); err != nil {
+				return err
+			}
+		}
+		entries = append(entries, archiveEntry{fullPath: fullPath, name: name, info: info, link: link})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(output), "."+filepath.Base(output)+".*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if retErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	zw, err := gzip.NewWriterLevel(tmp, gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+	zw.Header.ModTime = stamp
+	zw.Header.OS = 255
+	tw := tar.NewWriter(zw)
+	for _, entry := range entries {
+		header, err := tar.FileInfoHeader(entry.info, entry.link)
+		if err != nil {
+			return err
+		}
+		header.Name = entry.name
+		header.Uid = 0
+		header.Gid = 0
+		header.Uname = ""
+		header.Gname = ""
+		header.ModTime = stamp
+		header.AccessTime = time.Time{}
+		header.ChangeTime = time.Time{}
+		header.Format = tar.FormatUSTAR
+		switch {
+		case entry.info.IsDir():
+			header.Name = strings.TrimSuffix(header.Name, "/") + "/"
+			header.Mode = 0o755
+		case entry.info.Mode()&os.ModeSymlink != 0:
+			header.Mode = 0o777
+		case entry.info.Mode().IsRegular():
+			header.Mode = 0o644
+			if entry.info.Mode().Perm()&0o111 != 0 {
+				header.Mode = 0o755
+			}
+		default:
+			return fmt.Errorf("unsupported file type in release archive: %s", entry.fullPath)
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if !entry.info.Mode().IsRegular() {
+			continue
+		}
+		file, err := os.Open(entry.fullPath)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	if err := os.Remove(output); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Rename(tmpName, output); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeChecksums(output string, files []string) error {
+	type subject struct {
+		path string
+		name string
+	}
+	subjects := make([]subject, 0, len(files))
+	seen := map[string]bool{}
+	for _, file := range files {
+		info, err := os.Stat(file)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("checksum subject %q is not a regular file", file)
+		}
+		name := filepath.Base(file)
+		if seen[name] {
+			return fmt.Errorf("duplicate checksum subject name %q", name)
+		}
+		seen[name] = true
+		subjects = append(subjects, subject{path: file, name: name})
+	}
+	sort.Slice(subjects, func(i, j int) bool { return subjects[i].name < subjects[j].name })
+
+	var manifest strings.Builder
+	for _, subject := range subjects {
+		digest, err := fileSHA256(subject.path)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&manifest, "%s  %s\n", digest, subject.name)
+	}
+	return writeFileAtomic(output, []byte(manifest.String()), 0o644)
+}
+
+type spdxDocument struct {
+	SPDXVersion       string             `json:"spdxVersion"`
+	DataLicense       string             `json:"dataLicense"`
+	SPDXID            string             `json:"SPDXID"`
+	Name              string             `json:"name"`
+	DocumentNamespace string             `json:"documentNamespace"`
+	CreationInfo      spdxCreationInfo   `json:"creationInfo"`
+	Packages          []spdxPackage      `json:"packages"`
+	Relationships     []spdxRelationship `json:"relationships"`
+}
+
+type spdxCreationInfo struct {
+	Created  string   `json:"created"`
+	Creators []string `json:"creators"`
+}
+
+type spdxPackage struct {
+	Name               string            `json:"name"`
+	SPDXID             string            `json:"SPDXID"`
+	VersionInfo        string            `json:"versionInfo,omitempty"`
+	DownloadLocation   string            `json:"downloadLocation"`
+	FilesAnalyzed      bool              `json:"filesAnalyzed"`
+	LicenseConcluded   string            `json:"licenseConcluded"`
+	LicenseDeclared    string            `json:"licenseDeclared"`
+	CopyrightText      string            `json:"copyrightText"`
+	Comment            string            `json:"comment,omitempty"`
+	ExternalReferences []spdxExternalRef `json:"externalRefs,omitempty"`
+}
+
+type spdxExternalRef struct {
+	Category string `json:"referenceCategory"`
+	Type     string `json:"referenceType"`
+	Locator  string `json:"referenceLocator"`
+}
+
+type spdxRelationship struct {
+	Element string `json:"spdxElementId"`
+	Type    string `json:"relationshipType"`
+	Related string `json:"relatedSpdxElement"`
+}
+
+func writeSBOM(binaryPath, output, name, version string, stamp time.Time) error {
+	build, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		return err
+	}
+	document, err := newSPDXDocument(build, name, version, stamp)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileAtomic(output, data, 0o644)
+}
+
+func newSPDXDocument(build *debug.BuildInfo, name, version string, stamp time.Time) (*spdxDocument, error) {
+	if build.Path != mainModule {
+		return nil, fmt.Errorf("SBOM binary main package is %q, expected %q", build.Path, mainModule)
+	}
+	revision := ""
+	for _, setting := range build.Settings {
+		if setting.Key == "vcs.revision" {
+			revision = setting.Value
+			break
+		}
+	}
+	if revision == "" {
+		return nil, errors.New("SBOM binary is missing its VCS revision")
+	}
+
+	const noAssertion = "NOASSERTION"
+	mainID := "SPDXRef-Package-d2"
+	document := &spdxDocument{
+		SPDXVersion:       "SPDX-2.3",
+		DataLicense:       "CC0-1.0",
+		SPDXID:            "SPDXRef-DOCUMENT",
+		Name:              name,
+		DocumentNamespace: fmt.Sprintf("https://github.com/d2lang/d2/sbom/%s/%s", revision, url.PathEscape(version)),
+		CreationInfo: spdxCreationInfo{
+			Created:  stamp.UTC().Format(time.RFC3339),
+			Creators: []string{"Tool: github.com/d2lang/d2/ci/release/releasetool"},
+		},
+		Packages: []spdxPackage{{
+			Name:             mainModule,
+			SPDXID:           mainID,
+			VersionInfo:      version,
+			DownloadLocation: "git+https://github.com/d2lang/d2.git@" + revision,
+			FilesAnalyzed:    false,
+			LicenseConcluded: noAssertion,
+			LicenseDeclared:  "MPL-2.0",
+			CopyrightText:    noAssertion,
+			Comment:          "Built with " + build.GoVersion,
+			ExternalReferences: []spdxExternalRef{{
+				Category: "PACKAGE-MANAGER",
+				Type:     "purl",
+				Locator:  goModulePURL(mainModule, version),
+			}},
+		}},
+		Relationships: []spdxRelationship{{
+			Element: "SPDXRef-DOCUMENT",
+			Type:    "DESCRIBES",
+			Related: mainID,
+		}},
+	}
+
+	dependencies := append([]*debug.Module(nil), build.Deps...)
+	sort.Slice(dependencies, func(i, j int) bool {
+		return dependencies[i].Path < dependencies[j].Path
+	})
+	for index, dependency := range dependencies {
+		modulePath := dependency.Path
+		moduleVersion := dependency.Version
+		comment := ""
+		if dependency.Sum != "" {
+			comment = "Go module checksum: " + dependency.Sum
+		}
+		if dependency.Replace != nil {
+			replacement := dependency.Replace
+			if comment != "" {
+				comment += "; "
+			}
+			comment += "replaced by " + strings.TrimSpace(replacement.Path+" "+replacement.Version)
+			modulePath = replacement.Path
+			moduleVersion = replacement.Version
+		}
+		packageID := fmt.Sprintf("SPDXRef-Package-%d", index+1)
+		document.Packages = append(document.Packages, spdxPackage{
+			Name:             modulePath,
+			SPDXID:           packageID,
+			VersionInfo:      moduleVersion,
+			DownloadLocation: noAssertion,
+			FilesAnalyzed:    false,
+			LicenseConcluded: noAssertion,
+			LicenseDeclared:  noAssertion,
+			CopyrightText:    noAssertion,
+			Comment:          comment,
+			ExternalReferences: []spdxExternalRef{{
+				Category: "PACKAGE-MANAGER",
+				Type:     "purl",
+				Locator:  goModulePURL(modulePath, moduleVersion),
+			}},
+		})
+		document.Relationships = append(document.Relationships, spdxRelationship{
+			Element: mainID,
+			Type:    "DEPENDS_ON",
+			Related: packageID,
+		})
+	}
+	return document, nil
+}
+
+func goModulePURL(modulePath, version string) string {
+	escapedPath := strings.ReplaceAll(url.PathEscape(modulePath), "%2F", "/")
+	purl := "pkg:golang/" + escapedPath
+	if version != "" {
+		purl += "@" + url.PathEscape(version)
+	}
+	return purl
+}
+
+func verifyChecksums(manifestPath, directory string, expectedCount int) error {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		lines = nil
+	}
+	if expectedCount >= 0 && len(lines) != expectedCount {
+		return fmt.Errorf("checksum manifest has %d entries, expected %d", len(lines), expectedCount)
+	}
+	seen := map[string]bool{}
+	for lineNumber, line := range lines {
+		if len(line) < 67 || line[64:66] != "  " {
+			return fmt.Errorf("invalid checksum manifest line %d", lineNumber+1)
+		}
+		digest := line[:64]
+		if _, err := hex.DecodeString(digest); err != nil {
+			return fmt.Errorf("invalid checksum on line %d: %w", lineNumber+1, err)
+		}
+		name := line[66:]
+		if name == "" || filepath.Base(name) != name || name == "." || name == ".." {
+			return fmt.Errorf("invalid checksum subject %q", name)
+		}
+		if seen[name] {
+			return fmt.Errorf("duplicate checksum subject %q", name)
+		}
+		seen[name] = true
+		actual, err := fileSHA256(filepath.Join(directory, name))
+		if err != nil {
+			return err
+		}
+		if actual != digest {
+			return fmt.Errorf("SHA-256 mismatch for %s: got %s, want %s", name, actual, digest)
+		}
+	}
+	return nil
+}
+
+func fileSHA256(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func verifyBinary(binaryPath, goos, goarch, goVersion, revision, vcsModified string, maxSize int64) error {
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		return err
+	}
+	if info.Size() <= 0 || info.Size() > maxSize {
+		return fmt.Errorf("binary size %d is outside the allowed range 1..%d", info.Size(), maxSize)
+	}
+	build, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		return err
+	}
+	if build.GoVersion != goVersion {
+		return fmt.Errorf("binary uses %s, expected %s", build.GoVersion, goVersion)
+	}
+	if build.Path != mainModule {
+		return fmt.Errorf("binary main package is %q, expected %q", build.Path, mainModule)
+	}
+	settings := make(map[string]string, len(build.Settings))
+	for _, setting := range build.Settings {
+		settings[setting.Key] = setting.Value
+	}
+	wantSettings := map[string]string{
+		"-buildmode":   "exe",
+		"-compiler":    "gc",
+		"-trimpath":    "true",
+		"CGO_ENABLED":  "0",
+		"GOARCH":       goarch,
+		"GOOS":         goos,
+		"vcs":          "git",
+		"vcs.modified": vcsModified,
+		"vcs.revision": revision,
+	}
+	if goarch == "amd64" {
+		wantSettings["GOAMD64"] = "v1"
+	}
+	if goarch == "arm64" {
+		wantSettings["GOARM64"] = "v8.0"
+	}
+	for key, want := range wantSettings {
+		if got := settings[key]; got != want {
+			return fmt.Errorf("binary build setting %s is %q, expected %q", key, got, want)
+		}
+	}
+	return verifyStripped(binaryPath, goos)
+}
+
+func verifyStripped(binaryPath, goos string) error {
+	switch goos {
+	case "linux":
+		file, err := elf.Open(binaryPath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		if file.Section(".symtab") != nil || file.Section(".debug_info") != nil {
+			return errors.New("ELF binary still contains a symbol table or DWARF")
+		}
+		if file.Section(".gopclntab") == nil || file.Section(".go.buildinfo") == nil {
+			return errors.New("ELF binary is missing Go stack or build metadata")
+		}
+	case "darwin":
+		file, err := macho.Open(binaryPath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		for _, section := range file.Sections {
+			if section.Seg == "__DWARF" || strings.HasPrefix(section.Name, "__debug_") {
+				return errors.New("Mach-O binary still contains DWARF")
+			}
+		}
+		if file.Section("__gopclntab") == nil || file.Section("__go_buildinfo") == nil {
+			return errors.New("Mach-O binary is missing Go stack or build metadata")
+		}
+		if file.Symtab != nil {
+			for _, symbol := range file.Symtab.Syms {
+				if symbol.Name == "main.main" || symbol.Name == "runtime.main" || symbol.Name == "_main.main" || symbol.Name == "_runtime.main" {
+					return errors.New("Mach-O binary still contains Go linker symbols")
+				}
+			}
+		}
+	case "windows":
+		file, err := pe.Open(binaryPath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		for _, section := range file.Sections {
+			if strings.HasPrefix(section.Name, ".debug_") {
+				return errors.New("PE binary still contains DWARF")
+			}
+		}
+		for _, symbol := range file.Symbols {
+			if symbol.Name == "main.main" || symbol.Name == "runtime.main" {
+				return errors.New("PE binary still contains Go linker symbols")
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported release GOOS %q", goos)
+	}
+	return nil
+}
+
+func verifyArchive(archivePath, root string, stamp time.Time, maxSize int64) error {
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		return err
+	}
+	if info.Size() <= 0 || info.Size() > maxSize {
+		return fmt.Errorf("archive size %d is outside the allowed range 1..%d", info.Size(), maxSize)
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	zr, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+	if !zr.Header.ModTime.Equal(stamp) {
+		return fmt.Errorf("gzip timestamp is %s, expected %s", zr.Header.ModTime, stamp)
+	}
+
+	required := map[string]bool{
+		root + "/":                        false,
+		root + "/LICENSE.txt":             false,
+		root + "/THIRD_PARTY_NOTICES.txt": false,
+		root + "/Makefile":                false,
+		root + "/README.md":               false,
+		root + "/man/d2.1":                false,
+		root + "/scripts/install.sh":      false,
+		root + "/scripts/lib.sh":          false,
+		root + "/scripts/uninstall.sh":    false,
+	}
+	binaryPrefix := root + "/bin/d2"
+	binaryFound := false
+	previous := ""
+	count := 0
+	tr := tar.NewReader(zr)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		count++
+		name := header.Name
+		clean := path.Clean(name)
+		if strings.HasPrefix(name, "/") || strings.ContainsAny(name, "\\\x00") || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+			return fmt.Errorf("unsafe archive path %q", name)
+		}
+		if name != root+"/" && !strings.HasPrefix(name, root+"/") {
+			return fmt.Errorf("archive entry %q is outside %q", name, root)
+		}
+		if previous != "" && name <= previous {
+			return fmt.Errorf("archive entries are not strictly sorted: %q follows %q", name, previous)
+		}
+		previous = name
+		if !header.ModTime.Equal(stamp) || !header.AccessTime.IsZero() || !header.ChangeTime.IsZero() {
+			return fmt.Errorf("archive entry %q has non-normalized timestamps", name)
+		}
+		if header.Uid != 0 || header.Gid != 0 || header.Uname != "" || header.Gname != "" {
+			return fmt.Errorf("archive entry %q has non-normalized ownership", name)
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if header.Mode != 0o755 || !strings.HasSuffix(name, "/") {
+				return fmt.Errorf("archive directory %q has mode %#o or no trailing slash", name, header.Mode)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Mode != 0o644 && header.Mode != 0o755 {
+				return fmt.Errorf("archive file %q has mode %#o", name, header.Mode)
+			}
+		case tar.TypeSymlink:
+			if header.Mode != 0o777 {
+				return fmt.Errorf("archive symlink %q has mode %#o", name, header.Mode)
+			}
+			if err := validateSymlink(name, header.Linkname, root); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("archive entry %q has unsupported type %d", name, header.Typeflag)
+		}
+		if _, ok := required[name]; ok {
+			required[name] = true
+		}
+		if name == binaryPrefix || name == binaryPrefix+".exe" {
+			if header.Typeflag != tar.TypeReg || header.Mode != 0o755 || header.Size <= 0 {
+				return fmt.Errorf("archive binary %q is invalid", name)
+			}
+			binaryFound = true
+		}
+	}
+	if count == 0 {
+		return errors.New("archive is empty")
+	}
+	if !binaryFound {
+		return errors.New("archive does not contain a D2 binary")
+	}
+	for name, found := range required {
+		if !found {
+			return fmt.Errorf("archive is missing %s", name)
+		}
+	}
+	return nil
+}
+
+func validateSymlink(name, target, root string) error {
+	if target == "" || path.IsAbs(target) || strings.ContainsAny(target, "\\\x00") || (len(target) >= 2 && target[1] == ':') {
+		return fmt.Errorf("archive symlink %q has unsafe target %q", name, target)
+	}
+	resolved := path.Clean(path.Join(path.Dir(name), target))
+	if resolved != root && !strings.HasPrefix(resolved, root+"/") {
+		return fmt.Errorf("archive symlink %q escapes %q with target %q", name, root, target)
+	}
+	return nil
+}
+
+func writeFileAtomic(output string, data []byte, mode fs.FileMode) (retErr error) {
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(output), "."+filepath.Base(output)+".*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if retErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	if err := os.Remove(output); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.Rename(tmpName, output)
+}

--- a/ci/release/releasetool/main_test.go
+++ b/ci/release/releasetool/main_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestArchiveIsReproducibleAndNormalized(t *testing.T) {
+	t.Parallel()
+	stamp := time.Unix(1_700_000_000, 0).UTC()
+	base := t.TempDir()
+	rootA := filepath.Join(base, "a", "d2-v1.2.3")
+	rootB := filepath.Join(base, "b", "d2-v1.2.3")
+	populateReleaseTree(t, rootA, time.Unix(10, 0))
+	populateReleaseTree(t, rootB, time.Unix(20, 0))
+	archiveA := filepath.Join(base, "a.tar.gz")
+	archiveB := filepath.Join(base, "b.tar.gz")
+	if err := writeArchive(rootA, archiveA, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeArchive(rootB, archiveB, stamp); err != nil {
+		t.Fatal(err)
+	}
+	bytesA, err := os.ReadFile(archiveA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytesB, err := os.ReadFile(archiveB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bytesA) != string(bytesB) {
+		t.Fatal("equivalent release trees produced different archives")
+	}
+	if err := verifyArchive(archiveA, "d2-v1.2.3", stamp, int64(len(bytesA))); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(archiveA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	zr, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	tr := tar.NewReader(zr)
+	var names []string
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		names = append(names, header.Name)
+		if header.Name == "d2-v1.2.3/bin/d2" && header.Mode != 0o755 {
+			t.Fatalf("binary mode is %#o", header.Mode)
+		}
+	}
+	if got := strings.Join(names, "\n"); !strings.Contains(got, "d2-v1.2.3/scripts/install.sh") {
+		t.Fatalf("archive names do not contain installer:\n%s", got)
+	}
+}
+
+func TestValidateSymlink(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		target string
+		ok     bool
+	}{
+		{name: "d2-v1.2.3/scripts/d2", target: "../bin/d2", ok: true},
+		{name: "d2-v1.2.3/d2", target: "bin/d2", ok: true},
+		{name: "d2-v1.2.3/d2", target: "/usr/bin/d2"},
+		{name: "d2-v1.2.3/d2", target: `C:\\Windows\\d2.exe`},
+		{name: "d2-v1.2.3/scripts/d2", target: "../../outside"},
+		{name: "d2-v1.2.3/scripts/d2", target: ""},
+	} {
+		err := validateSymlink(test.name, test.target, "d2-v1.2.3")
+		if (err == nil) != test.ok {
+			t.Errorf("validateSymlink(%q, %q) error = %v, want ok=%v", test.name, test.target, err, test.ok)
+		}
+	}
+}
+
+func TestArchiveRejectsOutputInsideRoot(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "d2-v1.2.3")
+	populateReleaseTree(t, root, time.Now())
+	err := writeArchive(root, filepath.Join(root, "release.tar.gz"), time.Unix(0, 0))
+	if err == nil || !strings.Contains(err.Error(), "must not be inside") {
+		t.Fatalf("writeArchive error = %v", err)
+	}
+}
+
+func TestChecksumsAreSortedAndVerified(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	a := filepath.Join(directory, "a.tar.gz")
+	b := filepath.Join(directory, "b.tar.gz")
+	if err := os.WriteFile(b, []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(a, []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(directory, "SHA256SUMS")
+	if err := writeChecksums(manifest, []string{b, a}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 || !strings.HasSuffix(lines[0], "  a.tar.gz") || !strings.HasSuffix(lines[1], "  b.tar.gz") {
+		t.Fatalf("manifest is not sorted:\n%s", data)
+	}
+	if err := verifyChecksums(manifest, directory, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(a, []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyChecksums(manifest, directory, 2); err == nil || !strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("verifyChecksums error = %v", err)
+	}
+}
+
+func TestChecksumsRejectUnsafeSubjects(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	manifest := filepath.Join(directory, "SHA256SUMS")
+	line := strings.Repeat("0", 64) + "  ../escape\n"
+	if err := os.WriteFile(manifest, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyChecksums(manifest, directory, 1); err == nil || !strings.Contains(err.Error(), "invalid checksum subject") {
+		t.Fatalf("verifyChecksums error = %v", err)
+	}
+}
+
+func TestSPDXDocumentIsDeterministicAndSorted(t *testing.T) {
+	t.Parallel()
+	build := &debug.BuildInfo{
+		GoVersion: "go1.27.0",
+		Path:      mainModule,
+		Settings: []debug.BuildSetting{{
+			Key:   "vcs.revision",
+			Value: strings.Repeat("a", 40),
+		}},
+		Deps: []*debug.Module{
+			{Path: "example.com/z", Version: "v1.0.0", Sum: "h1:z"},
+			{Path: "example.com/a", Version: "v2.0.0", Sum: "h1:a"},
+		},
+	}
+	stamp := time.Unix(1_700_000_000, 0).UTC()
+	document, err := newSPDXDocument(build, "d2-v1.2.3", "v1.2.3", stamp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.SPDXVersion != "SPDX-2.3" || document.CreationInfo.Created != "2023-11-14T22:13:20Z" {
+		t.Fatalf("unexpected SPDX metadata: %#v", document)
+	}
+	if len(document.Packages) != 3 || document.Packages[1].Name != "example.com/a" || document.Packages[2].Name != "example.com/z" {
+		t.Fatalf("SPDX packages are not sorted: %#v", document.Packages)
+	}
+	if len(document.Relationships) != 3 || document.Relationships[1].Type != "DEPENDS_ON" {
+		t.Fatalf("unexpected SPDX relationships: %#v", document.Relationships)
+	}
+	if got := document.Packages[1].ExternalReferences[0].Locator; got != "pkg:golang/example.com/a@v2.0.0" {
+		t.Fatalf("package URL = %q", got)
+	}
+}
+
+func populateReleaseTree(t *testing.T, root string, mtime time.Time) {
+	t.Helper()
+	files := map[string]struct {
+		contents string
+		mode     os.FileMode
+	}{
+		"LICENSE.txt":             {contents: "license\n", mode: 0o644},
+		"THIRD_PARTY_NOTICES.txt": {contents: "notices\n", mode: 0o644},
+		"Makefile":                {contents: "all:\n\t@true\n", mode: 0o644},
+		"README.md":               {contents: "readme\n", mode: 0o644},
+		"bin/d2":                  {contents: "binary\n", mode: 0o755},
+		"man/d2.1":                {contents: "manpage\n", mode: 0o644},
+		"scripts/install.sh":      {contents: "#!/bin/sh\n", mode: 0o755},
+		"scripts/lib.sh":          {contents: "#!/bin/sh\n", mode: 0o755},
+		"scripts/uninstall.sh":    {contents: "#!/bin/sh\n", mode: 0o755},
+	}
+	for name, file := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(file.contents), file.mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if runtime.GOOS != "windows" {
+		link := filepath.Join(root, "scripts", "d2-link")
+		if err := os.Symlink("../bin/d2", link); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -67,10 +67,18 @@ detailed docs on its various options and features.
 
 If you're still concerned, remember you can run with `--dry-run` to avoid writing anything.
 
-The install script does not yet verify any signature on the downloaded release
-but that is coming soon. [#315](https://github.com/terrastruct/d2/issues/315)
+For standalone installations, the script obtains the selected archive's SHA-256 digest
+from the GitHub Releases API and verifies both cached and newly downloaded archives before
+extracting them. Each new release also includes `SHA256SUMS` and GitHub artifact
+attestations. You can verify build provenance separately with:
+
+```sh
+gh attestation verify d2-v0.0.0-linux-amd64.tar.gz --repo d2lang/d2
+```
 
 ## macOS (Homebrew)
+
+D2 binaries built with Go 1.27 require macOS 13 Ventura or newer.
 
 If you're on macOS, you can install with `brew`.
 
@@ -159,7 +167,7 @@ You can always install from source:
 go install github.com/d2lang/d2@latest
 ```
 
-You need at least Go v1.20
+You need at least Go v1.27
 
 ### Source Release
 
@@ -176,7 +184,7 @@ fonts and icons. Furthermore, when installing a non versioned commit, installing
 will ensure that `d2 --version` works correctly by embedding the commit hash into the `d2`
 binary.
 
-Remember, you need at least Go v1.20
+Remember, you need at least Go v1.27
 
 ## Windows
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -68,9 +68,11 @@ detailed docs on its various options and features.
 If you're still concerned, remember you can run with `--dry-run` to avoid writing anything.
 
 For standalone installations, the script obtains the selected archive's SHA-256 digest
-from the GitHub Releases API and verifies both cached and newly downloaded archives before
-extracting them. Each new release also includes `SHA256SUMS` and GitHub artifact
-attestations. You can verify build provenance separately with:
+from the GitHub Releases API and, when GitHub provides one, verifies both cached and newly
+downloaded archives before extracting them. Historical releases for which GitHub reports
+no digest remain installable with a warning. Releases produced by the current release
+workflow also include `SHA256SUMS` and GitHub artifact attestations. You can verify build
+provenance separately with:
 
 ```sh
 gh attestation verify d2-v0.0.0-linux-amd64.tar.gz --repo d2lang/d2

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ set -eu
 # - ./ci/sub/lib/log.sh
 # - ./ci/sub/lib/flag.sh
 # - ./ci/sub/lib/release.sh
+# - ./ci/release/checksum.sh
 # - ./ci/release/_install.sh
 #
 # The last of which implements the installation logic.
@@ -597,8 +598,107 @@ ensure_prefix_sh_c() {
   fi
 }
 #!/bin/sh
+if [ -n "${D2_RELEASE_CHECKSUM-}" ]; then
+  return 0
+fi
+D2_RELEASE_CHECKSUM=1
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{ print $NF }'
+  else
+    echo >&2 "sha256sum, shasum, or openssl is required to verify release downloads"
+    return 1
+  fi
+}
+
+release_asset_digest_from_json() {
+  ASSET_NAME=$1
+  awk -v asset="$ASSET_NAME" '
+    /^[[:space:]]*"name":[[:space:]]*/ {
+      value = $0
+      sub(/^[^:]*:[[:space:]]*"/, "", value)
+      sub(/"[,[:space:]]*$/, "", value)
+      found = value == asset
+      next
+    }
+    found && /^[[:space:]]*"digest":[[:space:]]*/ {
+      value = $0
+      original = value
+      sub(/^[^:]*:[[:space:]]*"sha256:/, "", value)
+      if (value == original) {
+        exit
+      }
+      sub(/"[,[:space:]]*$/, "", value)
+      print value
+      exit
+    }
+  '
+}
+
+release_asset_sha256() {
+  REPOSITORY=$1
+  RELEASE_VERSION=$2
+  ASSET_NAME=$3
+  RELEASE_INFO=$(mktempd)/release.json
+  RELEASE_INFO_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE_VERSION"
+  DRY_RUN= fetch_gh "$RELEASE_INFO_URL" "$RELEASE_INFO" 'application/vnd.github+json'
+  EXPECTED_SHA256=$(release_asset_digest_from_json "$ASSET_NAME" <"$RELEASE_INFO")
+  EXPECTED_SHA256=$(printf '%s' "$EXPECTED_SHA256" | tr '[:upper:]' '[:lower:]')
+  if ! printf '%s\n' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo >&2 "$ASSET_NAME does not have a valid GitHub SHA-256 digest"
+    return 1
+  fi
+  printf '%s\n' "$EXPECTED_SHA256"
+}
+
+verify_sha256() {
+  FILE=$1
+  EXPECTED_SHA256=$2
+  ACTUAL_SHA256=$(sha256_file "$FILE")
+  ACTUAL_SHA256=$(printf '%s' "$ACTUAL_SHA256" | tr '[:upper:]' '[:lower:]')
+  if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo >&2 "$FILE has SHA-256 $ACTUAL_SHA256, expected $EXPECTED_SHA256"
+    return 1
+  fi
+}
+
+fetch_verified_release_asset() {
+  REPOSITORY=$1
+  RELEASE_VERSION=$2
+  ASSET_NAME=$3
+  ASSET_URL=$4
+  DESTINATION=$5
+
+  if [ -n "${DRY_RUN-}" ]; then
+    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest"
+    return
+  fi
+
+  EXPECTED_SHA256=$(release_asset_sha256 "$REPOSITORY" "$RELEASE_VERSION" "$ASSET_NAME")
+  if [ -e "$DESTINATION" ]; then
+    if verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"; then
+      log "reusing verified $DESTINATION"
+      return
+    fi
+    warn "discarding cached $ASSET_NAME after checksum verification failed"
+    rm -f "$DESTINATION"
+  fi
+  fetch_gh "$ASSET_URL" "$DESTINATION" 'application/octet-stream'
+  verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"
+  log "verified $ASSET_NAME ($EXPECTED_SHA256)"
+}
+#!/bin/sh
 set -eu
 
+
+if [ -z "${D2_RELEASE_CHECKSUM-}" ]; then
+  . "$(dirname "$0")/checksum.sh"
+fi
 
 help() {
   arg0="$0"
@@ -905,7 +1005,8 @@ install_d2_standalone() {
 
   ensure_version
   asset_url="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
-  fetch_gh "$asset_url" "$CACHE_DIR/$ARCHIVE" 'application/octet-stream'
+  fetch_verified_release_asset \
+    "$REPO" "$VERSION" "$ARCHIVE" "$asset_url" "$CACHE_DIR/$ARCHIVE"
 
   ensure_prefix_sh_c
   "$sh_c" mkdir -p "'$INSTALL_DIR'"

--- a/install.sh
+++ b/install.sh
@@ -628,6 +628,10 @@ release_asset_digest_from_json() {
     }
     found && /^[[:space:]]*"digest":[[:space:]]*/ {
       value = $0
+      if (value ~ /^[^:]*:[[:space:]]*null[,[:space:]]*$/) {
+        print "unavailable"
+        exit
+      }
       original = value
       sub(/^[^:]*:[[:space:]]*"sha256:/, "", value)
       if (value == original) {
@@ -648,6 +652,9 @@ release_asset_sha256() {
   RELEASE_INFO_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE_VERSION"
   DRY_RUN= fetch_gh "$RELEASE_INFO_URL" "$RELEASE_INFO" 'application/vnd.github+json'
   EXPECTED_SHA256=$(release_asset_digest_from_json "$ASSET_NAME" <"$RELEASE_INFO")
+  if [ "$EXPECTED_SHA256" = unavailable ]; then
+    return 0
+  fi
   EXPECTED_SHA256=$(printf '%s' "$EXPECTED_SHA256" | tr '[:upper:]' '[:lower:]')
   if ! printf '%s\n' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
     echo >&2 "$ASSET_NAME does not have a valid GitHub SHA-256 digest"
@@ -667,7 +674,7 @@ verify_sha256() {
   fi
 }
 
-fetch_verified_release_asset() {
+fetch_release_asset() {
   REPOSITORY=$1
   RELEASE_VERSION=$2
   ASSET_NAME=$3
@@ -675,11 +682,16 @@ fetch_verified_release_asset() {
   DESTINATION=$5
 
   if [ -n "${DRY_RUN-}" ]; then
-    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest"
+    sh_c "download $ASSET_NAME and verify its GitHub SHA-256 digest when available"
     return
   fi
 
   EXPECTED_SHA256=$(release_asset_sha256 "$REPOSITORY" "$RELEASE_VERSION" "$ASSET_NAME")
+  if [ -z "$EXPECTED_SHA256" ]; then
+    warn "GitHub does not provide a SHA-256 digest for $ASSET_NAME; continuing without checksum verification for compatibility with legacy releases"
+    fetch_gh "$ASSET_URL" "$DESTINATION" 'application/octet-stream'
+    return
+  fi
   if [ -e "$DESTINATION" ]; then
     if verify_sha256 "$DESTINATION" "$EXPECTED_SHA256"; then
       log "reusing verified $DESTINATION"
@@ -1005,7 +1017,7 @@ install_d2_standalone() {
 
   ensure_version
   asset_url="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
-  fetch_verified_release_asset \
+  fetch_release_asset \
     "$REPO" "$VERSION" "$ARCHIVE" "$asset_url" "$CACHE_DIR/$ARCHIVE"
 
   ensure_prefix_sh_c


### PR DESCRIPTION
## Summary

- build release archives with the exact `go.mod` toolchain, clean environment, `CGO_ENABLED=0`, explicit baseline architecture levels, `-trimpath`, and `-s -w`
- validate embedded build/VCS metadata, retained Go stack metadata, stripped symbols, archive layout, normalized metadata, safe paths, and fixed binary/archive size ceilings
- produce all six archives deterministically in a tag-triggered Actions workflow, rebuild them for a digest comparison, then smoke-test each archive on its matching native Linux, macOS, or Windows runner
- publish `SHA256SUMS`, an SPDX SBOM, and GitHub build-provenance/SBOM attestations; make the release script upload the exact immutable CI-built archives
- verify cached and newly downloaded D2 standalone archives whenever GitHub provides a release-asset SHA-256, while preserving older digest-less releases with an explicit warning
- document the Go 1.27 macOS floor and the new release/verification flow

GitHub's keyless attestations do not replace Authenticode or Apple platform signing; Authenticode remains tracked by #1078.

## Size

For Linux amd64, using the same source and version locally:

| | Previous build path | This PR | Change |
|---|---:|---:|---:|
| binary | 46,428,970 bytes | 34,758,816 bytes | -25.1% |
| `.tar.gz` | 23,159,785 bytes | 13,607,469 bytes | -41.2% |

The verifier explicitly requires Go's PC/line table and build info to remain present, so runtime stack traces and `debug/buildinfo` keep working despite `-s -w`.

## Validation

- `CI=1 go test ./...`
- `go vet --composites=false ./...`
- `go build ./...`
- `go test -race ./ci/release/...`
- actionlint v1.7.12
- generated installer stability and shell syntax checks
- real v0.7.0 standalone fresh-download and cached-archive installations with the legacy warning
- real v0.7.1 standalone download, GitHub SHA-256 verification, extraction, and `d2 --version`
- two clean, serial, production-mode builds of all six targets with an exact `SHA256SUMS` comparison
