### PR TITLE
compiler: prevent recursive class glob cycles

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,8 @@
 
 #### Bugfixes ⛑️
 
+- compiler: keep recursive globs out of class and variable definitions and report class reference cycles instead of overflowing the stack
+
 ---
 
 For the latest d2.js changes, see separate [changelog](https://github.com/d2lang/d2/blob/master/d2js/js/CHANGELOG.md).

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -256,7 +256,8 @@ func _findFieldAST(ast *d2ast.Map, path []string) *d2ast.Map {
 }
 
 type compiler struct {
-	err *d2parser.ParseError
+	err             *d2parser.ParseError
+	activeClassMaps map[*d2ir.Map]struct{}
 }
 
 func (c *compiler) errorf(n d2ast.Node, f string, v ...interface{}) {
@@ -291,7 +292,10 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 		for _, className := range classNames {
 			classMap := m.GetClassMap(className)
 			if classMap != nil {
-				c.compileMap(obj, classMap)
+				if c.beginClass(class, className, classMap) {
+					c.compileMap(obj, classMap)
+					c.endClass(classMap)
+				}
 			} else {
 				if strings.Contains(className, ",") {
 					split := strings.Split(className, ",")
@@ -340,6 +344,22 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 			c.compileEdge(obj, e)
 		}
 	}
+}
+
+func (c *compiler) beginClass(class *d2ir.Field, className string, classMap *d2ir.Map) bool {
+	if c.activeClassMaps == nil {
+		c.activeClassMaps = make(map[*d2ir.Map]struct{})
+	}
+	if _, ok := c.activeClassMaps[classMap]; ok {
+		c.errorf(class.LastRef().AST(), `class %q forms a reference cycle`, className)
+		return false
+	}
+	c.activeClassMaps[classMap] = struct{}{}
+	return true
+}
+
+func (c *compiler) endClass(classMap *d2ir.Map) {
+	delete(c.activeClassMaps, classMap)
 }
 
 func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
@@ -905,7 +925,10 @@ func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
 		for _, className := range classNames {
 			classMap := m.GetClassMap(className)
 			if classMap != nil {
-				c.compileEdgeMap(edge, classMap)
+				if c.beginClass(class, className, classMap) {
+					c.compileEdgeMap(edge, classMap)
+					c.endClass(classMap)
+				}
 			}
 		}
 	}

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -46,6 +46,18 @@ func TestOpacityValidation(t *testing.T) {
 	}
 }
 
