### PR TITLE
release: make Docker browser install noninteractive

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -259,6 +259,12 @@ jobs:
           ref: ${{ needs.validate.outputs.release_commit }}
           persist-credentials: false
 
+      - name: Check out release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .release-source
+          persist-credentials: false
+
       - name: Download and verify exact release archive
         env:
           GH_TOKEN: ${{ github.token }}
@@ -274,6 +280,10 @@ jobs:
           printf '%s  %s\n' "${ASSET_DIGEST#sha256:}" "$archive" | sha256sum -c -
           tar -tzf "$archive" >/dev/null
           cp ci/release/docker/entrypoint.sh "$RUNNER_TEMP/docker-context/entrypoint.sh"
+          bash .release-source/ci/release/docker/prepare-continuity-dockerfile.sh \
+            "$VERSION" \
+            ci/release/docker/Dockerfile \
+            "$RUNNER_TEMP/Dockerfile"
 
       - name: Log in to Docker Hub
         env:
@@ -300,7 +310,7 @@ jobs:
             --provenance=mode=max \
             --output "type=image,\"name=$images\",push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file "$metadata" \
-            --file ci/release/docker/Dockerfile \
+            --file "$RUNNER_TEMP/Dockerfile" \
             "$RUNNER_TEMP/docker-context"
 
           digest=$(jq -er '."containerimage.digest"' "$metadata")
@@ -381,6 +391,12 @@ jobs:
           ref: ${{ needs.validate.outputs.release_commit }}
           persist-credentials: false
 
+      - name: Check out release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .release-source
+          persist-credentials: false
+
       - name: Download and verify exact release archive
         env:
           GH_TOKEN: ${{ github.token }}
@@ -396,6 +412,10 @@ jobs:
           printf '%s  %s\n' "${ASSET_DIGEST#sha256:}" "$archive" | sha256sum -c -
           tar -tzf "$archive" >/dev/null
           cp ci/release/docker/entrypoint.sh "$RUNNER_TEMP/docker-context/entrypoint.sh"
+          bash .release-source/ci/release/docker/prepare-continuity-dockerfile.sh \
+            "$VERSION" \
+            ci/release/docker/Dockerfile \
+            "$RUNNER_TEMP/Dockerfile"
 
       - name: Log in to Docker Hub
         env:
@@ -422,7 +442,7 @@ jobs:
             --provenance=mode=max \
             --output "type=image,\"name=$images\",push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file "$metadata" \
-            --file ci/release/docker/Dockerfile \
+            --file "$RUNNER_TEMP/Dockerfile" \
             "$RUNNER_TEMP/docker-context"
 
           digest=$(jq -er '."containerimage.digest"' "$metadata")

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -141,7 +141,9 @@ Before publishing a production tag, the workflow:
 1. verifies the protected-master dispatch, published non-draft semver GitHub release, exact
    Linux amd64 and arm64 asset IDs, and their GitHub SHA-256 digests;
 2. explicitly peels the Git tag to a commit, requires that commit to be an ancestor of the
-   dispatched `master` commit, and uses that release commit's Dockerfile;
+   dispatched `master` commit, and uses that release commit's Dockerfile; current release
+   tooling may apply only an allowlisted, version-specific compatibility transform to an
+   immutable tagged Dockerfile (`v0.8.2` sets `CI=1` only for `d2 init-playwright`);
 3. builds on native GitHub-hosted amd64 and arm64 runners and pushes only untagged digests
    with provenance;
 4. runs native version, SVG, and PNG smoke tests for both digests; and

--- a/ci/release/docker/Dockerfile
+++ b/ci/release/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /usr/local/lib/d2 \
       && rm -Rf /tmp/d2-*-linux-"$TARGETARCH".tar.gz
 
 USER debian:debian
-RUN d2 init-playwright
+RUN CI=1 d2 init-playwright
 
 WORKDIR /home/debian/src
 EXPOSE 8080

