### PR TITLE
d2js: add worker disposal API

### DIFF
--- a/d2js/js/CHANGELOG.md
+++ b/d2js/js/CHANGELOG.md
@@ -5,6 +5,7 @@ include changes to the main d2 project.**
 
 ## Next
 
+- Add `D2.dispose()` for terminating the backing worker
 - Fix concurrent calls sharing a D2 instance
 - Fix completions after Unicode characters
 - Deprecate the raw `d2.getELKGraph` and `d2.getObjOrder` compatibility exports. They remain callable for one release and emit one migration warning per export.

--- a/d2js/js/README.md
+++ b/d2js/js/README.md
@@ -60,6 +60,7 @@ const d2 = new D2();
 
 const result = await d2.compile('x -> y');
 const svg = await d2.render(result.diagram, result.renderOptions);
+await d2.dispose();
 ```
 
 Configuring render options (see [CompileOptions](#compileoptions) for all available options):
@@ -112,6 +113,12 @@ Compiles D2 markup into an intermediate representation. It compile options are p
 ### `render(diagram: Diagram, options?: RenderOptions): Promise<string>`
 
 Renders a compiled diagram to SVG.
+
+### `dispose(): Promise<void>`
+
+Terminates the worker backing this D2 instance and rejects any pending operations. Call
+this when the instance is no longer needed so Node processes can exit and browser worker
+resources are released. Calling `dispose()` more than once is safe.
 
 ### `CompileOptions`
 

--- a/d2js/js/index.d.ts
+++ b/d2js/js/index.d.ts
@@ -3,6 +3,9 @@ export class D2 {
   compile(input: CompileRequest): Promise<CompileResponse>;
 
   render(diagram: Diagram, options?: RenderOptions): Promise<string>;
+
+  /** Terminates the backing worker and rejects any pending operations. */
+  dispose(): Promise<void>;
 }
 
 export interface RenderOptions {

--- a/d2js/js/src/index.js
+++ b/d2js/js/src/index.js
@@ -4,19 +4,21 @@ export class D2 {
   constructor() {
     this.nextRequestId = 0;
     this.pendingRequests = new Map();
+    this.disposed = false;
+    this.disposePromise = null;
     this.ready = this.init();
+  }
+
+  rejectPendingRequests(error) {
+    for (const request of this.pendingRequests.values()) {
+      request.reject(error);
+    }
+    this.pendingRequests.clear();
   }
 
   setupMessageHandler(isNode = typeof window === "undefined") {
     return new Promise((resolve, reject) => {
       let isReady = false;
-
-      const rejectPendingRequests = (error) => {
-        for (const request of this.pendingRequests.values()) {
-          request.reject(error);
-        }
-        this.pendingRequests.clear();
-      };
 
       const handleWorkerError = (error) => {
         const workerError =
@@ -24,7 +26,7 @@ export class D2 {
             ? error
             : new Error(error?.message || "D2 worker encountered an error");
         if (!isReady) reject(workerError);
-        rejectPendingRequests(workerError);
+        this.rejectPendingRequests(workerError);
         console.error(
           `Worker${isNode ? " (node)" : ""} encountered an error:`,
           workerError.message
@@ -44,7 +46,7 @@ export class D2 {
           if (data.type === "error") {
             const error = new Error(data.error);
             if (!isReady) reject(error);
-            rejectPendingRequests(error);
+            this.rejectPendingRequests(error);
           }
           return;
         }
@@ -91,7 +93,13 @@ export class D2 {
   }
 
   async sendMessage(type, data) {
+    if (this.disposed) {
+      throw new Error("D2 instance has been disposed");
+    }
     await this.ready;
+    if (this.disposed) {
+      throw new Error("D2 instance has been disposed");
+    }
     return new Promise((resolve, reject) => {
       const id = this.nextRequestId++;
       this.pendingRequests.set(id, { resolve, reject });
@@ -130,5 +138,24 @@ export class D2 {
 
   async jsVersion() {
     return this.sendMessage("jsVersion");
+  }
+
+  async dispose() {
+    if (this.disposePromise) return this.disposePromise;
+
+    this.disposed = true;
+    this.rejectPendingRequests(new Error("D2 instance has been disposed"));
+    this.disposePromise = (async () => {
+      try {
+        await this.ready;
+      } catch {
+        // Initialization errors are already exposed through ready. The worker,
+        // if one was created, still needs to be terminated.
+      }
+      const worker = this.worker;
+      this.worker = undefined;
+      if (worker) await worker.terminate();
+    })();
+    return this.disposePromise;
   }
 }

--- a/d2js/js/test/integration/cjs.test.js
+++ b/d2js/js/test/integration/cjs.test.js
@@ -6,6 +6,6 @@ describe("D2 CJS Integration", () => {
     const d2 = new D2();
     const result = await d2.compile("x -> y");
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 });

--- a/d2js/js/test/integration/esm.test.js
+++ b/d2js/js/test/integration/esm.test.js
@@ -6,6 +6,6 @@ describe("D2 ESM Integration", () => {
     const d2 = new D2();
     const result = await d2.compile("x -> y");
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 });

--- a/d2js/js/test/unit/basic.test.js
+++ b/d2js/js/test/unit/basic.test.js
@@ -6,14 +6,14 @@ describe("D2 Unit Tests", () => {
     const d2 = new D2();
     const result = await d2.compile("x -> y");
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("elk layout works", async () => {
     const d2 = new D2();
     const result = await d2.compile("x -> y", { layout: "elk" });
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("import works", async () => {
@@ -24,7 +24,7 @@ describe("D2 Unit Tests", () => {
     };
     const result = await d2.compile({ fs });
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("relative import works", async () => {
@@ -36,7 +36,7 @@ describe("D2 Unit Tests", () => {
     const inputPath = "folder/index.d2";
     const result = await d2.compile({ fs, inputPath });
     expect(result.diagram).toBeDefined();
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("render works", async () => {
@@ -45,7 +45,7 @@ describe("D2 Unit Tests", () => {
     const svg = await d2.render(result.diagram);
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("d2-config read correctly", async () => {
@@ -70,7 +70,7 @@ describe("D2 Unit Tests", () => {
     expect(result.renderOptions.darkThemeID).toBe(200);
     expect(result.renderOptions.center).toBe(true);
     expect(result.renderOptions.pad).toBe(10);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("render options take priority", async () => {
@@ -103,7 +103,7 @@ describe("D2 Unit Tests", () => {
     expect(result.renderOptions.darkThemeID).toBe(300);
     expect(result.renderOptions.center).toBe(false);
     expect(result.renderOptions.pad).toBe(0);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("sketch render works", async () => {
@@ -113,7 +113,7 @@ describe("D2 Unit Tests", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
     expect(svg).toContain("sketch-overlay");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("center render works", async () => {
@@ -123,7 +123,7 @@ describe("D2 Unit Tests", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
     expect(svg).toContain("xMidYMid meet");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("no XML tag works", async () => {
@@ -131,7 +131,7 @@ describe("D2 Unit Tests", () => {
     const result = await d2.compile("x -> y");
     const svg = await d2.render(result.diagram, { noXMLTag: true });
     expect(svg).not.toContain('<?xml version="1.0"');
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("force appendix works", async () => {
@@ -141,7 +141,7 @@ describe("D2 Unit Tests", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
     expect(svg).toContain('class="appendix"');
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("animated multi-board works", async () => {
@@ -159,7 +159,7 @@ describe("D2 Unit Tests", () => {
     const svg = await d2.render(result.diagram, result.renderOptions);
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("latex works", async () => {
@@ -168,7 +168,7 @@ describe("D2 Unit Tests", () => {
     const svg = await d2.render(result.diagram);
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("unicode characters work", async () => {
@@ -179,7 +179,7 @@ describe("D2 Unit Tests", () => {
     expect(svg).toContain("</svg>");
     expect(svg).toContain("こんにちは");
     expect(svg).toContain("♒️");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("handles syntax errors correctly", async () => {
@@ -191,7 +191,7 @@ describe("D2 Unit Tests", () => {
       expect(err).toBeDefined();
       expect(err.message).not.toContain("Should have thrown syntax error");
     }
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("handles unanimated multi-board error correctly", async () => {
@@ -212,7 +212,7 @@ describe("D2 Unit Tests", () => {
       expect(err).toBeDefined();
       expect(err.message).not.toContain("Should have thrown compile error");
     }
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("handles invalid imports correctly", async () => {
@@ -229,7 +229,7 @@ describe("D2 Unit Tests", () => {
       expect(err).toBeDefined();
       expect(err.message).not.toContain("Should have thrown compile error");
     }
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("theme overrides work correctly", async () => {
@@ -257,7 +257,7 @@ describe("D2 Unit Tests", () => {
     );
 
     expect(svgOverridden).toContain("fill:#000000");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("grid layout with elk engine matches go rendering", async () => {
@@ -303,7 +303,7 @@ describe("D2 Unit Tests", () => {
     expect(svg).toContain(">1</text>"); // Should contain the "1" element
     expect(svg).toContain(">2</text>"); // Should contain the "2" element
     expect(svg).toContain(">3</text>"); // Should contain the "3" element
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("layout engine switching works (dagre -> elk)", async () => {
@@ -348,7 +348,7 @@ describe("D2 Unit Tests", () => {
     expect(elkSvg).toContain("<svg");
     expect(elkSvg).toContain("</svg>");
 
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 30000);
 
   test("layout engine switching works (elk -> dagre -> elk)", async () => {
@@ -409,7 +409,7 @@ describe("D2 Unit Tests", () => {
     expect(elkSvg2).toContain("<svg");
     expect(elkSvg2).toContain("</svg>");
 
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 30000);
 
   test("version returns a string", async () => {
@@ -418,7 +418,7 @@ describe("D2 Unit Tests", () => {
     expect(version).toBeDefined();
     expect(typeof version).toBe("string");
     expect(version).toContain("v");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("jsVersion returns d2js version string", async () => {
@@ -427,7 +427,7 @@ describe("D2 Unit Tests", () => {
     expect(jsVersion).toBeDefined();
     expect(typeof jsVersion).toBe("string");
     expect(jsVersion.length).toBeGreaterThan(0);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("ASCII render works", async () => {
@@ -442,7 +442,7 @@ describe("D2 Unit Tests", () => {
     expect(ascii).toContain("┌") ||
       expect(ascii).toContain("└") ||
       expect(ascii).toContain("│");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("ASCII render with multiple shapes works", async () => {
@@ -460,7 +460,7 @@ describe("D2 Unit Tests", () => {
     expect(ascii).toContain("a");
     expect(ascii).toContain("b");
     expect(ascii).toContain("c");
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("ASCII mode options work correctly", async () => {
@@ -489,6 +489,6 @@ describe("D2 Unit Tests", () => {
     // Modes should produce different outputs
     expect(asciiExtended).not.toBe(asciiStandard);
 
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 });

--- a/d2js/js/test/unit/concurrency.test.js
+++ b/d2js/js/test/unit/concurrency.test.js
@@ -6,6 +6,7 @@ class FakeNodeWorker {
   constructor() {
     this.handlers = new Map();
     this.messages = [];
+    this.terminateCalls = 0;
   }
 
   on(type, handler) {
@@ -19,11 +20,17 @@ class FakeNodeWorker {
   emitMessage(message) {
     this.handlers.get("message")(message);
   }
+
+  terminate() {
+    this.terminateCalls++;
+    return Promise.resolve(0);
+  }
 }
 
 class FakeBrowserWorker {
   constructor() {
     this.messages = [];
+    this.terminateCalls = 0;
   }
 
   postMessage(message) {
@@ -32,6 +39,10 @@ class FakeBrowserWorker {
 
   emitMessage(message) {
     this.onmessage({ data: message });
+  }
+
+  terminate() {
+    this.terminateCalls++;
   }
 }
 
@@ -124,6 +135,31 @@ for (const [name, isNode] of [
       await expect(d2.version()).rejects.toThrow("post failed");
       expect(d2.pendingRequests.size).toBe(0);
     });
+
+    test("disposes the worker exactly once", async () => {
+      const { d2, worker } = createD2(isNode);
+
+      await Promise.all([d2.dispose(), d2.dispose()]);
+
+      expect(worker.terminateCalls).toBe(1);
+      expect(d2.worker).toBeUndefined();
+      await expect(d2.version()).rejects.toThrow("D2 instance has been disposed");
+    });
+
+    test("rejects pending requests when disposed", async () => {
+      const { d2, worker } = createD2(isNode);
+      const result = d2.compile("pending").then(
+        () => ({ resolved: true }),
+        (error) => ({ error })
+      );
+      await waitForRequests(worker, 1);
+
+      await d2.dispose();
+
+      expect((await result).error.message).toBe("D2 instance has been disposed");
+      expect(d2.pendingRequests.size).toBe(0);
+      expect(worker.terminateCalls).toBe(1);
+    });
   });
 }
 
@@ -147,5 +183,5 @@ test("correlates every operation through the real worker", async () => {
   expect(decoded).toBe("decoded result");
   expect(version).toMatch(/^v?\d+\.\d+\.\d+/);
   expect(jsVersion).toBe(packageJson.version);
-  await d2.worker.terminate();
+  await d2.dispose();
 }, 20000);

--- a/d2js/js/test/unit/encoding.test.js
+++ b/d2js/js/test/unit/encoding.test.js
@@ -9,7 +9,7 @@ describe("D2 Encoding Tests", () => {
     expect(encoded).toBeDefined();
     expect(typeof encoded).toBe("string");
     expect(encoded.length).toBeGreaterThan(0);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("decode encoded script works", async () => {
@@ -18,7 +18,7 @@ describe("D2 Encoding Tests", () => {
     const encoded = await d2.encode(script);
     const decoded = await d2.decode(encoded);
     expect(decoded).toBe(script);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("encode and decode complex script works", async () => {
@@ -45,7 +45,7 @@ user -> network.cell tower: make call`;
 
     const decoded = await d2.decode(encoded);
     expect(decoded).toBe(script);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("encode and decode unicode characters works", async () => {
@@ -57,7 +57,7 @@ user -> network.cell tower: make call`;
 
     const decoded = await d2.decode(encoded);
     expect(decoded).toBe(script);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("decode handles invalid input correctly", async () => {
@@ -69,7 +69,7 @@ user -> network.cell tower: make call`;
       expect(err).toBeDefined();
       expect(err.message).not.toContain("Should have thrown decode error");
     }
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 
   test("encode empty string works", async () => {
@@ -81,6 +81,6 @@ user -> network.cell tower: make call`;
 
     const decoded = await d2.decode(encoded);
     expect(decoded).toBe(script);
-    await d2.worker.terminate();
+    await d2.dispose();
   }, 20000);
 });


### PR DESCRIPTION
## Summary

- add a public, idempotent `D2.dispose()` API
- reject pending and future requests after disposal
- terminate and clear the backing Node or browser worker
- document and type the lifecycle API, and migrate tests off private worker access

## Verification

- `./ci/build.sh`
- `bun test:all` (43 unit tests and 2 CJS/ESM integration tests passed)

Fixes #2746