### PR TITLE
release: discover draft releases by listing

### DIFF
--- a/.github/workflows/windows-msi.yml
+++ b/.github/workflows/windows-msi.yml
@@ -35,6 +35,8 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     timeout-minutes: 70
+    permissions:
+      contents: write
     outputs:
       archive_asset_id: ${{ steps.release.outputs.archive_asset_id }}
       archive_digest: ${{ steps.release.outputs.archive_digest }}
@@ -90,6 +92,29 @@ jobs:
 
           release_json=
           archive_json=
+          find_release() {
+            local release_pages release_matches release_count
+            # GitHub's tag endpoint returns only published releases. The list
+            # endpoint includes drafts for this write-scoped release job.
+            release_pages=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/releases?per_page=100")
+            if ! printf '%s' "$release_pages" | jq -e \
+              'type == "array" and all(.[]; type == "array")' >/dev/null; then
+              echo "GitHub returned malformed release listings" >&2
+              return 1
+            fi
+            release_matches=$(printf '%s' "$release_pages" | jq -c --arg version "$version" \
+              '[.[][] | select(.tag_name == $version)]')
+            release_count=$(printf '%s' "$release_matches" | jq -r length)
+            case "$release_count" in
+              0) return 0 ;;
+              1) printf '%s' "$release_matches" | jq -c '.[0]' ;;
+              *)
+                echo "GitHub returned multiple releases for $version" >&2
+                return 1
+                ;;
+            esac
+          }
           expected_assets=$(jq -cn --arg version "$version" '[
             "d2-\($version)-linux-amd64.tar.gz",
             "d2-\($version)-linux-arm64.tar.gz",
@@ -99,7 +124,7 @@ jobs:
             "d2-\($version)-windows-arm64.tar.gz"
           ]')
           for attempt in $(seq 1 "$attempts"); do
-            release_json=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$version" 2>/dev/null || true)
+            release_json=$(find_release)
             if [[ -n "$release_json" ]]; then
               if printf '%s' "$release_json" | jq -e --argjson expected "$expected_assets" '
                 [.assets[] | select(.name as $name | $expected | index($name))] as $matches |

--- a/ci/release/release.sh
+++ b/ci/release/release.sh
@@ -65,34 +65,39 @@ case "$VERSION_ARG" in
       echo >&2 "cannot safely distinguish a missing release from a hidden draft release"
       exit 1
     fi
-    if RELEASE_RESPONSE=$(gh api --include \
-      "repos/$REPOSITORY/releases/tags/$VERSION_ARG" 2>&1); then
-      STATUS_CODE=$(printf '%s\n' "$RELEASE_RESPONSE" \
-        | sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p')
-      if [ "$STATUS_CODE" != 200 ]; then
-        echo >&2 "unexpected GitHub release lookup status: $STATUS_CODE"
-        exit 1
-      fi
-      RELEASE_JSON=$(printf '%s\n' "$RELEASE_RESPONSE" \
-        | awk 'body { print } /^\r?$/ { body = 1 }')
-      if ! printf '%s' "$RELEASE_JSON" | jq -e --arg version "$VERSION_ARG" \
-        'type == "object" and (.id | type == "number") and
-          .tag_name == $version and (.assets | type == "array")' >/dev/null; then
-        echo >&2 "GitHub returned malformed release metadata for $VERSION_ARG"
-        exit 1
-      fi
-      MSI_COUNT=$(printf '%s' "$RELEASE_JSON" | jq -r --arg asset "$MSI_ASSET" \
-        '[.assets[] | select(.name == $asset)] | length')
-    else
-      STATUS_CODE=$(printf '%s\n' "$RELEASE_RESPONSE" \
-        | sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p')
-      if [ "$STATUS_CODE" != 404 ]; then
-        printf '%s\n' "$RELEASE_RESPONSE" >&2
-        echo >&2 "unable to verify whether $VERSION_ARG already has an MSI"
-        exit 1
-      fi
-      MSI_COUNT=0
+    # GitHub's tag endpoint returns only published releases. Enumerate releases
+    # after confirming push access so an existing draft cannot bypass this guard.
+    RELEASE_PAGES=$(gh api --paginate --slurp \
+      "repos/$REPOSITORY/releases?per_page=100")
+    if ! printf '%s' "$RELEASE_PAGES" | jq -e \
+      'type == "array" and all(.[]; type == "array")' >/dev/null; then
+      echo >&2 "GitHub returned malformed release listings"
+      exit 1
     fi
+    RELEASE_MATCHES=$(printf '%s' "$RELEASE_PAGES" | jq -c \
+      --arg version "$VERSION_ARG" \
+      '[.[][] | select(.tag_name == $version)]')
+    RELEASE_COUNT=$(printf '%s' "$RELEASE_MATCHES" | jq -r length)
+    case "$RELEASE_COUNT" in
+      0)
+        MSI_COUNT=0
+        ;;
+      1)
+        RELEASE_JSON=$(printf '%s' "$RELEASE_MATCHES" | jq -c '.[0]')
+        if ! printf '%s' "$RELEASE_JSON" | jq -e --arg version "$VERSION_ARG" \
+          'type == "object" and (.id | type == "number") and
+            .tag_name == $version and (.assets | type == "array")' >/dev/null; then
+          echo >&2 "GitHub returned malformed release metadata for $VERSION_ARG"
+          exit 1
+        fi
+        MSI_COUNT=$(printf '%s' "$RELEASE_JSON" | jq -r --arg asset "$MSI_ASSET" \
+          '[.assets[] | select(.name == $asset)] | length')
+        ;;
+      *)
+        echo >&2 "GitHub returned multiple releases for $VERSION_ARG"
+        exit 1
+        ;;
+    esac
     if [ -n "$MSI_COUNT" ] && [ "$MSI_COUNT" -gt 0 ]; then
       echo >&2 "$MSI_ASSET is already attached to the release"
       echo >&2 "do not rerun the release builder or move its tag; merge the release PR and publish the reviewed draft on GitHub"


### PR DESCRIPTION
## Summary

- find a release by filtering the paginated release listing instead of the tag-specific endpoint, which only returns published releases
- let the trusted Windows validation job see drafts while preserving GitHub read-only token downgrades for fork pull requests
- fail closed on malformed or duplicate release metadata in both the MSI workflow and release rerun guard

## Regression and recovery

The v0.8.2 release attempt reproduced the issue: its draft release and six complete archives existed, but the tag-triggered Windows MSI job kept polling an endpoint that returns 404 for drafts. That run was cancelled without moving the signed tag or publishing the release.

After this lands, the Windows MSI workflow can be dispatched from protected master for v0.8.2 with release upload enabled. It will pin the existing tag, release ID, archive asset ID, and digest before building and attaching the MSI.

## Validation

- live GitHub API check: tag-specific lookup returns 404 while the paginated release listing returns exactly the v0.8.2 draft and its seven assets
- release dry-run resolves the existing draft
- sh -n ci/release/release.sh
- workflow YAML parse
- Go formatting, generation, vet, build, unit tests, and E2E tests
- D2.js build with pinned Bun 1.3.14: 39 unit and 2 integration tests
- git diff --check