--- a/ci/release/docker/prepare-continuity-dockerfile.sh
+++ b/ci/release/docker/prepare-continuity-dockerfile.sh
@@ -24,6 +24,18 @@ case "$version" in
     playwright_version=1.47.2
     playwright_sha256=4f14eac4a244fada8e072d9932a1f9a4752a161b6726f227223ef33fd5dddbf4
     ;;
+  v0.8.2)
+    # v0.8.2 prompts before installing Chromium outside CI. Tagged release
+    # sources are immutable, so make only that installation step
+    # non-interactive when rebuilding its production Docker image.
+    if [[ $(grep -Fxc 'RUN d2 init-playwright' "$source_dockerfile") -ne 1 ]]; then
+      echo "expected exactly one interactive d2 init-playwright instruction in $source_dockerfile" >&2
+      exit 1
+    fi
+    sed 's/^RUN d2 init-playwright$/RUN CI=1 d2 init-playwright/' \
+      "$source_dockerfile" >"$output_dockerfile"
+    exit 0
+    ;;
   *)
     install -m 0644 "$source_dockerfile" "$output_dockerfile"
     exit 0

--- a/ci/release/docker/prepare_continuity_dockerfile_test.go
+++ b/ci/release/docker/prepare_continuity_dockerfile_test.go
@@ -1,0 +1,68 @@
+package docker_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareV082DockerfileMakesPlaywrightNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	input := "FROM ubuntu:24.04\nUSER debian:debian\nRUN d2 init-playwright\nENTRYPOINT [\"d2\"]\n"
+	output := runPrepareDockerfile(t, "v0.8.2", input, true)
+	want := strings.Replace(input, "RUN d2 init-playwright", "RUN CI=1 d2 init-playwright", 1)
+	if output != want {
+		t.Fatalf("prepared Dockerfile differs:\nwant:\n%s\ngot:\n%s", want, output)
+	}
+}
+
+func TestPrepareV082DockerfileRejectsUnexpectedSource(t *testing.T) {
+	t.Parallel()
+
+	runPrepareDockerfile(t, "v0.8.2", "FROM ubuntu:24.04\n", false)
+}
+
+func TestPrepareOtherDockerfileCopiesExactly(t *testing.T) {
+	t.Parallel()
+
+	input := "FROM scratch\nCOPY d2 /d2\n"
+	if got := runPrepareDockerfile(t, "v1.2.3", input, true); got != input {
+		t.Fatalf("prepared Dockerfile differs:\nwant:\n%s\ngot:\n%s", input, got)
+	}
+}
+
+func runPrepareDockerfile(t *testing.T, version, input string, wantSuccess bool) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	source := filepath.Join(tempDir, "Dockerfile.in")
+	output := filepath.Join(tempDir, "Dockerfile.out")
+	if err := os.WriteFile(source, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", "./prepare-continuity-dockerfile.sh", version, source, output)
+	combined, err := cmd.CombinedOutput()
+	if wantSuccess && err != nil {
+		t.Fatalf("prepare Dockerfile failed: %v\n%s", err, combined)
+	}
+	if !wantSuccess {
+		if err == nil {
+			t.Fatalf("prepare Dockerfile unexpectedly succeeded:\n%s", combined)
+		}
+		if !bytes.Contains(combined, []byte("expected exactly one interactive d2 init-playwright instruction")) {
+			t.Fatalf("unexpected failure:\n%s", combined)
+		}
+		return ""
+	}
+
+	prepared, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(prepared)
+}


### PR DESCRIPTION
## Summary

- make the Playwright browser install noninteractive in release Dockerfiles
- apply one fail-closed, version-specific compatibility transform when rebuilding the immutable v0.8.2 Dockerfile
- cover the compatibility helper with tests

## Why

The first v0.8.2 Docker publish run failed on both native builders because d2 init-playwright prompted for confirmation in Docker and received EOF. The run failed before any v0.8.2 or latest tags were written.

Failed run: https://github.com/d2lang/d2/actions/runs/33141073222

## Validation

- go test ./ci/release/docker -count=1
- full Go build, vet, and repository test suite
- workflow YAML parse
- exact tagged v0.8.2 Dockerfile transform matches the corrected current Dockerfile
- git diff --check