+func TestClassReferenceCycle(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := d2compiler.Compile(
+		"class-cycle.d2",
+		strings.NewReader("classes: { x: { class: x } }\na.class: x"),
+		nil,
+	)
+	assert.ErrorString(t, err, `class-cycle.d2:1:17: "class" cannot appear within "classes"
+class-cycle.d2:1:17: class "x" forms a reference cycle`)
+}
+
 func TestCompile(t *testing.T) {
 	t.Parallel()
 
@@ -3328,6 +3340,31 @@ nostar -> 1star: { class: path }
 
 				tassert.Equal(t, "4", g.Edges[0].Style.StrokeWidth.Value)
 				tassert.Equal(t, "then", g.Edges[0].Label.Value)
+			},
+		},
+		{
+			name: "recursive-glob-skips-definitions",
+			text: `classes: {
+  container: {
+    style.fill: red
+  }
+}
+vars: {
+  cont_variable: {
+    label: cont variable
+  }
+}
+**: {
+  &label: cont*
+  class: container
+}
+cont_target
+`,
+			assertions: func(t *testing.T, g *d2graph.Graph) {
+				tassert.Equal(t, 1, len(g.Objects))
+				tassert.Equal(t, "cont_target", g.Objects[0].AbsID())
+				tassert.Equal(t, []string{"container"}, g.Objects[0].Classes)
+				tassert.Equal(t, "red", g.Objects[0].Style.Fill.Value)
 			},
 		},
 		{

--- a/d2ir/pattern.go
+++ b/d2ir/pattern.go
@@ -76,7 +76,7 @@ func _doubleGlobField(f *Field, matches *[]*Field) {
 	}
 	name := f.Name.ScalarString()
 	if _, reserved := d2ast.ReservedKeywords[name]; reserved && f.Name.IsUnquoted() {
-		if _, board := d2ast.BoardKeywords[name]; board {
+		if skipDoubleGlobSubtree(name) {
 			return
 		}
 		if f.Map() != nil {
@@ -90,6 +90,15 @@ func _doubleGlobField(f *Field, matches *[]*Field) {
 	if f.Map() != nil {
 		f.Map()._doubleGlob(matches)
 	}
+}
+
+func skipDoubleGlobSubtree(name string) bool {
+	if _, board := d2ast.BoardKeywords[name]; board {
+		return true
+	}
+	// Classes and variables are definitions, not diagram objects. Applying
+	// recursive globs inside either map can mutate definitions before use.
+	return name == "classes" || name == "vars"
 }
 
 func _tripleGlobField(f *Field, matches *[]*Field) {
@@ -119,8 +128,9 @@ func (m *Map) _doubleGlob(fa *[]*Field) {
 		if f.Name == nil {
 			continue
 		}
-		if _, ok := d2ast.ReservedKeywords[f.Name.ScalarString()]; ok && f.Name.IsUnquoted() {
-			if _, ok := d2ast.BoardKeywords[f.Name.ScalarString()]; ok {
+		name := f.Name.ScalarString()
+		if _, ok := d2ast.ReservedKeywords[name]; ok && f.Name.IsUnquoted() {
+			if skipDoubleGlobSubtree(name) {
 				continue
 			}
 			if f.Map() != nil {

--- a/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.exp.json
+++ b/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.exp.json
@@ -1,0 +1,413 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,0:0:0-15:0:165",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,0:0:0-4:1:51",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,0:0:0-0:7:7",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,0:0:0-0:7:7",
+                    "value": [
+                      {
+                        "string": "classes",
+                        "raw_string": "classes"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,0:9:9-4:1:51",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,1:2:13-3:3:49",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,1:2:13-1:11:22",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,1:2:13-1:11:22",
+                              "value": [
+                                {
+                                  "string": "container",
+                                  "raw_string": "container"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,1:13:24-3:3:49",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,2:4:30-2:19:45",
+                                "key": {
+                                  "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,2:4:30-2:14:40",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,2:4:30-2:9:35",
+                                        "value": [
+                                          {
+                                            "string": "style",
+                                            "raw_string": "style"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,2:10:36-2:14:40",
+                                        "value": [
+                                          {
+                                            "string": "fill",
+                                            "raw_string": "fill"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "unquoted_string": {
+                                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,2:16:42-2:19:45",
+                                    "value": [
+                                      {
+                                        "string": "red",
+                                        "raw_string": "red"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,5:0:52-9:1:109",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,5:0:52-5:4:56",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,5:0:52-5:4:56",
+                    "value": [
+                      {
+                        "string": "vars",
+                        "raw_string": "vars"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,5:6:58-9:1:109",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,6:2:62-8:3:107",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,6:2:62-6:15:75",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,6:2:62-6:15:75",
+                              "value": [
+                                {
+                                  "string": "cont_variable",
+                                  "raw_string": "cont_variable"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,6:17:77-8:3:107",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,7:4:83-7:24:103",
+                                "key": {
+                                  "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,7:4:83-7:9:88",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,7:4:83-7:9:88",
+                                        "value": [
+                                          {
+                                            "string": "label",
+                                            "raw_string": "label"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "unquoted_string": {
+                                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,7:11:90-7:24:103",
+                                    "value": [
+                                      {
+                                        "string": "cont variable",
+                                        "raw_string": "cont variable"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,10:0:110-13:1:152",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,10:0:110-10:2:112",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,10:0:110-10:2:112",
+                    "value": [
+                      {
+                        "string": "**",
+                        "raw_string": "**"
+                      }
+                    ],
+                    "pattern": [
+                      "*",
+                      "",
+                      "*"
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,10:4:114-13:1:152",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,11:2:118-11:15:131",
+                      "ampersand": true,
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,11:3:119-11:8:124",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,11:3:119-11:8:124",
+                              "value": [
+                                {
+                                  "string": "label",
+                                  "raw_string": "label"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,11:10:126-11:15:131",
+                          "value": [
+                            {
+                              "string": "cont*",
+                              "raw_string": "cont*"
+                            }
+                          ],
+                          "pattern": [
+                            "cont",
+                            "*"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,12:2:134-12:18:150",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,12:2:134-12:7:139",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,12:2:134-12:7:139",
+                              "value": [
+                                {
+                                  "string": "class",
+                                  "raw_string": "class"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,12:9:141-12:18:150",
+                          "value": [
+                            {
+                              "string": "container",
+                              "raw_string": "container"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,14:0:153-14:11:164",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,14:0:153-14:11:164",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,14:0:153-14:11:164",
+                    "value": [
+                      {
+                        "string": "cont_target",
+                        "raw_string": "cont_target"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "iconStyle": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "cont_target",
+        "id_val": "cont_target",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,14:0:153-14:11:164",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/recursive-glob-skips-definitions.d2,14:0:153-14:11:164",
+                    "value": [
+                      {
+                        "string": "cont_target",
+                        "raw_string": "cont_target"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "cont_target"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {
+            "fill": {
+              "value": "red"
+            }
+          },
+          "iconStyle": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null,
+          "classes": [
+            "container"
+          ]
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": null
+}


### PR DESCRIPTION
## Summary

- keep recursive globs out of `classes` and `vars` definition maps
- detect class-reference cycles during object and edge compilation
- return a source diagnostic instead of overflowing the Go stack

## Verification

- `go test ./d2ir ./d2compiler -count=1`
- `go test -race ./d2ir ./d2compiler -count=1`
- `go vet ./d2ir ./d2compiler`
- the minimized issue input now compiles successfully
- full `e2etests` package passed
- `go test ./ci/release -count=1`

Fixes #2851