### PR TITLE
release: hand off draft archive to Windows job

### DIFF
--- a/.github/workflows/windows-msi.yml
+++ b/.github/workflows/windows-msi.yml
@@ -207,13 +207,41 @@ jobs:
             echo "version=$version"
           } >>"$GITHUB_OUTPUT"
 
+      - name: Download and verify pinned Windows archive
+        env:
+          ARCHIVE_ASSET_ID: ${{ steps.release.outputs.archive_asset_id }}
+          ARCHIVE_DIGEST: ${{ steps.release.outputs.archive_digest }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/d2-$VERSION-windows-amd64.tar.gz"
+          gh api \
+            -H 'Accept: application/octet-stream' \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$ARCHIVE_ASSET_ID" >"$archive"
+
+          expected=${ARCHIVE_DIGEST#sha256:}
+          actual=$(sha256sum "$archive" | awk '{print $1}')
+          if [[ "$actual" != "$expected" ]]; then
+            echo "archive SHA-256 is $actual, expected $expected" >&2
+            exit 1
+          fi
+
+      - name: Upload pinned Windows archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-release-archive
+          path: ${{ runner.temp }}/d2-${{ steps.release.outputs.version }}-windows-amd64.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
   build:
     needs: validate
     if: ${{ github.event_name != 'pull_request' || vars.WIX7_EULA_ACCEPTED == 'true' }}
     runs-on: windows-2022
     timeout-minutes: 30
     env:
-      ARCHIVE_ASSET_ID: ${{ needs.validate.outputs.archive_asset_id }}
       ARCHIVE_DIGEST: ${{ needs.validate.outputs.archive_digest }}
       VERSION: ${{ needs.validate.outputs.version }}
     steps:
@@ -221,6 +249,11 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.checkout_commit }}
           persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-release-archive
+          path: ${{ runner.temp }}
 
       - name: Confirm WiX 7 EULA acceptance
         shell: pwsh
@@ -238,24 +271,10 @@ jobs:
           dotnet tool install --tool-path "$env:RUNNER_TEMP\wix" wix --version 7.0.0
           "$env:RUNNER_TEMP\wix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Download and verify release archive
+      - name: Verify release archive
         shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           $archive = "$env:RUNNER_TEMP\d2-$env:VERSION-windows-amd64.tar.gz"
-          $headers = @{
-            Accept = 'application/octet-stream'
-            Authorization = "Bearer $env:GH_TOKEN"
-            'X-GitHub-Api-Version' = '2022-11-28'
-          }
-          $downloadParameters = @{
-            Headers = $headers
-            Uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$env:ARCHIVE_ASSET_ID"
-            OutFile = $archive
-          }
-          Invoke-WebRequest @downloadParameters
-
           $expected = $env:ARCHIVE_DIGEST.Substring('sha256:'.Length)
           $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -cne $expected) {


### PR DESCRIPTION
## Summary

- download the pinned Windows release archive in the trusted validation job that can access draft releases
- verify its GitHub SHA-256 digest before uploading it as a run-scoped Actions artifact
- keep the code-executing Windows build job read-only and have it independently verify the same digest before building the MSI

## Regression and recovery

The protected-master v0.8.2 recovery run successfully found and pinned the draft release, asset ID, digest, and signed tag. Its Windows job then received a 403 when its intentionally read-only token tried to download the draft asset.

This preserves the least-privilege boundary instead of granting write access to the Windows job. After merge, a new protected-master dispatch can reuse the existing immutable release archive without moving the v0.8.2 tag or replacing any release assets.

Failed recovery run: https://github.com/d2lang/d2/actions/runs/32760646794

## Validation

- live download of draft asset 527960109 matched SHA-256 2c223b56ce5f5984c235b88b1e0e996126ba7c8a37476ad9b47d7d6db9475f18
- full ./make.sh: formatting, generation, vet, build, Go tests, E2E tests, D2.js build, 39 unit tests, and 2 integration tests
- workflow YAML parse
- git diff --check