### PR TITLE
png: honor configured timeout in Playwright

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,8 @@
 
 #### Bugfixes ⛑️
 
+- exports: honor `D2_TIMEOUT` during PNG and GIF rendering in Playwright
+
 ---
 
 For the latest d2.js changes, see separate [changelog](https://github.com/d2lang/d2/blob/master/d2js/js/CHANGELOG.md).

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mxschmitt/playwright-go"
 
 	"github.com/d2lang/d2/lib/compression"
+	"github.com/d2lang/d2/lib/env"
 	"github.com/d2lang/d2/lib/version"
 )
 
@@ -118,7 +119,26 @@ func InitPlaywrightWithPrompt() (Playwright, error) {
 	return InitPlaywright()
 }
 
+type timeoutSetter interface {
+	SetDefaultTimeout(float64)
+	SetDefaultNavigationTimeout(float64)
+}
+
+func configureTimeout(target timeoutSetter) {
+	seconds, ok := env.Timeout()
+	if !ok {
+		return
+	}
+	if seconds < 0 {
+		seconds = 0
+	}
+	timeout := float64(seconds) * 1000
+	target.SetDefaultTimeout(timeout)
+	target.SetDefaultNavigationTimeout(timeout)
+}
+
 func MountSVG(page playwright.Page, svgMarkup string) error {
+	configureTimeout(page)
 	decompressed := compression.UnzipEmbeddedSVGImages([]byte(svgMarkup))
 	html := `<!doctype html><meta charset="utf-8">
 <style>

--- a/lib/png/png_test.go
+++ b/lib/png/png_test.go
@@ -1,0 +1,52 @@
+package png
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type timeoutRecorder struct {
+	defaultCalled     bool
+	navigationCalled  bool
+	defaultTimeout    float64
+	navigationTimeout float64
+}
+
+func (r *timeoutRecorder) SetDefaultTimeout(timeout float64) {
+	r.defaultCalled = true
+	r.defaultTimeout = timeout
+
+}
+
+func (r *timeoutRecorder) SetDefaultNavigationTimeout(timeout float64) {
+	r.navigationCalled = true
+	r.navigationTimeout = timeout
+}
+
+func TestConfigureTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		value       string
+		wantCalled  bool
+		wantTimeout float64
+	}{
+		{name: "unset"},
+		{name: "seconds", value: "125", wantCalled: true, wantTimeout: 125000},
+		{name: "disabled", value: "0", wantCalled: true},
+		{name: "negative disables", value: "-1", wantCalled: true},
+		{name: "invalid", value: "invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("D2_TIMEOUT", tc.value)
+			recorder := &timeoutRecorder{}
+
+			configureTimeout(recorder)
+
+			assert.Equal(t, tc.wantCalled, recorder.defaultCalled)
+			assert.Equal(t, tc.wantCalled, recorder.navigationCalled)
+			assert.Equal(t, tc.wantTimeout, recorder.defaultTimeout)
+			assert.Equal(t, tc.wantTimeout, recorder.navigationTimeout)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- propagate `D2_TIMEOUT` to Playwright before mounting SVGs
- configure both action and navigation timeouts so `Goto`, locator waits, screenshots, and GIF frames share the CLI limit
- preserve the existing zero-or-negative no-timeout behavior

## Verification

- `go test ./lib/png ./lib/xgif ./d2cli -count=1`
- `go test -race ./lib/png ./lib/xgif ./d2cli -count=1`
- `go vet ./lib/png ./lib/xgif ./d2cli`
- `go test ./ci/release -count=1`
- unit coverage verifies unset, positive, zero, negative, and invalid values for both Playwright timeout channels

Fixes #2761