### PR TITLE
release: avoid duplicate Docker browser install

### DIFF
--- a/.github/workflows/docker-image-smoke.yml
+++ b/.github/workflows/docker-image-smoke.yml
@@ -1,0 +1,128 @@
+name: Docker image smoke
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/docker-image-smoke.yml
+      - ci/release/docker/Dockerfile
+      - ci/release/docker/entrypoint.sh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    env:
+      ARCH: ${{ matrix.arch }}
+      IMAGE: d2:docker-smoke-${{ matrix.arch }}
+      PLATFORM: ${{ matrix.platform }}
+      VERSION: v0.0.0-docker-smoke
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: ./go.mod
+          cache: true
+
+      - name: Build representative release archive
+        run: ./ci/release/build.sh --rebuild --run="linux/$ARCH" --version="$VERSION"
+
+      - name: Prepare Docker context
+        run: |
+          set -euo pipefail
+          context="$RUNNER_TEMP/docker-context"
+          mkdir -p "$context"
+          cp "ci/release/build/$VERSION/d2-$VERSION-linux-$ARCH.tar.gz" "$context/"
+          cp ci/release/docker/entrypoint.sh "$context/entrypoint.sh"
+
+      - name: Build and measure image
+        id: image
+        run: |
+          set -euo pipefail
+          builder="d2-docker-smoke-$ARCH"
+          oci_archive="$RUNNER_TEMP/d2-$ARCH.oci.tar"
+          context="$RUNNER_TEMP/docker-context"
+
+          docker buildx create --name "$builder" --driver docker-container --use
+          docker buildx inspect --bootstrap
+          docker buildx build \
+            --platform "$PLATFORM" \
+            --provenance=false \
+            --output "type=oci,dest=$oci_archive,compression=gzip,compression-level=6,force-compression=true" \
+            --file ci/release/docker/Dockerfile \
+            "$context"
+
+          manifest_digest=$(tar -xOf "$oci_archive" index.json | jq -er '.manifests[0].digest')
+          manifest_path="blobs/sha256/${manifest_digest#sha256:}"
+          compressed_bytes=$(tar -xOf "$oci_archive" "$manifest_path" | \
+            jq -er '[.layers[].size] | add')
+          rm "$oci_archive"
+
+          docker buildx build \
+            --platform "$PLATFORM" \
+            --provenance=false \
+            --load \
+            --tag "$IMAGE" \
+            --file ci/release/docker/Dockerfile \
+            "$context"
+          uncompressed_bytes=$(docker image inspect --format '{{.Size}}' "$IMAGE")
+
+          printf 'Compressed OCI layers: %s bytes\n' "$compressed_bytes"
+          printf 'Uncompressed image: %s bytes\n' "$uncompressed_bytes"
+          echo "compressed_bytes=$compressed_bytes" >>"$GITHUB_OUTPUT"
+          echo "uncompressed_bytes=$uncompressed_bytes" >>"$GITHUB_OUTPUT"
+          {
+            echo "### $PLATFORM"
+            echo
+            echo "- Compressed OCI layers: $compressed_bytes bytes"
+            echo "- Uncompressed image: $uncompressed_bytes bytes"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Smoke-test CLI, SVG, and PNG
+        run: |
+          set -euo pipefail
+          smoke="$RUNNER_TEMP/smoke"
+          mkdir -p "$smoke"
+          printf 'x -> y\n' >"$smoke/input.d2"
+
+          version_output=$(docker run --rm --platform "$PLATFORM" "$IMAGE" --version)
+          version_output=${version_output%$'\r'}
+          test "$version_output" = "$VERSION"
+
+          docker run --rm --platform "$PLATFORM" \
+            -u "$(id -u):$(id -g)" \
+            -v "$smoke:/home/debian/src" \
+            "$IMAGE" input.d2 output.svg
+          test -s "$smoke/output.svg"
+          grep -q '<svg' "$smoke/output.svg"
+
+          docker run --rm --platform "$PLATFORM" \
+            -u "$(id -u):$(id -g)" \
+            -v "$smoke:/home/debian/src" \
+            "$IMAGE" input.d2 output.png
+          test -s "$smoke/output.png"
+          test "$(od -An -tx1 -N8 "$smoke/output.png" | tr -d ' \n')" = 89504e470d0a1a0a
+
+      - name: Clean up Docker image and builder
+        if: always()
+        run: |
+          docker image rm --force "$IMAGE" >/dev/null 2>&1 || true
+          docker buildx rm "d2-docker-smoke-$ARCH" >/dev/null 2>&1 || true

--- a/ci/release/docker/Dockerfile
+++ b/ci/release/docker/Dockerfile
@@ -4,11 +4,18 @@ FROM ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e8
 ARG TARGETARCH
 ARG FIXUID_VERSION=0.6.0
 
-RUN apt-get update && apt-get install -y ca-certificates curl dumb-init sudo
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl dumb-init sudo \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash -s - && \
-  apt-get install -y nodejs
-RUN npx playwright@1.61.1 install --with-deps chromium
+  apt-get install -y --no-install-recommends nodejs && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install Chromium's system libraries without downloading a browser. The
+# non-root d2 init-playwright step below installs the single runtime copy.
+RUN npx --yes playwright@1.61.1 install-deps chromium \
+  && rm -rf /root/.npm /var/lib/apt/lists/*
 
 RUN adduser --gecos '' --disabled-password debian \
   && echo "debian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd

--- a/ci/release/docker/prepare_continuity_dockerfile_test.go
+++ b/ci/release/docker/prepare_continuity_dockerfile_test.go
@@ -20,6 +20,25 @@ func TestPrepareV082DockerfileMakesPlaywrightNonInteractive(t *testing.T) {
 	}
 }
 
+func TestReleaseDockerfileInstallsOnePlaywrightBrowser(t *testing.T) {
+	t.Parallel()
+
+	dockerfile, err := os.ReadFile("Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(dockerfile)
+	if strings.Contains(source, "install --with-deps chromium") {
+		t.Fatal("release Dockerfile downloads a root-owned Playwright browser")
+	}
+	if got := strings.Count(source, "install-deps chromium"); got != 1 {
+		t.Fatalf("release Dockerfile has %d Playwright dependency installs, want 1", got)
+	}
+	if got := strings.Count(source, "RUN CI=1 d2 init-playwright"); got != 1 {
+		t.Fatalf("release Dockerfile has %d runtime Playwright installs, want 1", got)
+	}
+}
+
 func TestPrepareV082DockerfileRejectsUnexpectedSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- install only Playwright system dependencies in the root Docker layer
- keep one runtime Chromium installation owned by the non-root D2 user
- remove package-manager metadata from the image layers
- add native amd64 and arm64 image builds that report compressed size and smoke-test CLI, SVG, and PNG output

## Why
The v0.8.2 Dockerfile installs Chromium first through `npx playwright install --with-deps` as root and then through `d2 init-playwright` as the runtime user, so the browser is downloaded into two separate user caches.

This changes the root step to Playwright's dependency-only installation. The existing non-root initialization remains the single browser installation, preserving PNG export behavior.

The workflow reports measured image sizes rather than enforcing a fixed ceiling.

## Measured result
Compressed OCI layers, compared with the currently published v0.8.2 images:

| Platform | v0.8.2 | This PR | Reduction |
| --- | ---: | ---: | ---: |
| linux/amd64 | 968,956,824 B | 625,396,438 B | 343,560,386 B (35.46%) |
| linux/arm64 | 1,037,552,173 B | 656,945,936 B | 380,606,237 B (36.68%) |

Both native jobs passed D2 version, SVG, and PNG rendering smoke tests.

## Validation
- `go test ./ci/release/docker -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docker-image-smoke.yml`
- representative release archives built for linux/amd64 and linux/arm64
- full `COLOR=1 CI_FORCE=1 ./make.sh`
- [native linux/amd64 and linux/arm64 Docker smoke run](https://github.com/d2lang/d2/actions/runs/33204283655)