### PR TITLE
d2sequence: stabilize lifeline endpoint IDs

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Bugfixes ⛑️
 
+- sequence diagrams: keep synthetic lifeline endpoint IDs stable across architectures
 - exports: honor `D2_TIMEOUT` during PNG and GIF rendering in Playwright
 - compiler: keep recursive globs out of class and variable definitions and report class reference cycles instead of overflowing the stack
 - renders: decode gzip, Brotli, and deflate remote images before embedding them

--- a/d2layouts/d2sequence/layout_test.go
+++ b/d2layouts/d2sequence/layout_test.go
@@ -126,6 +126,12 @@ n2 -> n1
 	lastSequenceEdge := g.Edges[nEdges-1]
 	for i := nEdges; i < nExpectedEdges; i++ {
 		edge := g.Edges[i]
+		if got, want := edge.Dst.ID, d2sequence.LifelineEndID(edge.Src.ID); got != want {
+			t.Fatalf("expected lifeline edge[%d] destination ID %q, got %q", i, want, got)
+		}
+		if !d2sequence.IsLifelineEnd(edge.Dst) {
+			t.Fatalf("expected lifeline edge[%d] destination to be recognized as a lifeline end", i)
+		}
 		if len(edge.Route) != 2 {
 			t.Fatalf("expected lifeline edge[%d] to have only 2 points", i)
 		}

--- a/d2layouts/d2sequence/lifeline_test.go
+++ b/d2layouts/d2sequence/lifeline_test.go
@@ -1,0 +1,49 @@
+package d2sequence_test
+
+import (
+	"testing"
+
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2layouts/d2sequence"
+	"github.com/d2lang/d2/lib/geo"
+)
+
+func TestLifelineEndIDArchitectureStable(t *testing.T) {
+	const actorID = "a"
+	const want = "a-lifeline-end-2251863791"
+
+	if got := d2sequence.LifelineEndID(actorID); got != want {
+		t.Fatalf("LifelineEndID(%q) = %q, want %q", actorID, got, want)
+	}
+
+	legacySignedID := "a-lifeline-end--2043103505"
+	if d2sequence.IsLifelineEnd(&d2graph.Object{ID: legacySignedID}) {
+		t.Fatalf("IsLifelineEnd accepted architecture-dependent ID %q", legacySignedID)
+	}
+}
+
+func TestIsLifelineEnd(t *testing.T) {
+	actorWithMarker := "actor-lifeline-end-archive"
+	validID := d2sequence.LifelineEndID(actorWithMarker)
+
+	tests := []struct {
+		name string
+		obj  *d2graph.Object
+		want bool
+	}{
+		{name: "nil", obj: nil},
+		{name: "valid", obj: &d2graph.Object{ID: validID}, want: true},
+		{name: "wrong hash", obj: &d2graph.Object{ID: actorWithMarker + "-lifeline-end-0"}},
+		{name: "ordinary object", obj: &d2graph.Object{ID: actorWithMarker}},
+		{name: "graph member", obj: &d2graph.Object{ID: validID, Graph: &d2graph.Graph{}}},
+		{name: "child", obj: &d2graph.Object{ID: validID, Parent: &d2graph.Object{}}},
+		{name: "positioned", obj: &d2graph.Object{ID: validID, Box: geo.NewBox(nil, 1, 1)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := d2sequence.IsLifelineEnd(test.obj); got != test.want {
+				t.Fatalf("IsLifelineEnd(%#v) = %t, want %t", test.obj, got, test.want)
+			}
+		})
+	}
+}

--- a/d2layouts/d2sequence/sequence_diagram.go
+++ b/d2layouts/d2sequence/sequence_diagram.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"slices"
 	"sort"
@@ -442,7 +443,7 @@ func (sd *sequenceDiagram) addLifelineEdges() {
 			Src:        actor,
 			SrcArrow:   false,
 			Dst: &d2graph.Object{
-				ID: actor.ID + fmt.Sprintf("-lifeline-end-%d", go2.StringToIntHash(actor.ID+"-lifeline-end")),
+				ID: LifelineEndID(actor.ID),
 			},
 			DstArrow: false,
 			Route:    []*geo.Point{actorBottom, actorLifelineEnd},
@@ -451,23 +452,30 @@ func (sd *sequenceDiagram) addLifelineEdges() {
 	}
 }
 
+const lifelineEndSuffix = "-lifeline-end"
+
+// LifelineEndID returns the synthetic endpoint ID for an actor's lifeline.
+// The hash is formatted as an unsigned 32-bit value so the ID is stable across
+// architectures.
+func LifelineEndID(actorID string) string {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(actorID + lifelineEndSuffix))
+	return actorID + lifelineEndSuffix + "-" + strconv.FormatUint(uint64(hash.Sum32()), 10)
+}
+
+// IsLifelineEnd reports whether obj is a synthetic sequence-diagram lifeline
+// endpoint.
 func IsLifelineEnd(obj *d2graph.Object) bool {
 	// lifeline ends only have ID and no graph parent or box set
-	if obj.Graph != nil || obj.Parent != nil || obj.Box != nil {
+	if obj == nil || obj.Graph != nil || obj.Parent != nil || obj.Box != nil {
 		return false
 	}
-	if !strings.Contains(obj.ID, "-lifeline-end-") {
+	marker := lifelineEndSuffix + "-"
+	markerIndex := strings.LastIndex(obj.ID, marker)
+	if markerIndex < 0 {
 		return false
 	}
-	parts := strings.Split(obj.ID, "-lifeline-end-")
-	if len(parts) > 1 {
-		hash := parts[len(parts)-1]
-		actorID := strings.Join(parts[:len(parts)-1], "-lifeline-end-")
-		if strconv.Itoa(go2.StringToIntHash(actorID+"-lifeline-end")) == hash {
-			return true
-		}
-	}
-	return false
+	return obj.ID == LifelineEndID(obj.ID[:markerIndex])
 }
 
 func (sd *sequenceDiagram) placeNotes() {


### PR DESCRIPTION
## Human

minor nondeterminism fix in d2sequence

---

## AI

Sequence diagrams previously formatted their FNV-32 lifeline hashes through Go's architecture-sized `int`. Hashes with the high bit set therefore produced positive endpoint IDs on 64-bit native builds but negative IDs on 32-bit and WebAssembly builds.

This change:

- centralizes endpoint generation in `d2sequence.LifelineEndID`
- formats hashes as unsigned 32-bit values on every architecture
- makes `IsLifelineEnd` validate the same canonical ID and handle nil safely
- rejects the former signed 32-bit spelling instead of preserving a second protocol
- covers generated edges, high-bit hashes, embedded markers, malformed IDs, and structural guards

Existing 64-bit/native IDs and checked-in goldens are unchanged.

Verification:

- `CI=1 GOWORK=off go test ./... -count=1`
- `GOWORK=off go test -race ./d2layouts/d2sequence ./d2layouts -count=1`
- `GOWORK=off go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.8.1 ./d2layouts/d2sequence ./d2layouts`
- executed `GOOS=js GOARCH=wasm` tests for `./d2layouts/d2sequence ./d2layouts`
- built `./d2js` with `GOOS=js GOARCH=wasm`
- cross-compiled the sequence package tests for `linux/386`
