### PR TITLE
perf: eliminate repeated compiler and font work

### DIFF
--- a/ci/nonlayout-perf/README.md
+++ b/ci/nonlayout-perf/README.md
@@ -1,0 +1,94 @@
+# D2 E2E performance without layout
+
+This diagnostic harness runs the **existing active E2E tests**, using Go source
+overlays to time their phases and optionally capture inputs for a renderer-only
+replay. It preserves their skip rules, assertions, expected errors, geometry
+JSON goldens, SVG goldens, and ASCII goldens. No tests or golden files are edited.
+Generated binaries, profiles, results, and captured diagrams belong outside the
+repository. Python 3.9+, Git, and the repository's Go toolchain are required.
+
+Use an explicit baseline commit, or a separate baseline worktree with `--current`.
+There is no default baseline: committing the candidate must not silently change
+the control. `--base-ref` restores changed Go sources with an overlay and excludes
+Go files added after that ref. It rejects differing `go.mod`/`go.sum` and non-Go inputs outside this harness,
+including embedded assets and txtar fixtures; use a separate baseline worktree
+when those inputs differ. Instrumentation fails if its
+source anchors change, so a new E2E/compiler structure needs an explicit review.
+
+From the repository root, for example:
+
+```sh
+BASE=0515f60e985ad829d652456e07831170583011a0
+python3 ci/nonlayout-perf/run.py phases --base-ref "$BASE" --out /tmp/d2-base-1 --capture
+python3 ci/nonlayout-perf/run.py phases --current --out /tmp/d2-head-1
+python3 ci/nonlayout-perf/run.py phases --current --out /tmp/d2-head-2
+python3 ci/nonlayout-perf/run.py phases --base-ref "$BASE" --out /tmp/d2-base-2
+python3 ci/nonlayout-perf/run.py compare \
+  --baseline /tmp/d2-base-1/run-0.json /tmp/d2-base-2/run-0.json \
+  --candidate /tmp/d2-head-1/run-0.json /tmp/d2-head-2/run-0.json
+```
+
+Each invocation builds its source variant, then starts a fresh test process with
+`CI=1`, error-level logging, `GOMAXPROCS=1`, and `-test.parallel 1`.
+Inherited golden acceptance (`TESTDATA_ACCEPT`/`TA`), SVG skipping, and diff
+suppression settings are cleared so verification cannot silently accept output. It runs from the
+E2E directory so relative fixtures resolve correctly. Build time is excluded from
+reported process wall/user/system time. `--runs N` repeats fresh processes;
+alternating variants helps control system noise. `--gomaxprocs N` changes the CPU
+limit. Use a fresh output directory for each invocation; previous results are
+never overwritten. Provenance records the source ref, working-tree diff and new
+Go source hashes, toolchain, harness files, and binary hash.
+
+The product non-layout metric is:
+
+```
+compile_total - layout_excluded + svg_render + animation
+```
+
+`layout_excluded` wraps **all of `d2layouts.LayoutNested`**, including nested
+placement, routing, and layout-internal sizing. Layout signature/preparation work
+outside that call remains included. Compiler, theme, dimensions, and export are
+reported as a decomposition of compilation; they are not added a second time.
+Setup/serde separately includes ruler construction, its compiler and dimension
+passes, graph serialization/deserialization, and JSON equality checking. XML
+verification and ASCII rendering are also separate. The combined timed metric
+excludes test registration, feature checks, assertions, golden I/O/diffing, capture
+and hash/output overhead. It is **not total E2E wall time**.
+
+`compare` requires identical complete output fingerprint sets and per-case phase
+invocation counts. Counts are derived from the running suite, not fixed in the
+harness. `--profile` adds CPU profiles for diagnosis. Profiling has substantial
+cost for this allocation-heavy workload: use unprofiled runs for performance
+claims. The labels describe the innermost timed phase; an enclosing compilation
+CPU total must not be inferred from these labels.
+
+## Renderer replay with zero layout calls
+
+The capture contains actual pre-render diagrams and finalized options, including
+multiboard master IDs. It does not reconstruct inputs or options from goldens.
+Use this same corpus for both variants:
+
+```sh
+python3 ci/nonlayout-perf/run.py render --base-ref "$BASE" \
+  --corpus /tmp/d2-base-1/corpus --oracle /tmp/d2-base-1/run-0.json --out /tmp/d2-render-base-1
+python3 ci/nonlayout-perf/run.py render --current \
+  --corpus /tmp/d2-base-1/corpus --oracle /tmp/d2-base-1/run-0.json --out /tmp/d2-render-head-1
+python3 ci/nonlayout-perf/run.py compare \
+  --baseline /tmp/d2-render-base-1/run-0.json \
+  --candidate /tmp/d2-render-head-1/run-0.json --threshold 10
+```
+
+Use the same alternating order and multiple samples as the phase comparison for
+final measurements. Every replay verifies byte-for-byte SHA256/length equality
+against the SVGs produced by the original E2E run and checks that rendering did
+not mutate the captured input. It reports individual diagram timings, aggregate
+render/animation time, allocations, process CPU/wall time, and a distribution of
+per-diagram speedups. `--threshold` optionally counts diagrams meeting any chosen
+ratio; it does not change the aggregate metric or its interpretation.
+
+Fixture loading and package initialization are outside individual render timers
+but inside process time. SHA/input-mutation checks are outside render timers but
+inside pass wall/alloc totals. GC is forced before each pass; GC during rendering
+is included. `--passes 2` runs first use and then reuse of the same in-memory
+inputs in one process; there is no output cache in the harness. Keep first-use and
+reuse results separate when interpreting workload behavior.

--- a/ci/nonlayout-perf/overlay.py
+++ b/ci/nonlayout-perf/overlay.py
@@ -1,0 +1,165 @@
+"""Build private, source-checked instrumentation without editing tracked files."""
+
+import re
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def git(repo, *args):
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True)
+
+
+def replace(source, old, new, count=1):
+    actual = source.count(old)
+    if actual != count:
+        raise ValueError(
+            f"Instrumentation source changed: expected {count} occurrence(s), "
+            f"found {actual}: {old!r}"
+        )
+    return source.replace(old, new)
+
+
+def prepare(repo, output, base_ref):
+    def read(path):
+        if base_ref:
+            return git(repo, "show", f"{base_ref}:{path}")
+        return (repo / path).read_text()
+
+    source = read("d2lib/d2.go")
+    source = replace(source, '"context"', '''"context"
+        "crypto/sha256"
+        "encoding/json"
+        "os"
+        "path/filepath"
+        "runtime/pprof"
+        "sync"
+        "time"''')
+    source = replace(
+        source, "\tg, config, err := d2compiler.Compile",
+        '\tprobeCompiler := NonlayoutProbe(ctx, "compiler")\n'
+        "\tg, config, err := d2compiler.Compile",
+    )
+    source = replace(source, "\t\tFS:       compileOpts.FS,\n\t})",
+                     "\t\tFS:       compileOpts.FS,\n\t})\n probeCompiler()")
+
+    # These statements are disjoint. The enclosing compile_total is reported
+    # separately and is never added to its own component measurements.
+    statements = [
+        ("theme", "\terr := g.ApplyTheme(*renderOpts.ThemeID)"),
+        ("dimensions", "\t\terr := g.SetDimensions(compileOpts.MeasuredTexts, "
+         "compileOpts.Ruler, compileOpts.FontFamily, compileOpts.MonoFontFamily)"),
+        ("layout_excluded", "\t\t\terr = d2layouts.LayoutNested(ctx, g, "
+         "graphInfo, coreLayout, edgeRouter)"),
+        ("export", "\td, err := d2exporter.Export(ctx, g, compileOpts.FontFamily, "
+         "compileOpts.MonoFontFamily)"),
+    ]
+    for phase, statement in statements:
+        variable = "probe_" + phase
+        source = replace(source, statement,
+                         f'\n{variable} := NonlayoutProbe(ctx, "{phase}")\n'
+                         + statement + f"\n{variable}()")
+    helper = (HERE / "probe.go.txt").read_text()
+    source += "\n" + replace(helper, "package d2lib\n\n", "")
+
+    test = read("e2etests/e2e_test.go")
+    test = replace(test, "func TestE2E(t *testing.T) {",
+                   "func TestE2E(t *testing.T) {\n"
+                   "t.Cleanup(func() { assert.Success(t, d2lib.NonlayoutProbeWrite()) })")
+    test = replace(test, "ctx = log.Leveled(ctx, slog.LevelDebug)",
+                   "ctx = log.Leveled(ctx, slog.LevelError)\n"
+                   'ctx = d2lib.NonlayoutCase(ctx, strings.TrimPrefix(t.Name(), "TestE2E/"))', 2)
+    test = replace(test,
+                   "func serde(t *testing.T, tc testCase, ruler *textmeasure.Ruler) {",
+                   "func serde(t *testing.T, tc testCase, ruler *textmeasure.Ruler, "
+                   "ctx context.Context) {\n"
+                   'probeSerde := d2lib.NonlayoutProbe(ctx, "serde_compiler")')
+    test = replace(test, "serde(t, tc, ruler)", "serde(t, tc, ruler, ctx)", 2)
+    test = replace(test, "\t\tUTF16Pos: false,\n\t})",
+                   "\t\tUTF16Pos: false,\n\t})\nprobeSerde()")
+
+    statements = [
+        ("serde_dimensions", "\t\terr = g.SetDimensions(nil, ruler, nil, nil)"),
+        ("serde_serialize", "\tb, err := d2graph.SerializeGraph(g)"),
+        ("serde_deserialize", "\terr = d2graph.DeserializeGraph(b, &newG)"),
+        ("serde_serialize", "\troundTripBytes, err := d2graph.SerializeGraph(&newG)"),
+        ("serde_json_compare", "\ttrequire.JSONEq(t, string(b), string(roundTripBytes))"),
+        ("ruler", "\truler, err := textmeasure.NewRuler()"),
+        ("ruler", "\t\truler, err = textmeasure.NewRuler()"),
+    ]
+    for index, (phase, statement) in enumerate(statements):
+        variable = f"probe_{index}"
+        test = replace(test, statement,
+                       f'\n{variable} := d2lib.NonlayoutProbe(ctx, "{phase}")\n'
+                       + statement + f"\n{variable}()")
+
+    test = replace(test, "\tfor _, layoutName := range layoutsTested {",
+                   "\tfor _, layoutName := range layoutsTested {\n"
+                   'ctx = d2lib.NonlayoutCase(ctx, strings.TrimPrefix(t.Name(), "TestE2E/")+"/"+layoutName)')
+    test = replace(test, "\tplugin := &d2plugin.ELKPlugin",
+                   'ctx = d2lib.NonlayoutCase(ctx, strings.TrimPrefix(t.Name(), "TestE2E/")+"/elk")\n'
+                   "\tplugin := &d2plugin.ELKPlugin")
+
+    # Two runners execute the real active cases: ordinary E2E and ASCII txtar.
+    # Newline prefixes prevent matching a statement with deeper indentation.
+    for indent in ("\n\t", "\n\t\t"):
+        statements = [
+            ("compile_total", indent + "diagram, g, err := d2lib.Compile(ctx, "
+             "tc.script, compileOpts, renderOpts)"),
+            ("svg_render", indent + "boards, err := d2svg.RenderMultiboard(diagram, renderOpts)"),
+            ("xml_verify", indent + "err = xml.Unmarshal(svgBytes, &xmlParsed)"),
+            ("animation", indent + "\tsvgBytes, err = d2animate.Wrap(diagram, boards, *renderOpts, 1000)"),
+        ]
+        for phase, statement in statements:
+            prefix = ""
+            suffix = ""
+            if phase == "svg_render":
+                prefix = "\nassert.Success(t, d2lib.NonlayoutCapture(ctx, diagram, renderOpts))\n"
+            elif phase == "xml_verify":
+                suffix = '\nd2lib.NonlayoutFingerprint(ctx, "svg", svgBytes)'
+            variable = "probe_" + phase
+            test = replace(test, statement, prefix
+                           + f'\n{variable} := d2lib.NonlayoutProbe(ctx, "{phase}")'
+                           + statement + f"\n{variable}()" + suffix)
+
+    for mode in ("extended", "standard"):
+        statement = (f"\t{mode}Bytes, err := {mode}AsciiArtist.Render(ctx, "
+                     f"diagram, {mode}RenderOpts)")
+        test = replace(test, statement,
+                       f'\nprobe_{mode} := d2lib.NonlayoutProbe(ctx, "ascii_{mode}")\n'
+                       + statement + f"\nprobe_{mode}()\n"
+                       + f'd2lib.NonlayoutFingerprint(ctx, "ascii_{mode}", {mode}Bytes)')
+
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "d2.go").write_text(source)
+    (output / "e2e_test.go").write_text(test)
+    mapping = {
+        str(repo / "d2lib/d2.go"): str(output / "d2.go"),
+        str(repo / "e2etests/e2e_test.go"): str(output / "e2e_test.go"),
+    }
+    if base_ref:
+        paths = set(git(repo, "diff", "--name-only", base_ref, "--", "*.go").splitlines())
+        paths.update(git(repo, "ls-files", "--others", "--exclude-standard", "--", "*.go").splitlines())
+        for index, path in enumerate(sorted(paths)):
+            if str(repo / path) in mapping:
+                continue
+            replacement = output / f"base-{index}.go"
+            exists = subprocess.run(
+                ["git", "-C", str(repo), "cat-file", "-e", f"{base_ref}:{path}"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            ).returncode == 0
+            if exists:
+                contents = read(path)
+            else:
+                # A file introduced after the baseline must not contribute code,
+                # tests, or initializers to the baseline binary.
+                current = (repo / path).read_text()
+                match = re.search(r"(?m)^package\s+(\w+)", current)
+                if not match:
+                    raise ValueError(f"Cannot identify package in {path}")
+                contents = f"package {match.group(1)}\n"
+            replacement.write_text(contents)
+            mapping[str(repo / path)] = str(replacement)
+    subprocess.run(["gofmt", "-w", str(output / "d2.go"), str(output / "e2e_test.go")], check=True)
+    return mapping

--- a/ci/nonlayout-perf/probe.go.txt
+++ b/ci/nonlayout-perf/probe.go.txt
@@ -1,0 +1,88 @@
+package d2lib
+
+// Private performance overlay helpers; never compiled into repository artifacts.
+type NonlayoutEvent struct {
+	Case        string `json:"case"`
+	Phase       string `json:"phase"`
+	Count       int    `json:"count"`
+	Nanoseconds int64  `json:"nanoseconds"`
+}
+type NonlayoutHash struct {
+	Case   string `json:"case"`
+	Kind   string `json:"kind"`
+	SHA256 string `json:"sha256"`
+	Bytes  int    `json:"bytes"`
+}
+
+var nonlayoutProbeData = struct {
+	sync.Mutex
+	Events map[string]*NonlayoutEvent
+	Hashes []NonlayoutHash
+}{Events: make(map[string]*NonlayoutEvent)}
+
+func NonlayoutCase(ctx context.Context, name string) context.Context {
+	ctx = pprof.WithLabels(ctx, pprof.Labels("case", name))
+	pprof.SetGoroutineLabels(ctx)
+	return ctx
+}
+func nonlayoutCaseName(ctx context.Context) string { name, _ := pprof.Label(ctx, "case"); return name }
+func NonlayoutProbe(ctx context.Context, phase string) func() {
+	name := nonlayoutCaseName(ctx)
+	pprof.SetGoroutineLabels(pprof.WithLabels(ctx, pprof.Labels("phase", phase)))
+	start := time.Now()
+	return func() {
+		elapsed := time.Since(start).Nanoseconds()
+		pprof.SetGoroutineLabels(ctx)
+		nonlayoutProbeData.Lock()
+		defer nonlayoutProbeData.Unlock()
+		key := name + "\x00" + phase
+		e := nonlayoutProbeData.Events[key]
+		if e == nil {
+			e = &NonlayoutEvent{Case: name, Phase: phase}
+			nonlayoutProbeData.Events[key] = e
+		}
+		e.Count++
+		e.Nanoseconds += elapsed
+	}
+}
+func NonlayoutCapture(ctx context.Context, d *d2target.Diagram, o *d2svg.RenderOpts) error {
+	path := os.Getenv("D2_NONLAYOUT_CAPTURE")
+	if path == "" {
+		return nil
+	}
+	name := nonlayoutCaseName(ctx)
+	data, err := json.Marshal(struct {
+		Case    string            `json:"case"`
+		Diagram *d2target.Diagram `json:"diagram"`
+		Options *d2svg.RenderOpts `json:"options"`
+	}{name, d, o})
+	if err != nil {
+		return err
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(path, hash+".json"), data, 0600)
+}
+func NonlayoutFingerprint(ctx context.Context, kind string, data []byte) {
+	nonlayoutProbeData.Lock()
+	defer nonlayoutProbeData.Unlock()
+	nonlayoutProbeData.Hashes = append(nonlayoutProbeData.Hashes, NonlayoutHash{nonlayoutCaseName(ctx), kind, fmt.Sprintf("%x", sha256.Sum256(data)), len(data)})
+}
+func NonlayoutProbeWrite() error {
+	path := os.Getenv("D2_NONLAYOUT_PHASE_OUT")
+	if path == "" {
+		return nil
+	}
+	nonlayoutProbeData.Lock()
+	defer nonlayoutProbeData.Unlock()
+	data, err := json.MarshalIndent(struct {
+		Events map[string]*NonlayoutEvent `json:"events"`
+		Hashes []NonlayoutHash            `json:"hashes"`
+	}{nonlayoutProbeData.Events, nonlayoutProbeData.Hashes}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/ci/nonlayout-perf/render.go.txt
+++ b/ci/nonlayout-perf/render.go.txt
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"time"
+
+	"github.com/d2lang/d2/d2renderers/d2animate"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+type fixture struct {
+	Case    string            `json:"case"`
+	Diagram *d2target.Diagram `json:"diagram"`
+	Options *d2svg.RenderOpts `json:"options"`
+}
+type result struct {
+	Case         string `json:"case"`
+	Pass         int    `json:"pass"`
+	RenderNS     int64  `json:"render_ns"`
+	AnimationNS  int64  `json:"animation_ns"`
+	SHA256       string `json:"sha256"`
+	Bytes        int    `json:"bytes"`
+	InputMutated bool   `json:"input_mutated"`
+}
+type passResult struct {
+	Pass        int    `json:"pass"`
+	RenderNS    int64  `json:"render_ns"`
+	AnimationNS int64  `json:"animation_ns"`
+	WallNS      int64  `json:"wall_ns"`
+	AllocBytes  uint64 `json:"alloc_bytes"`
+	Allocs      uint64 `json:"allocs"`
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+func hash(v any) [32]byte { b, e := json.Marshal(v); check(e); return sha256.Sum256(b) }
+func main() {
+	corpus := flag.String("corpus", "", "captured render fixture directory")
+	out := flag.String("out", "", "output JSON path")
+	repeat := flag.Int("repeat", 1, "passes through corpus in one process")
+	profile := flag.String("cpu-profile", "", "optional render-only profile path")
+	flag.Parse()
+	if *corpus == "" || *out == "" || *repeat < 1 {
+		panic("corpus, out, and repeat>=1 required")
+	}
+	paths, e := filepath.Glob(filepath.Join(*corpus, "*.json"))
+	check(e)
+	if len(paths) == 0 {
+		panic("empty corpus")
+	}
+	fixtures := make([]fixture, 0, len(paths))
+	for _, p := range paths {
+		b, e := os.ReadFile(p)
+		check(e)
+		var f fixture
+		check(json.Unmarshal(b, &f))
+		fixtures = append(fixtures, f)
+	}
+	sort.Slice(fixtures, func(i, j int) bool { return fixtures[i].Case < fixtures[j].Case })
+	inputs := make([][32]byte, len(fixtures))
+	for i := range fixtures {
+		inputs[i] = hash(fixtures[i])
+	}
+	if *profile != "" {
+		f, e := os.Create(*profile)
+		check(e)
+		check(pprof.StartCPUProfile(f))
+		defer func() { pprof.StopCPUProfile(); check(f.Close()) }()
+	}
+	results := make([]result, 0, len(fixtures)**repeat)
+	passes := make([]passResult, 0, *repeat)
+	for pass := 0; pass < *repeat; pass++ {
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		start := time.Now()
+		p := passResult{Pass: pass}
+		for i := range fixtures {
+			f := &fixtures[i]
+			r := result{Case: f.Case, Pass: pass}
+			opts := *f.Options
+			start := time.Now()
+			boards, e := d2svg.RenderMultiboard(f.Diagram, &opts)
+			r.RenderNS = time.Since(start).Nanoseconds()
+			check(e)
+			var svg []byte
+			if len(boards) == 1 {
+				svg = boards[0]
+			} else {
+				start = time.Now()
+				svg, e = d2animate.Wrap(f.Diagram, boards, opts, 1000)
+				r.AnimationNS = time.Since(start).Nanoseconds()
+				check(e)
+			}
+			r.SHA256 = fmt.Sprintf("%x", sha256.Sum256(svg))
+			r.Bytes = len(svg)
+			r.InputMutated = inputs[i] != hash(*f)
+			if r.InputMutated {
+				panic("render mutated input: " + f.Case)
+			}
+			p.RenderNS += r.RenderNS
+			p.AnimationNS += r.AnimationNS
+			results = append(results, r)
+		}
+		p.WallNS = time.Since(start).Nanoseconds()
+		runtime.ReadMemStats(&after)
+		p.AllocBytes = after.TotalAlloc - before.TotalAlloc
+		p.Allocs = after.Mallocs - before.Mallocs
+		passes = append(passes, p)
+	}
+	b, e := json.MarshalIndent(struct {
+		Cases   int          `json:"cases"`
+		Passes  []passResult `json:"passes"`
+		Results []result     `json:"results"`
+	}{len(fixtures), passes, results}, "", "  ")
+	check(e)
+	check(os.WriteFile(*out, b, 0600))
+}

--- a/ci/nonlayout-perf/run.py
+++ b/ci/nonlayout-perf/run.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Measure the real E2E corpus with layout excluded, without editing its tests."""
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+from pathlib import Path
+import resource
+import statistics
+import sys
+import subprocess
+import time
+
+sys.dont_write_bytecode = True
+
+from overlay import HERE, git, prepare
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def execute(command, cwd, env, log):
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    start = time.perf_counter()
+    with log.open("w") as output:
+        result = subprocess.run(command, cwd=cwd, env=env, stdout=output, stderr=subprocess.STDOUT)
+    wall = time.perf_counter() - start
+    after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    if result.returncode:
+        raise RuntimeError(f"Command failed ({result.returncode}); see {log}")
+    return {
+        "wall_seconds": wall,
+        "user_seconds": after.ru_utime - before.ru_utime,
+        "system_seconds": after.ru_stime - before.ru_stime,
+    }
+
+
+def run(args):
+    repo = args.repo.resolve()
+    output = args.out.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    if list(output.glob("run-*.json")):
+        raise ValueError(f"Refusing to overwrite previous results in {output}; use a fresh output directory")
+    base_ref = git(repo, "rev-parse", args.base_ref).strip() if args.base_ref else None
+    if base_ref:
+        for name in ("go.mod", "go.sum"):
+            if git(repo, "show", f"{base_ref}:{name}") != (repo / name).read_text():
+                raise ValueError(f"{name} differs from the baseline; use a separate baseline worktree")
+        changed = set(git(repo, "diff", "--name-only", base_ref).splitlines())
+        changed.update(git(repo, "ls-files", "--others", "--exclude-standard").splitlines())
+        assets = sorted(path for path in changed
+                        if not path.endswith(".go") and not path.startswith("ci/nonlayout-perf/"))
+        if assets:
+            raise ValueError(f"Non-Go inputs differ from baseline; use a separate baseline worktree: {assets}")
+    mapping = prepare(repo, output / "overlay", base_ref)
+    overlay = output / "overlay.json"
+    overlay.write_text(json.dumps({"Replace": mapping}, indent=2) + "\n")
+    binary = output / ("e2e.test" if args.mode == "phases" else "render")
+    if args.mode == "phases":
+        command = ["go", "test", "-c", "-overlay", str(overlay), "-o", str(binary), "./e2etests"]
+    else:
+        runner = output / "render.go"
+        runner.write_text((HERE / "render.go.txt").read_text())
+        command = ["go", "build", "-overlay", str(overlay), "-o", str(binary), str(runner)]
+    subprocess.run(command, cwd=repo, check=True)
+    provenance = {
+        "source_ref": base_ref,
+        "worktree_head": git(repo, "rev-parse", "HEAD").strip(),
+        "worktree_tracked_diff_sha256": hashlib.sha256(git(repo, "diff", "--binary", "HEAD").encode()).hexdigest(),
+        "go_version": subprocess.check_output(["go", "version"], text=True).strip(),
+        "binary_sha256": sha256(binary),
+        "harness_sha256": {p.name: sha256(p) for p in HERE.iterdir() if p.is_file()},
+        "gomaxprocs": args.gomaxprocs,
+        "worktree_untracked_go_sha256": {
+            path: sha256(repo / path)
+            for path in git(repo, "ls-files", "--others", "--exclude-standard", "--", "*.go").splitlines()
+        },
+    }
+    provenance["runs"] = args.runs
+    provenance["passes"] = getattr(args, "passes", None)
+    provenance["mode"] = args.mode
+    provenance["test_filter"] = getattr(args, "test", None)
+    if args.mode == "render":
+        provenance["corpus_sha256"] = {path.name: sha256(path) for path in sorted(args.corpus.glob("*.json"))}
+        provenance["oracle_sha256"] = sha256(args.oracle)
+    (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+    for index in range(args.runs):
+        result_path = output / f"run-{index}.json"
+        env = dict(os.environ, GOMAXPROCS=str(args.gomaxprocs), CI="1")
+        # Do not inherit settings that change test verification or add capture work.
+        for key in ("SKIP_SVG_CHECK", "TESTDATA_ACCEPT", "TA", "NO_DIFF", "ND", "D2_NONLAYOUT_CAPTURE", "D2_NONLAYOUT_PHASE_OUT"):
+            env.pop(key, None)
+        command = [str(binary)]
+        if args.mode == "phases":
+            cwd = repo / "e2etests"
+            env["D2_NONLAYOUT_PHASE_OUT"] = str(result_path)
+            if args.capture and index == 0:
+                env["D2_NONLAYOUT_CAPTURE"] = str(output / "corpus")
+            command += ["-test.run", args.test, "-test.parallel", "1"]
+            if args.profile:
+                command += ["-test.cpuprofile", str(output / f"run-{index}.cpu.pprof")]
+        else:
+            cwd = repo
+            command += ["-corpus", str(args.corpus.resolve()), "-out", str(result_path), "-repeat", str(args.passes)]
+            if args.profile:
+                command += ["-cpu-profile", str(output / f"run-{index}.cpu.pprof")]
+        process = execute(command, cwd, env, output / f"run-{index}.log")
+        data = json.loads(result_path.read_text())
+        if args.mode == "render":
+            oracle = fingerprints(json.loads(args.oracle.read_text()))
+            expected = {key: value for key, value in oracle.items() if key[1] == "svg"}
+            if fingerprints(data) != expected:
+                raise ValueError("Render replay differs from the original E2E SVG output set")
+        data["process"] = process
+        data["profiled"] = args.profile
+        data["requested_passes"] = getattr(args, "passes", None)
+        result_path.write_text(json.dumps(data, indent=2) + "\n")
+        print(result_path, json.dumps(process), flush=True)
+
+
+def phase_summary(data):
+    totals = collections.Counter()
+    counts = collections.Counter()
+    for event in data["events"].values():
+        totals[event["phase"]] += event["nanoseconds"] / 1e9
+        counts[event["phase"]] += event["count"]
+    product = totals["compile_total"] - totals["layout_excluded"] + totals["svg_render"] + totals["animation"]
+    setup = sum(totals[k] for k in ("ruler", "serde_compiler", "serde_dimensions", "serde_serialize", "serde_deserialize", "serde_json_compare"))
+    other = sum(totals[k] for k in ("xml_verify", "ascii_extended", "ascii_standard"))
+    return {
+        "product_nonlayout_seconds": product,
+        "setup_serde_seconds": setup,
+        "all_timed_nonlayout_seconds": product + setup + other,
+        "phase_seconds": dict(totals),
+        "phase_counts": dict(counts),
+    }
+
+
+def fingerprints(data):
+    if "events" in data:
+        rows = [(x["case"], x["kind"], x["sha256"], x["bytes"]) for x in data["hashes"]]
+        groups = [rows]
+    else:
+        cases = data["cases"]
+        passes = data["passes"]
+        if not isinstance(cases, int) or cases < 1 or not passes:
+            raise ValueError("Empty or invalid render metadata")
+        ids = [row["pass"] for row in passes]
+        if ids != list(range(len(passes))):
+            raise ValueError("Missing, duplicate, or unordered pass metadata")
+        if data.get("requested_passes") not in (None, len(passes)):
+            raise ValueError("A requested render pass is missing")
+        if len(data["results"]) != cases * len(passes):
+            raise ValueError("Render result count disagrees with case/pass metadata")
+        if {row["pass"] for row in data["results"]} != set(ids):
+            raise ValueError("Render result pass IDs disagree with metadata")
+        groups = []
+        for metadata in passes:
+            rows = [row for row in data["results"] if row["pass"] == metadata["pass"]]
+            if len(rows) != cases:
+                raise ValueError("A render pass has missing or additional cases")
+            for field in ("render_ns", "animation_ns"):
+                if metadata[field] != sum(row[field] for row in rows):
+                    raise ValueError(f"Render pass {field} disagrees with per-case results")
+            if any(row["input_mutated"] for row in rows):
+                raise ValueError("A render changed its input")
+            groups.append([(row["case"], "svg", row["sha256"], row["bytes"]) for row in rows])
+    result = None
+    for rows in groups:
+        current = {(case, kind): (digest, size) for case, kind, digest, size in rows}
+        if len(current) != len(rows) or not rows:
+            raise ValueError("Duplicate or empty fingerprint set")
+        if result is not None and current != result:
+            raise ValueError("Repeated passes changed output")
+        result = current
+    return result
+
+
+def percentile(values, fraction):
+    values = sorted(values)
+    position = (len(values) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(values) - 1)
+    return values[lower] + (values[upper] - values[lower]) * (position - lower)
+
+
+def compare(args):
+    variants = [[json.loads(path.read_text()) for path in paths] for paths in (args.baseline, args.candidate)]
+    expected = fingerprints(variants[0][0])
+    phases = "events" in variants[0][0]
+    expected_counts = None
+    if phases:
+        expected_counts = {key: value["count"] for key, value in variants[0][0]["events"].items()}
+    for data in sum(variants, []):
+        if ("events" in data) != phases:
+            raise ValueError("Compare phase files together or render files together")
+        if phases:
+            counts = {key: value["count"] for key, value in data["events"].items()}
+            if counts != expected_counts:
+                raise ValueError("Measured case/phase invocation counts changed")
+        actual = fingerprints(data)
+        if actual != expected:
+            changed = sorted(key for key in expected.keys() | actual.keys() if expected.get(key) != actual.get(key))
+            raise ValueError(f"Output mismatch: {changed}")
+    report = {"fingerprints_equal": len(expected), "profiled": any(x.get("profiled", False) for x in sum(variants, []))}
+    if phases:
+        summary = [[phase_summary(x) for x in group] for group in variants]
+        report["baseline"], report["candidate"] = summary
+        report["ratios"] = {
+            key: statistics.median(x[key] for x in summary[0]) / statistics.median(x[key] for x in summary[1])
+            for key in ("product_nonlayout_seconds", "setup_serde_seconds", "all_timed_nonlayout_seconds")
+        }
+    else:
+        summaries = []
+        case_times = []
+        for group in variants:
+            totals = []
+            cases = collections.defaultdict(list)
+            for data in group:
+                totals += [(x["render_ns"] + x["animation_ns"]) / 1e9 for x in data["passes"]]
+                for row in data["results"]:
+                    cases[row["case"]].append(row["render_ns"] + row["animation_ns"])
+            summaries.append(totals)
+            case_times.append({key: statistics.median(values) for key, values in cases.items()})
+        ratios = {key: case_times[0][key] / case_times[1][key] for key in case_times[0]}
+        report["baseline_seconds"], report["candidate_seconds"] = summaries
+        report["aggregate_ratio"] = statistics.median(summaries[0]) / statistics.median(summaries[1])
+        report["case_ratio_distribution"] = {"p10": percentile(ratios.values(), .1), "median": statistics.median(ratios.values()), "p90": percentile(ratios.values(), .9)}
+        if args.threshold is not None:
+            report["case_ratio_threshold"] = {"threshold": args.threshold, "count": sum(x >= args.threshold for x in ratios.values()), "cases": len(ratios)}
+        report["case_ratios"] = ratios
+    report["process"] = [[x.get("process") for x in group] for group in variants]
+    print(json.dumps(report, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_subparsers(dest="mode", required=True)
+    for name in ("phases", "render"):
+        command = modes.add_parser(name)
+        command.add_argument("--repo", type=Path, default=HERE.parents[1])
+        command.add_argument("--out", type=Path, required=True)
+        sources = command.add_mutually_exclusive_group(required=True)
+        sources.add_argument("--base-ref", help="Explicit immutable baseline ref; overlaid onto this worktree")
+        sources.add_argument("--current", action="store_true", help="Measure current worktree sources")
+        command.add_argument("--runs", type=int, default=1)
+        command.add_argument("--gomaxprocs", type=int, default=1)
+        command.add_argument("--profile", action="store_true", help="Diagnostic only; do not use these timings for final claims")
+        if name == "phases":
+            command.add_argument("--capture", action="store_true")
+            command.add_argument("--test", default="^TestE2E$", help="Optional smoke-test filter; full corpus is the default")
+        else:
+            command.add_argument("--corpus", type=Path, required=True)
+            command.add_argument("--oracle", type=Path, required=True, help="Phase JSON from the E2E run that captured the corpus")
+            command.add_argument("--passes", type=int, default=1)
+    command = modes.add_parser("compare")
+    command.add_argument("--baseline", type=Path, nargs="+", required=True)
+    command.add_argument("--candidate", type=Path, nargs="+", required=True)
+    command.add_argument("--threshold", type=float, help="Optional per-diagram speedup threshold to count")
+    args = parser.parse_args()
+    if args.mode == "compare":
+        compare(args)
+    else:
+        if args.runs < 1 or args.gomaxprocs < 1 or getattr(args, "passes", 1) < 1:
+            parser.error("runs, passes, and gomaxprocs must be positive")
+        run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Improvements 🧹
 
+- performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.
 - renders: render Markdown labels as native SVG instead of HTML `foreignObject` content
 
 #### Bugfixes ⛑️

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -85,7 +85,12 @@ func compileIR(ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
 }
 
 func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
-	ir = ir.Copy(nil).(*d2ir.Map)
+	// Graph compilation reads the IR. Nested boards still need an independent
+	// root for class lookup, and boards with children need a copy because the
+	// folder comparison below uses CopyBase, which also modifies its source.
+	if !ir.Root() || hasBoardFields(ir) {
+		ir = ir.Copy(nil).(*d2ir.Map)
+	}
 	c.compileMap(g.Root, ir)
 	c.setDefaultShapes(g)
 	if len(c.err.Errors) == 0 {
@@ -101,8 +106,8 @@ func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
 	c.compileBoardsField(g, ir, "layers")
 	c.compileBoardsField(g, ir, "scenarios")
 	c.compileBoardsField(g, ir, "steps")
-	if d2ir.ParentMap(ir).CopyBase(nil).Equal(ir.CopyBase(nil)) {
-		if len(g.Layers) > 0 || len(g.Scenarios) > 0 || len(g.Steps) > 0 {
+	if len(g.Layers) > 0 || len(g.Scenarios) > 0 || len(g.Steps) > 0 {
+		if d2ir.ParentMap(ir).CopyBase(nil).Equal(ir.CopyBase(nil)) {
 			g.IsFolderOnly = true
 		}
 	}
@@ -110,6 +115,14 @@ func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
 		g.IsFolderOnly = true
 	}
 	return g
+}
+
+func hasBoardFields(ir *d2ir.Map) bool {
+	// Use the same lookups as compileBoardsField, including GetField's live
+	// ReservedKeywords rules for distinguishing quoted and unquoted names.
+	return ir.GetField(d2ast.FlatUnquotedString("layers")) != nil ||
+		ir.GetField(d2ast.FlatUnquotedString("scenarios")) != nil ||
+		ir.GetField(d2ast.FlatUnquotedString("steps")) != nil
 }
 
 func (c *compiler) compileLegend(g *d2graph.Graph, m *d2ir.Map) {

--- a/d2compiler/ir_copy_test.go
+++ b/d2compiler/ir_copy_test.go
@@ -1,0 +1,322 @@
+package d2compiler
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2ir"
+	"github.com/d2lang/d2/d2parser"
+	"github.com/d2lang/d2/d2target"
+)
+
+// Compare the entire graph, including ASTs, references, parents, legends and
+// nested boards, against the previous copying implementation below. Graph
+// serialization intentionally omits some of those fields.
+func TestCompileBoardCopyOracle(t *testing.T) {
+	cases := []struct {
+		name, source string
+		invalid      bool
+	}{
+		{"empty", "", false},
+		{"ordinary", `a: {b; c}; a.b -> a.c: connection`, false},
+		{"classes", `classes: {red: {style.fill: red}; linked: {link: https://example.com}}
+a: {class: red; b.class: red}
+a.b -> c: {class: linked}`, false},
+		{"variables", `vars: {text: hello; nodes: {x; y; x -> y}}
+a: ${text}
+group: ${nodes}`, false},
+		{"legend", `vars: {d2-legend: {a: {style.fill: red}; a -> b: relation}}
+x -> y`, false},
+		{"quoted_board_names", `"layers": {x}; "steps": {y}; "scenarios": {z}`, false},
+		{"empty_boards", `layers: {empty}; scenarios: {}; steps: {}`, false},
+		{"folded_board_names", `ſteps: {one: {a}}; b`, false},
+		{"nested_classes", `classes: {box: {style.fill: red}}
+a.class: box
+layers: {one: {classes: {box: {style.fill: blue}}; b.class: box; layers: {deep: {c.class: box}}}}
+scenarios: {two: {a.style.fill: green}}
+steps: {three: {a -> z}; four: {z -> zz}}`, false},
+		{"folders", `layers: {one: {layers: {two: {a}}}}`, false},
+		{"board_links", `a.link: layers.one
+layers: {one: {b.link: root}}`, false},
+		{"glob_class", `classes: {container: {style.fill: transparent}}
+**: {&label: cont*; class: container}
+cont_target`, false},
+		{"class_cycle", `classes: {x: {class: x}}; a.class: x`, true},
+		{"invalid_shape", `a: {shape: image; b}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGraph, oldConfig, oldErr, oldAST := compileCopyOracleInput(t, tc.source, true)
+			graph, config, err, ast := compileCopyOracleInput(t, tc.source, false)
+			if oldErr != err {
+				t.Fatalf("errors differ: original %q, current %q", oldErr, err)
+			}
+			if (err != "") != tc.invalid {
+				t.Fatalf("unexpected compile result: %q", err)
+			}
+			if !reflect.DeepEqual(oldGraph, graph) {
+				t.Fatal("full graph differs from copying implementation")
+			}
+			if !reflect.DeepEqual(oldConfig, config) {
+				t.Fatal("configuration differs from copying implementation")
+			}
+			if !reflect.DeepEqual(oldAST, ast) {
+				t.Fatal("source AST differs from copying implementation")
+			}
+		})
+	}
+}
+
+func compileCopyOracleInput(t *testing.T, source string, original bool) (*d2graph.Graph, *d2target.Config, string, *d2ast.Map) {
+	t.Helper()
+	ast, ir := parseCopyOracleInput(t, source)
+	var g *d2graph.Graph
+	var err error
+	if original {
+		g, err = compileIRCopyOracle(ast, ir)
+	} else {
+		g, err = compileIR(ast, ir)
+	}
+	if err != nil {
+		return nil, nil, err.Error(), ast
+	}
+	g.SortObjectsByAST()
+	g.SortEdgesByAST()
+	config, err := compileConfig(ir)
+	if err != nil {
+		return nil, nil, err.Error(), ast
+	}
+	return g, config, "", ast
+}
+
+func parseCopyOracleInput(t *testing.T, source string) (*d2ast.Map, *d2ir.Map) {
+	t.Helper()
+	ast, err := d2parser.Parse("copy-oracle.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir, _, err := d2ir.Compile(ast, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ast, ir
+}
+
+func TestCompileRootIROwnership(t *testing.T) {
+	const source = `vars: {d2-config: {theme-id: 100; pad: 42}}
+classes: {red: {style.fill: red}}
+a: {class: red; b}
+a.b -> c: relation
+"layers": {x}
+`
+	ast, ir := parseCopyOracleInput(t, source)
+	beforeIR, beforeAST := copyOracleJSON(t, ir), copyOracleJSON(t, ast)
+	beforeNodes, beforeParents := copyOracleNodes(ir)
+	g, err := compileIR(ast, ir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Graph attributes must remain independently owned even though the IR itself
+	// is read directly. AST references keep their existing shared ownership.
+	for _, obj := range g.Objects {
+		obj.Label.Value = "changed"
+		if obj.Style.Fill != nil {
+			obj.Style.Fill.Value = "blue"
+		}
+	}
+	if string(beforeIR) != string(copyOracleJSON(t, ir)) || string(beforeAST) != string(copyOracleJSON(t, ast)) {
+		t.Fatal("graph compilation or attribute edits mutated input IR/AST")
+	}
+	nodes, parents := copyOracleNodes(ir)
+	if len(nodes) != len(beforeNodes) {
+		t.Fatal("graph compilation changed the input node count")
+	}
+	for i := range nodes {
+		if nodes[i] != beforeNodes[i] || parents[i] != beforeParents[i] {
+			t.Fatal("graph compilation changed input node identity, order, or parent links")
+		}
+	}
+	repeated, err := compileIR(ast, ir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, expectedErr, _ := compileCopyOracleInput(t, source, true)
+	if expectedErr != "" {
+		t.Fatal(expectedErr)
+	}
+	repeated.SortObjectsByAST()
+	repeated.SortEdgesByAST()
+	if !reflect.DeepEqual(expected, repeated) {
+		t.Fatal("recompiling the same IR differs from an independent copying compile")
+	}
+}
+
+func TestCompileBoardCopyWithCustomReservedKeywords(t *testing.T) {
+	// Do not run in parallel: callers may customize this exported keyword map.
+	for _, name := range []string{"layers", "scenarios", "steps"} {
+		t.Run(name, func(t *testing.T) {
+			value, existed := d2ast.ReservedKeywords[name]
+			delete(d2ast.ReservedKeywords, name)
+			t.Cleanup(func() {
+				if existed {
+					d2ast.ReservedKeywords[name] = value
+				} else {
+					delete(d2ast.ReservedKeywords, name)
+				}
+			})
+
+			// Without the reserved keyword, GetField also matches the quoted
+			// declaration. CopyBase would move it after tail in the source IR.
+			source := fmt.Sprintf(`%q: {one: {a}}; tail`, name)
+			ast, ir := parseCopyOracleInput(t, source)
+			before := copyOracleJSON(t, ir)
+			g, err := compileIR(ast, ir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(before) != string(copyOracleJSON(t, ir)) {
+				t.Fatal("custom keyword lookup allowed folder comparison to mutate source IR")
+			}
+			g.SortObjectsByAST()
+			g.SortEdgesByAST()
+			want, _, wantErr, _ := compileCopyOracleInput(t, source, true)
+			if wantErr != "" || !reflect.DeepEqual(g, want) {
+				t.Fatalf("custom keyword graph differs from copying implementation: %s", wantErr)
+			}
+		})
+	}
+}
+
+func copyOracleJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+func copyOracleNodes(n d2ir.Node) (nodes, parents []d2ir.Node) {
+	var visit func(d2ir.Node)
+	visit = func(n d2ir.Node) {
+		nodes = append(nodes, n)
+		parents = append(parents, n.Parent())
+		switch n := n.(type) {
+		case *d2ir.Map:
+			for _, f := range n.Fields {
+				visit(f)
+			}
+			for _, e := range n.Edges {
+				visit(e)
+			}
+		case *d2ir.Field:
+			if n.Primary_ != nil {
+				visit(n.Primary_)
+			}
+			if n.Composite != nil {
+				visit(n.Composite)
+			}
+		case *d2ir.Edge:
+			if n.Primary_ != nil {
+				visit(n.Primary_)
+			}
+			if n.Map_ != nil {
+				visit(n.Map_)
+			}
+		case *d2ir.Array:
+			for _, v := range n.Values {
+				visit(v)
+			}
+		}
+	}
+	visit(n)
+	return nodes, parents
+}
+
+// Frozen board-conversion orchestration from the pre-optimization source.
+func compileIRCopyOracle(ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
+	c := &compiler{
+		err: &d2parser.ParseError{},
+	}
+
+	g := d2graph.NewGraph()
+	g.AST = ast
+	g.BaseAST = ast
+	c.compileBoardCopyOracle(g, m)
+	if len(c.err.Errors) > 0 {
+		return nil, c.err
+	}
+	c.validateBoardLinks(g)
+	if len(c.err.Errors) > 0 {
+		return nil, c.err
+	}
+	return g, nil
+}
+
+func (c *compiler) compileBoardCopyOracle(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
+	ir = ir.Copy(nil).(*d2ir.Map)
+	c.compileMap(g.Root, ir)
+	c.setDefaultShapes(g)
+	if len(c.err.Errors) == 0 {
+		c.validateKeys(g.Root, ir)
+	}
+	c.validateLabels(g)
+	c.validateNear(g)
+	c.validateEdges(g)
+	c.validatePositionsCompatibility(g)
+
+	c.compileLegend(g, ir)
+
+	c.compileBoardsFieldCopyOracle(g, ir, "layers")
+	c.compileBoardsFieldCopyOracle(g, ir, "scenarios")
+	c.compileBoardsFieldCopyOracle(g, ir, "steps")
+	if d2ir.ParentMap(ir).CopyBase(nil).Equal(ir.CopyBase(nil)) {
+		if len(g.Layers) > 0 || len(g.Scenarios) > 0 || len(g.Steps) > 0 {
+			g.IsFolderOnly = true
+		}
+	}
+	if len(g.Objects) == 0 {
+		g.IsFolderOnly = true
+	}
+	return g
+}
+
+func (c *compiler) compileBoardsFieldCopyOracle(g *d2graph.Graph, ir *d2ir.Map, fieldName string) {
+	boards := ir.GetField(d2ast.FlatUnquotedString(fieldName))
+	if boards.Map() == nil {
+		return
+	}
+	for _, f := range boards.Map().Fields {
+		m := f.Map()
+		if f.Map() == nil {
+			m = &d2ir.Map{}
+		}
+		if g.GetBoard(f.Name.ScalarString()) != nil {
+			c.errorf(f.References[0].AST(), "board name %v already used by another board", f.Name.ScalarString())
+			continue
+		}
+		g2 := d2graph.NewGraph()
+		g2.Parent = g
+		g2.AST = m.AST().(*d2ast.Map)
+		if g.BaseAST != nil {
+			g2.BaseAST = findFieldAST(g.BaseAST, f)
+		}
+		c.compileBoardCopyOracle(g2, m)
+		if f.Primary() != nil {
+			c.compileLabel(&g2.Root.Attributes, f)
+		}
+		g2.Name = f.Name.ScalarString()
+		switch fieldName {
+		case "layers":
+			g.Layers = append(g.Layers, g2)
+		case "scenarios":
+			g.Scenarios = append(g.Scenarios, g2)
+		case "steps":
+			g.Steps = append(g.Steps, g2)
+		}
+	}
+}

--- a/d2format/keypath.go
+++ b/d2format/keypath.go
@@ -1,0 +1,50 @@
+package d2format
+
+import (
+	"strings"
+
+	"github.com/d2lang/d2/d2ast"
+)
+
+// FormatKeyPath formats the scalar values in a as a canonical key path, like
+// Format(d2ast.MakeKeyPathString(a)), without building a temporary key path AST.
+// Quoting in the input nodes is intentionally ignored, just as in MakeKeyPathString.
+func FormatKeyPath(a []d2ast.String) string {
+	p := printer{inKey: true}
+	for i, s := range a {
+		if i > 0 {
+			p.sb.WriteByte('.')
+		}
+		value := s.ScalarString()
+		// The exported specials set can be customized by callers.
+		if plainKey(value) && !strings.ContainsAny(value, d2ast.UnquotedKeySpecials) {
+			lower := strings.ToLower(value)
+			if lower == "null" {
+				p.sb.WriteString("'null'")
+			} else if _, reserved := d2ast.ReservedKeywords[lower]; reserved {
+				p.sb.WriteString(lower)
+			} else {
+				p.sb.WriteString(value)
+			}
+		} else {
+			p.node(d2ast.RawString(value, true))
+		}
+	}
+	return p.sb.String()
+}
+
+// Keep the fast path deliberately narrow. Other strings use the regular
+// formatter's quoting, escaping, Unicode, and invalid UTF-8 handling.
+func plainKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/d2format/keypath_test.go
+++ b/d2format/keypath_test.go
@@ -1,0 +1,56 @@
+package d2format_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2format"
+)
+
+func TestFormatKeyPath(t *testing.T) {
+	values := []string{"", "a", "a_b", "A0", "_", "null", "NULL", "nUlL", "suspend", "unsuspend", "true", "a b", " a", "a ", "a.b", "a-b", "a--b", "a-", "-a", "a\\b", "a\nb", "a\rb", "a\tb", "a\"b", "a'b", "'a", "\"a", "|a", "&a", "$a", "${a}", "*", "**", "***", "a: b", "世界", "é", "\u00a0a", "a\u2000", string([]byte{0xff}), "x\x00y"}
+	for reserved := range d2ast.ReservedKeywords {
+		values = append(values, reserved, strings.ToUpper(reserved))
+	}
+	check := func(path []d2ast.String) {
+		t.Helper()
+		want := d2format.Format(d2ast.MakeKeyPathString(path))
+		if got := d2format.FormatKeyPath(path); got != want {
+			t.Fatalf("path %q: got %q, want %q", path, got, want)
+		}
+	}
+	check(nil)
+	for _, a := range values {
+		for _, b := range values {
+			// Input quoting and string node type must not affect canonical IDs.
+			check([]d2ast.String{d2ast.FlatUnquotedString(a), d2ast.FlatDoubleQuotedString(b), &d2ast.SingleQuotedString{Value: a}})
+		}
+	}
+}
+
+func FuzzFormatKeyPath(f *testing.F) {
+	for _, seed := range []string{"", "a.b", "NULL", "style.fill", "${a}", "世界", " a\n\"b", "x\xffy"} {
+		f.Add(seed, "STYLE", "a_b")
+	}
+	f.Fuzz(func(t *testing.T, a, b, c string) {
+		path := []d2ast.String{d2ast.FlatUnquotedString(a), d2ast.FlatDoubleQuotedString(b), &d2ast.SingleQuotedString{Value: c}}
+		want := d2format.Format(d2ast.MakeKeyPathString(path))
+		if got := d2format.FormatKeyPath(path); got != want {
+			t.Fatalf("path %q: got %q, want %q", []string{a, b, c}, got, want)
+		}
+	})
+}
+
+func TestFormatKeyPathCustomizedSpecials(t *testing.T) {
+	previous := d2ast.UnquotedKeySpecials
+	t.Cleanup(func() { d2ast.UnquotedKeySpecials = previous })
+	for _, specials := range []string{previous + "x", previous + "N", previous + "_", "a012", ""} {
+		d2ast.UnquotedKeySpecials = specials
+		path := []d2ast.String{d2ast.FlatUnquotedString("x"), d2ast.FlatUnquotedString("NULL"), d2ast.FlatUnquotedString("a_b"), d2ast.FlatUnquotedString("A0")}
+		want := d2format.Format(d2ast.MakeKeyPathString(path))
+		if got := d2format.FormatKeyPath(path); got != want {
+			t.Fatalf("specials %q: got %q, want %q", specials, got, want)
+		}
+	}
+}

--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -704,9 +704,7 @@ func (obj *Object) Text() *d2target.MText {
 }
 
 func (obj *Object) newObject(ids d2ast.String) *Object {
-	id := d2format.Format(&d2ast.KeyPath{
-		Path: []*d2ast.StringBox{d2ast.MakeValueBox(d2ast.RawString(ids.ScalarString(), true)).StringBox()},
-	})
+	id := d2format.FormatKeyPath([]d2ast.String{ids})
 	idval := id
 	k, _ := d2parser.ParseKey(id)
 	if k != nil && len(k.Path) > 0 {
@@ -917,9 +915,7 @@ func (obj *Object) EnsureChild(ida []d2ast.String) *Object {
 		return obj.Parent.EnsureChild(ida)
 	}
 
-	head := d2format.Format(&d2ast.KeyPath{
-		Path: []*d2ast.StringBox{d2ast.MakeValueBox(d2ast.RawString(id.ScalarString(), true)).StringBox()},
-	})
+	head := d2format.FormatKeyPath([]d2ast.String{id})
 	child, ok := obj.Children[strings.ToLower(head)]
 	if !ok {
 		child = obj.newObject(id)

--- a/d2graph/keypath_ids_test.go
+++ b/d2graph/keypath_ids_test.go
@@ -1,0 +1,71 @@
+package d2graph_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2format"
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2parser"
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestEnsureChildCanonicalIDs(t *testing.T) {
+	for _, value := range []string{"", "a", "A0", "a_b", "shape", "SHAPE", "NULL", "a.b", "a b", " a ", "a--b", "a\\b", "a\nb", `a"b`, "${a}", "**", "世界", "x\x00y", string([]byte{0xff})} {
+		t.Run(value, func(t *testing.T) {
+			// Use the old one-element AST formatting expression as the oracle.
+			wantID := d2format.Format(&d2ast.KeyPath{Path: []*d2ast.StringBox{d2ast.MakeValueBox(d2ast.RawString(value, true)).StringBox()}})
+			wantValue := wantID
+			if key, _ := d2parser.ParseKey(wantID); key != nil && len(key.Path) > 0 {
+				wantValue = key.Path[0].Unbox().ScalarString()
+			}
+			g := d2graph.NewGraph()
+			quoted := d2ast.FlatDoubleQuotedString(value)
+			child := g.Root.EnsureChild([]d2ast.String{quoted})
+			if child == g.Root || child.ID != wantID || child.IDVal != wantValue || child.Label.Value != wantValue {
+				t.Fatalf("ID/value/label = %q/%q/%q, want %q/%q/%q", child.ID, child.IDVal, child.Label.Value, wantID, wantValue, wantValue)
+			}
+			if child.Parent != g.Root || child.Graph != g || len(g.Objects) != 1 || g.Objects[0] != child || g.Root.Children[strings.ToLower(wantID)] != child {
+				t.Fatal("created child is not registered consistently")
+			}
+			// Quoting syntax does not distinguish canonical graph IDs.
+			repeated := g.Root.EnsureChild([]d2ast.String{&d2ast.SingleQuotedString{Value: value}})
+			if repeated != child || len(g.Objects) != 1 || len(g.Root.ChildrenArray) != 1 {
+				t.Fatal("canonical lookup created a duplicate object")
+			}
+		})
+	}
+}
+
+func TestEnsureChildReservedAndSequenceIDs(t *testing.T) {
+	g := d2graph.NewGraph()
+	shape := d2ast.FlatUnquotedString("shape")
+	if g.Root.EnsureChild([]d2ast.String{shape}) != g.Root {
+		t.Fatal("unquoted reserved field created an object")
+	}
+	quotedShape := g.Root.EnsureChild([]d2ast.String{d2ast.FlatDoubleQuotedString("shape")})
+	if quotedShape == g.Root || quotedShape.ID != "shape" {
+		t.Fatal("quoted reserved name did not create a child")
+	}
+	actor := g.Root.EnsureChild([]d2ast.String{d2ast.FlatUnquotedString("Alice")})
+	if g.Root.EnsureChild([]d2ast.String{d2ast.FlatDoubleQuotedString("alice")}) != actor {
+		t.Fatal("case-insensitive lookup created a duplicate object")
+	}
+
+	seq := g.Root.EnsureChild([]d2ast.String{d2ast.FlatUnquotedString("sequence")})
+	seq.Shape.Value = d2target.ShapeSequenceDiagram
+	alice := seq.EnsureChild([]d2ast.String{d2ast.FlatUnquotedString("alice")})
+	group := seq.EnsureChild([]d2ast.String{d2ast.FlatDoubleQuotedString("group.with.dot")})
+	if group.EnsureChild([]d2ast.String{d2ast.FlatDoubleQuotedString("alice")}) != alice {
+		t.Fatal("group reference did not resolve the sequence actor")
+	}
+	nested := alice.EnsureChild([]d2ast.String{d2ast.FlatUnquotedString("alice")})
+	if nested == alice || nested.Parent != alice || nested.ID != "alice" {
+		t.Fatal("same-name nested actor resolved to the sequence root")
+	}
+	peer := group.EnsureChild([]d2ast.String{d2ast.FlatUnquotedString("_"), d2ast.FlatUnquotedString("bob")})
+	if peer.Parent != seq || peer.ID != "bob" {
+		t.Fatal("parent reference did not retain its scope")
+	}
+}

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -504,9 +504,9 @@ func (c *compiler) ampersandFilterMap(dst *Map, ast, scopeAST *d2ast.Map) bool {
 				}
 				var ks string
 				if gctx.refctx.Key.HasTripleGlob() {
-					ks = d2format.Format(d2ast.MakeKeyPathString(IDA(dst)))
+					ks = d2format.FormatKeyPath(IDA(dst))
 				} else {
-					ks = d2format.Format(d2ast.MakeKeyPathString(BoardIDA(dst)))
+					ks = d2format.FormatKeyPath(BoardIDA(dst))
 				}
 				delete(gctx.appliedFields, ks)
 				delete(gctx.appliedEdges, ks)
@@ -782,6 +782,15 @@ func (c *compiler) applyLazyGlobs(created []*Field) {
 		return
 	}
 	root := RootMap(ParentMap(created[0]))
+	if len(c.globContexts()) == 0 {
+		// Preserve the settled version and pending post-targets: a later key or
+		// nested value can introduce globs. There is no worklist to run yet.
+		if c.lazySettledVersions == nil {
+			c.lazySettledVersions = make(map[*Map]uint64)
+		}
+		c.lazySettledVersions[root] = root.structureVersion
+		return
+	}
 
 	c.applyingLazyWorklist = true
 	defer func() {

--- a/d2ir/d2ir.go
+++ b/d2ir/d2ir.go
@@ -1210,9 +1210,9 @@ func (m *Map) ensureField(i int, kp *d2ast.KeyPath, refctx *RefContext, create b
 		if gctx != nil {
 			var ks string
 			if refctx.Key.HasTripleGlob() {
-				ks = d2format.Format(d2ast.MakeKeyPathString(IDA(f)))
+				ks = d2format.FormatKeyPath(IDA(f))
 			} else {
-				ks = d2format.Format(d2ast.MakeKeyPathString(BoardIDA(f)))
+				ks = d2format.FormatKeyPath(BoardIDA(f))
 			}
 			if !kp.HasGlob() {
 				if !passthrough {
@@ -1368,8 +1368,8 @@ func (m *Map) ensureField(i int, kp *d2ast.KeyPath, refctx *RefContext, create b
 	if !create {
 		return nil
 	}
-	shape := ParentShape(m)
 	if _, ok := d2ast.ReservedKeywords[strings.ToLower(head.ScalarString())]; !(ok && head.IsUnquoted()) && len(c.globRefContextStack) > 0 {
+		shape := ParentShape(m)
 		if shape == d2target.ShapeClass || shape == d2target.ShapeSQLTable {
 			return nil
 		}
@@ -1385,9 +1385,9 @@ func (m *Map) ensureField(i int, kp *d2ast.KeyPath, refctx *RefContext, create b
 		for _, grefctx := range c.globRefContextStack {
 			var ks string
 			if grefctx.Key.HasTripleGlob() {
-				ks = d2format.Format(d2ast.MakeKeyPathString(IDA(f)))
+				ks = d2format.FormatKeyPath(IDA(f))
 			} else {
-				ks = d2format.Format(d2ast.MakeKeyPathString(BoardIDA(f)))
+				ks = d2format.FormatKeyPath(BoardIDA(f))
 			}
 			gctx2 := c.getGlobContext(grefctx)
 			gctx2.appliedFields[ks] = struct{}{}
@@ -1618,9 +1618,9 @@ func (m *Map) getEdges(eid *EdgeID, refctx *RefContext, gctx *globContext, index
 				if gctx != nil {
 					var ks string
 					if refctx.Key.HasTripleGlob() {
-						ks = d2format.Format(d2ast.MakeKeyPathString(IDA(e)))
+						ks = d2format.FormatKeyPath(IDA(e))
 					} else {
-						ks = d2format.Format(d2ast.MakeKeyPathString(BoardIDA(e)))
+						ks = d2format.FormatKeyPath(BoardIDA(e))
 					}
 					if _, ok := gctx.appliedEdges[ks]; ok {
 						continue
@@ -1849,9 +1849,9 @@ func (m *Map) createEdge2(eid *EdgeID, refctx *RefContext, gctx *globContext, c 
 		e2.ID = e2.ID.Copy()
 		e2.ID.Index = nil
 		if refctx.Key.HasTripleGlob() {
-			ks = d2format.Format(d2ast.MakeKeyPathString(IDA(e2)))
+			ks = d2format.FormatKeyPath(IDA(e2))
 		} else {
-			ks = d2format.Format(d2ast.MakeKeyPathString(BoardIDA(e2)))
+			ks = d2format.FormatKeyPath(BoardIDA(e2))
 		}
 		if _, ok := gctx.appliedEdges[ks]; ok {
 			return nil, nil

--- a/d2ir/lazy_glob_scheduler_test.go
+++ b/d2ir/lazy_glob_scheduler_test.go
@@ -1,0 +1,134 @@
+package d2ir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2parser"
+	"github.com/d2lang/util-go/mapfs"
+)
+
+func TestLazyGlobsCanBeginAfterOrdinaryFields(t *testing.T) {
+	root := compileIndexTestSource(t, `before
+*.style.fill: red
+after
+`)
+	assertLazyGlobScalar(t, root, "red", "before", "style", "fill")
+	assertLazyGlobScalar(t, root, "red", "after", "style", "fill")
+}
+
+func TestLazyGlobsCanBeginInsideNestedScope(t *testing.T) {
+	root := compileIndexTestSource(t, `outside
+container: {
+  before
+  *.style.fill: red
+  after
+}
+sibling
+`)
+	assertLazyGlobScalar(t, root, "red", "container", "before", "style", "fill")
+	assertLazyGlobScalar(t, root, "red", "container", "after", "style", "fill")
+	for _, name := range []string{"outside", "container", "sibling"} {
+		field := root.GetField(d2ast.FlatUnquotedString(name), d2ast.FlatUnquotedString("style"))
+		if field != nil {
+			t.Fatalf("nested glob escaped its scope to %s.style", name)
+		}
+	}
+}
+
+func TestLazyGlobsIntroducedByImportPreserveClasses(t *testing.T) {
+	const source = `before
+...@defs
+after: { class: paint }
+`
+	filesystem, err := mapfs.New(map[string]string{
+		"index.d2": source,
+		"defs.d2": `***.style.fill: green
+imported: { child }
+classes: { paint: { style.stroke: blue } }
+`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer filesystem.Close()
+	ast, err := d2parser.Parse("index.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := Compile(ast, &CompileOptions{FS: filesystem})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLazyGlobScalar(t, root, "green", "before", "style", "fill")
+	assertLazyGlobScalar(t, root, "green", "imported", "child", "style", "fill")
+	assertLazyGlobScalar(t, root, "green", "after", "style", "fill")
+	assertLazyGlobScalar(t, root, "paint", "after", "class")
+	assertLazyGlobScalar(t, root, "blue", "classes", "paint", "style", "stroke")
+}
+
+func TestEmptyGlobScopePreservesDeferredTargets(t *testing.T) {
+	root := &Map{}
+	root.initRoot()
+	x := &Field{parent: root, Name: d2ast.FlatUnquotedString("x")}
+	root.appendField(x)
+	c := &compiler{globContextStack: [][]*globContext{{}}}
+	c.enqueueLazyPostTargets(x)
+	c.applyLazyGlobs([]*Field{x})
+	if len(c.lazyPostTargets) != 1 || c.lazyPostTargets[0] != x {
+		t.Fatal("settling an empty glob scope discarded its deferred target")
+	}
+	if _, queued := c.lazyPostQueued[x]; !queued {
+		t.Fatal("settling an empty glob scope discarded deferred-target deduplication")
+	}
+	if version, ok := c.lazySettledVersions[root]; !ok || version != root.structureVersion {
+		t.Fatal("empty glob scope did not settle the current structure version")
+	}
+
+	// A glob declared before the surrounding key finishes still needs the
+	// original post-target, even though its initial scheduling found no globs.
+	key, err := d2parser.ParseMapKey("*.style.fill: red")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ensureGlobContext(&RefContext{Key: key, ScopeMap: root})
+	c.applyLazyGlobs(c.takeLazyPostTargets(0))
+	assertLazyGlobScalar(t, root, "red", "x", "style", "fill")
+}
+
+func TestGlobFieldCreationRespectsNearestShape(t *testing.T) {
+	for _, shape := range []string{"class", "sql_table", "rectangle"} {
+		t.Run(shape, func(t *testing.T) {
+			root := compileIndexTestSource(t, `box: {
+  shape: `+shape+`
+  explicit: kept
+  inner: { shape: rectangle }
+}
+*.generated: value
+*.inner.generated: inner value
+*.style.fill: red
+`)
+			assertLazyGlobScalar(t, root, "kept", "box", "explicit")
+			assertLazyGlobScalar(t, root, "inner value", "box", "inner", "generated")
+			assertLazyGlobScalar(t, root, "red", "box", "style", "fill")
+			if shape == "rectangle" {
+				assertLazyGlobScalar(t, root, "value", "box", "generated")
+			} else if root.GetField(d2ast.FlatUnquotedString("box"), d2ast.FlatUnquotedString("generated")) != nil {
+				t.Fatal("glob created a non-reserved field inside a class or table")
+			}
+		})
+	}
+}
+
+func assertLazyGlobScalar(t *testing.T, root *Map, want string, names ...string) {
+	t.Helper()
+	path := make([]d2ast.String, len(names))
+	for i, name := range names {
+		path[i] = d2ast.FlatUnquotedString(name)
+	}
+	field := root.GetField(path...)
+	if field == nil || field.Primary() == nil || field.Primary().Value.ScalarString() != want {
+		t.Fatalf("%s = %#v, want %q", strings.Join(names, "."), field, want)
+	}
+}

--- a/d2parser/buffer_equivalence_test.go
+++ b/d2parser/buffer_equivalence_test.go
@@ -1,0 +1,184 @@
+package d2parser_test
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2parser"
+)
+
+type parserBufferCase struct {
+	name, source string
+	readerLimit  int
+	readerError  bool
+}
+
+func parserBufferCases() []parserBufferCase {
+	return []parserBufferCase{
+		{name: "empty"},
+		{name: "ordinary", source: "first.child -> second: an ordinary label\nthird: 42\n"},
+		{name: "raw_escape", source: "a: before\\t after\\n end\\ \\*\nb: \\a\\b\\f\\r\\t\\v\\\\\\\""},
+		{name: "substitutions", source: "vars: {x: value}\na: before${x} after\\t${x} tail\nb: ${x}${x}\nc: $\n"},
+		{name: "quoted", source: "a: \"before${x} after\\t${x} tail\"\nb: 'single\\quote'\n"},
+		{name: "escaped_newlines", source: "first\\\n  second: before\\\n\t after\\t\\\n\n"},
+		{name: "patterns", source: "*.**.***: value\na\\*.b*: text*\\*\n"},
+		{name: "edge_groups", source: "(a -> b)[0].style: {stroke: red}\na-(name): value\n"},
+		{name: "crlf_unicode", source: "α.😀: café\r\nβ: 中文\rnext: yes\n"},
+		{name: "invalid_utf8", source: "a\xff.\xe2\x82: \xc0\xaf\nnext: \xf0\x9f\x98\n"},
+		{name: "utf16_bom", source: "\xff\xfea\x00:\x00 \x00b\x00\r\x00\n\x00c\x00"},
+		{name: "short_prefixes", source: "a\nbc\n...@file\nx: ...@file\ny: ...\nz: ..\n"},
+		{name: "eof_escape", source: "a: tail\\"},
+		{name: "eof_dash", source: "a-"},
+		{name: "eof_quote", source: "a: \"unfinished\\"},
+		{name: "comments_blocks", source: "# comment\na: |md\n  **bold**\n|\n\"\"\" block comment \"\"\"\n"},
+		{name: "long_lookahead", source: "a" + strings.Repeat(" ", 2048) + ".b: label" + strings.Repeat("\t", 2048) + "\nnext: value"},
+		{name: "whitespace_rewind", source: "a: \"value\"" + strings.Repeat(" ", 2048) + "\n" + strings.Repeat("\t", 2048) + "b: other"},
+		{name: "delimiters", source: "a: [first; second; ${x}; last]\n# end\nb -> c: label; d: another\n"},
+		{name: "reader_error_initial", source: "a: value", readerError: true},
+		{name: "reader_error_prefix", source: "α: value", readerLimit: 3, readerError: true},
+		{name: "reader_error_escape", source: "a: before\\tafter", readerLimit: 10, readerError: true},
+	}
+}
+
+type parserOracleReader struct {
+	data  string
+	limit int
+	fail  bool
+	pos   int
+	calls int
+}
+
+func (r *parserOracleReader) Read(b []byte) (int, error) {
+	r.calls++
+	if r.fail && r.pos == r.limit {
+		return 0, errors.New("oracle read failure")
+	}
+	if r.pos == len(r.data) {
+		return 0, io.EOF
+	}
+	// One-byte reads exercise partial UTF-8/BOM input and make read-ahead
+	// consumption observable independently of the parser's rune positions.
+	b[0] = r.data[r.pos]
+	r.pos++
+	return 1, nil
+}
+
+type parserBufferObservation struct {
+	Mode       string
+	AST        any
+	Error      string
+	Structured *d2parser.ParseError
+	Panic      string
+	ReadCalls  int
+	ReadBytes  int
+}
+
+func parserBufferObservations(tc parserBufferCase) []parserBufferObservation {
+	var observations []parserBufferObservation
+	for _, utf16 := range []bool{false, true} {
+		reader := &parserOracleReader{data: tc.source, limit: tc.readerLimit, fail: tc.readerError}
+		observation := parserBufferObservation{Mode: fmt.Sprintf("parse/utf16=%v", utf16)}
+		func() {
+			defer func() {
+				if value := recover(); value != nil {
+					observation.Panic = fmt.Sprint(value)
+				}
+			}()
+			ast, err := d2parser.Parse("oracle.d2", reader, &d2parser.ParseOptions{UTF16Pos: utf16})
+			observation.AST = ast
+			if err != nil {
+				observation.Error = err.Error()
+				errors.As(err, &observation.Structured)
+			}
+		}()
+		observation.ReadCalls, observation.ReadBytes = reader.calls, reader.pos
+		observations = append(observations, observation)
+	}
+	if !tc.readerError {
+		for _, mode := range []string{"key", "map-key", "value"} {
+			observation := parserBufferObservation{Mode: mode}
+			func() {
+				defer func() {
+					if value := recover(); value != nil {
+						observation.Panic = fmt.Sprint(value)
+					}
+				}()
+				var err error
+				switch mode {
+				case "key":
+					observation.AST, err = d2parser.ParseKey(tc.source)
+				case "map-key":
+					observation.AST, err = d2parser.ParseMapKey(tc.source)
+				case "value":
+					observation.AST, err = d2parser.ParseValue(tc.source)
+				}
+				if err != nil {
+					observation.Error = err.Error()
+					errors.As(err, &observation.Structured)
+				}
+			}()
+			observations = append(observations, observation)
+		}
+	}
+	return observations
+}
+
+func TestParserBufferEquivalence(t *testing.T) {
+	for _, tc := range parserBufferCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(parserBufferObservations(tc))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := fmt.Sprintf("%x", sha256.Sum256(data))
+			if got != parserBufferLegacyDigests[tc.name] {
+				t.Fatalf("AST/errors/positions/reader trace changed for %q: digest %s\n%s", tc.source, got, data)
+			}
+		})
+	}
+}
+
+func TestUnquotedRawStringOwnership(t *testing.T) {
+	for _, source := range []string{"ordinary", `escaped\ttext`, `before${variable} after`, `before\t${variable} after`} {
+		value, err := d2parser.ParseValue(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		unquoted, ok := value.(*d2ast.UnquotedString)
+		if !ok {
+			t.Fatalf("expected unquoted value, got %T", value)
+		}
+		for _, part := range unquoted.Value {
+			if part.String == nil || part.StringRaw == nil {
+				continue
+			}
+			raw := *part.StringRaw
+			*part.String = "changed"
+			if *part.StringRaw != raw {
+				t.Fatal("decoded string mutation changed raw string")
+			}
+		}
+	}
+}
+
+func BenchmarkParserLookaheadWhitespace(b *testing.B) {
+	for _, spaces := range []int{16, 1024, 16384} {
+		b.Run(fmt.Sprint(spaces), func(b *testing.B) {
+			// Finishing a quoted scalar peeks across the following whitespace
+			// before rewinding it for the map parser to consume again.
+			source := "a: \"value\"" + strings.Repeat(" ", spaces) + "\n" + strings.Repeat("\t", spaces) + "b: other"
+			b.ReportAllocs()
+			for range b.N {
+				if _, err := d2parser.Parse("bench.d2", strings.NewReader(source), nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/d2parser/buffer_fingerprints_test.go
+++ b/d2parser/buffer_fingerprints_test.go
@@ -1,0 +1,27 @@
+package d2parser_test
+
+// Frozen AST, error, position, and reader-call digests from 5f01776201890014cbe1131e87e89db891fa5b24.
+var parserBufferLegacyDigests = map[string]string{
+	"empty":                "da6530fb9a3c1527e0a09153d468a561fe95573bccb37b482f669b76de3063d8",
+	"ordinary":             "56ae1a8b2ed4da386b6320d2e73557fb0ae84f8b201c50af1b13bd58e6ad8366",
+	"raw_escape":           "358b5068d0f97244b2b1318c97788daf366702af12f2c1c22798a35998bdf378",
+	"substitutions":        "49d113aad13ba5bd74974e38dd025c1100004c1cbdc7ab108370bac9b31a54b9",
+	"quoted":               "de207464cc7e1d308375f7b6f0f18e0788b45c86013208971e4c31cf50590a5f",
+	"escaped_newlines":     "179950a3c271641e2a1d1f779908d467389ded6c81689cacd74f673c3718be86",
+	"patterns":             "7edb6c054e6380cff7346116d02f8b72eb5ca0f9808390f573c098c726510984",
+	"edge_groups":          "281bfac475e68d6fa3cd54db701271846fc1b4e6f9d3cd2ddcfc64d2dc35a411",
+	"crlf_unicode":         "b66c0ac6d7fe7d75e6e5cd81f42f9c8dd21fb465fe7b50bdf648b11a65142933",
+	"invalid_utf8":         "153b53180a4f7d0128b978e095e64000415ec6288991971f371219153448c17a",
+	"utf16_bom":            "3a4329f882a544072f1600afbe4313d0e68239efa386fd3b16d8bd134c2bc948",
+	"short_prefixes":       "707b8c80677001a33270705272fe403b2dee4b7ea0a2b185e51f30f8f676fa50",
+	"eof_escape":           "575a6b9f2dcea38a345f08d2b4f6dc6aec5c809fdefeb9b97ccad4f0e23f60e6",
+	"eof_dash":             "8f11d0e0db5b47c4bc76aab01c8ebebbeffe102b3602bccaa60a190b7142d2b3",
+	"eof_quote":            "787a6980d65354d7251370cb4e23857dd43f510a64e9ab6601ca36f49cc03a54",
+	"comments_blocks":      "1e6b1ef546b96b5610539a9bb1798ad0eafd279cf32b83c9ffd700abd2aee174",
+	"long_lookahead":       "45a380987406395ccf64b5e23a656b5e490423d928f19227bde4a765b1b54b24",
+	"whitespace_rewind":    "f6b84b47209abeb251fb12de7d762158657991ccdad5cc06e62c26a40d3f247b",
+	"delimiters":           "092f1a3dd7fd1f1796dce9cf4da253da6f8c57952ba1f0b94a86173981ebecd2",
+	"reader_error_initial": "569e1dd11f2b25f688662fc6062445e6bf052f0068fec8781a69f36d07984b11",
+	"reader_error_prefix":  "9f91836eb59cae16969478390311c9ab8b07dc6a6a9bfcf34dc10b774ca4c0a7",
+	"reader_error_escape":  "c717d9044912b6ece4a4230c9fdf7f56b564d0d5830ab87525df1d3fbcbbf111",
+}

--- a/d2parser/parse.go
+++ b/d2parser/parse.go
@@ -147,9 +147,10 @@ type parser struct {
 	reader    io.RuneReader
 	readerPos d2ast.Position
 
-	readahead    []rune
-	lookahead    []rune
-	lookaheadPos d2ast.Position
+	readahead      []rune
+	readaheadIndex int
+	lookahead      []rune
+	lookaheadPos   d2ast.Position
 
 	ioerr bool
 	err   *ParseError
@@ -209,9 +210,13 @@ func (p *parser) errorf(start d2ast.Position, end d2ast.Position, f string, v ..
 
 // _readRune reads the next rune from the underlying reader or from the p.readahead buffer.
 func (p *parser) _readRune() (r rune, eof bool) {
-	if len(p.readahead) > 0 {
-		r = p.readahead[0]
-		p.readahead = append(p.readahead[:0], p.readahead[1:]...)
+	if p.readaheadIndex < len(p.readahead) {
+		r = p.readahead[p.readaheadIndex]
+		p.readaheadIndex++
+		if p.readaheadIndex == len(p.readahead) {
+			p.readahead = p.readahead[:0]
+			p.readaheadIndex = 0
+		}
 		return r, false
 	}
 
@@ -367,16 +372,18 @@ func (p *parser) rewind() {
 
 	// This is more complex than it needs to be to allow reusing the buffer underlying
 	// p.readahead.
-	newcap := len(p.lookahead) + len(p.readahead)
+	unread := p.readahead[p.readaheadIndex:]
+	newcap := len(p.lookahead) + len(unread)
 	if cap(p.readahead) < newcap {
 		readahead2 := make([]rune, newcap)
-		copy(readahead2[len(p.lookahead):], p.readahead)
+		copy(readahead2[len(p.lookahead):], unread)
 		p.readahead = readahead2
 	} else {
 		p.readahead = p.readahead[:newcap]
-		copy(p.readahead[len(p.lookahead):], p.readahead)
+		copy(p.readahead[len(p.lookahead):], unread)
 	}
 	copy(p.readahead, p.lookahead)
+	p.readaheadIndex = 0
 
 	p.lookahead = p.lookahead[:0]
 	p.lookaheadPos = p.pos
@@ -1078,10 +1085,14 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 
 	var sb strings.Builder
 	var rawb strings.Builder
+	hasRaw := false
 	lastPatternIndex := 0
 	defer func() {
 		sv := strings.TrimRightFunc(sb.String(), unicode.IsSpace)
-		rawv := strings.TrimRightFunc(rawb.String(), unicode.IsSpace)
+		rawv := sv
+		if hasRaw {
+			rawv = strings.TrimRightFunc(rawb.String(), unicode.IsSpace)
+		}
 		if s.Pattern != nil {
 			if lastPatternIndex < len(sv) {
 				s.Pattern = append(s.Pattern, sv[lastPatternIndex:])
@@ -1100,12 +1111,22 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 		s.Value = append(s.Value, d2ast.InterpolationBox{String: &sv, StringRaw: &rawv})
 	}()
 
-	_s, eof := p.peekn(4)
-	p.rewind()
-	if !eof {
-		if _s == "...@" {
-			p.errorf(p.pos, p.pos.AdvanceString("...@", p.utf16Pos), "unquoted strings cannot begin with ...@ as that's import spread syntax")
+	// Preserve all four peeks, including their I/O/error behavior, without
+	// allocating a temporary string for this fixed prefix check.
+	importSpread := true
+	for _, want := range "...@" {
+		r, eof := p.peek()
+		if eof {
+			importSpread = false
+			break
 		}
+		if r != want {
+			importSpread = false
+		}
+	}
+	p.rewind()
+	if importSpread {
+		p.errorf(p.pos, p.pos.AdvanceString("...@", p.utf16Pos), "unquoted strings cannot begin with ...@ as that's import spread syntax")
 	}
 
 	for {
@@ -1131,7 +1152,9 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 			p.commit()
 			lastNonSpace = p.pos
 			sb.WriteRune(r)
-			rawb.WriteRune(r)
+			if hasRaw {
+				rawb.WriteRune(r)
+			}
 			continue
 		}
 
@@ -1161,7 +1184,9 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 					p.peek()
 					p.commit()
 					sb.WriteRune(r)
-					rawb.WriteRune(r)
+					if hasRaw {
+						rawb.WriteRune(r)
+					}
 					return s
 				}
 				if r2 == '-' || r2 == '>' || r2 == '*' {
@@ -1169,7 +1194,9 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 					return s
 				}
 				sb.WriteRune(r)
-				rawb.WriteRune(r)
+				if hasRaw {
+					rawb.WriteRune(r)
+				}
 				r = r2
 			}
 		}
@@ -1194,10 +1221,14 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 			if subst != nil {
 				if sb.Len() > 0 {
 					sv := sb.String()
-					rawv := rawb.String()
+					rawv := sv
+					if hasRaw {
+						rawv = rawb.String()
+					}
 					s.Value = append(s.Value, d2ast.InterpolationBox{String: &sv, StringRaw: &rawv})
 					sb.Reset()
 					rawb.Reset()
+					hasRaw = false
 				}
 				s.Value = append(s.Value, d2ast.InterpolationBox{Substitution: subst})
 				continue
@@ -1207,7 +1238,9 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 
 		if r != '\\' {
 			sb.WriteRune(r)
-			rawb.WriteRune(r)
+			if hasRaw {
+				rawb.WriteRune(r)
+			}
 			continue
 		}
 
@@ -1228,6 +1261,12 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 			continue
 		}
 
+		// Raw and decoded text are identical until the first real escape.
+		// Copy that prefix once; ordinary tokens need only the decoded builder.
+		if !hasRaw {
+			rawb.WriteString(sb.String())
+			hasRaw = true
+		}
 		sb.WriteRune(decodeEscape(r2))
 		rawb.WriteByte('\\')
 		rawb.WriteRune(r2)

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -2474,7 +2474,7 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	}
 	fmt.Fprint(buf, `<style type="text/css"><![CDATA[`)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
@@ -2483,7 +2483,8 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 			`class="md"`,
 			`class="md `,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text {
 	font-family: "%s-font-regular";
 }
@@ -2491,20 +2492,22 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-regular;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			fontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				fontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
 			`text-semibold`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-semibold {
 	font-family: "%s-font-semibold";
 }
@@ -2512,11 +2515,12 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-semibold;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			fontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				fontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
 	appendOnTrigger(
@@ -2591,7 +2595,7 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 }`,
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
@@ -2599,7 +2603,8 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 			`<b>`,
 			`<strong>`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-bold {
 	font-family: "%s-font-bold";
 }
@@ -2607,14 +2612,15 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-bold;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			fontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				fontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
@@ -2622,7 +2628,8 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 			`<em>`,
 			`<dfn>`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-italic {
 	font-family: "%s-font-italic";
 }
@@ -2630,14 +2637,15 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-italic;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			fontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				fontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
@@ -2647,7 +2655,8 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 			`<kbd>`,
 			`<samp>`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-mono {
 	font-family: "%s-font-mono";
 }
@@ -2655,20 +2664,22 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-mono;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			monoFontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				monoFontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
 			`text-mono-semibold`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-mono-semibold {
 	font-family: "%s-font-mono-semibold";
 }
@@ -2676,20 +2687,22 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-mono-semibold;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			monoFontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				monoFontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
 			`text-mono-bold`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-mono-bold {
 	font-family: "%s-font-mono-bold";
 }
@@ -2697,20 +2710,22 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-mono-bold;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			monoFontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				monoFontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
-	appendOnTrigger(
+	appendOnTriggerLazy(
 		buf,
 		source,
 		[]string{
 			`text-mono-italic`,
 		},
-		fmt.Sprintf(`
+		func() string {
+			return fmt.Sprintf(`
 .%s .text-mono-italic {
 	font-family: "%s-font-mono-italic";
 }
@@ -2718,11 +2733,12 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 	font-family: %s-font-mono-italic;
 	src: url("%s");
 }`,
-			diagramHash,
-			diagramHash,
-			diagramHash,
-			monoFontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
-		),
+				diagramHash,
+				diagramHash,
+				diagramHash,
+				monoFontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
+			)
+		},
 	)
 
 	appendOnTrigger(
@@ -2786,6 +2802,17 @@ func appendOnTrigger(buf *bytes.Buffer, source string, triggers []string, newCon
 	for _, trigger := range triggers {
 		if strings.Contains(source, trigger) {
 			fmt.Fprint(buf, newContent)
+			break
+		}
+	}
+}
+
+// appendOnTriggerLazy avoids constructing a font subset unless its CSS is used.
+// Match the source and trigger order used by appendOnTrigger exactly.
+func appendOnTriggerLazy(buf *bytes.Buffer, source string, triggers []string, newContent func() string) {
+	for _, trigger := range triggers {
+		if strings.Contains(source, trigger) {
+			fmt.Fprint(buf, newContent())
 			break
 		}
 	}

--- a/d2renderers/d2svg/font_embedding_oracle_test.go
+++ b/d2renderers/d2svg/font_embedding_oracle_test.go
@@ -1,0 +1,337 @@
+package d2svg
+
+// Frozen font embedding from 0515f60e985ad829d652456e07831170583011a0.
+// Keep trigger construction independent of the production lazy path.
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"strings"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+)
+
+func legacyEmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fonts.FontFamily, monoFontFamily *d2fonts.FontFamily, corpus string) {
+	// Markdown generates text that may not exist literally in the D2 source,
+	// such as list markers and decoded entities. Include those rendered runs in
+	// every font subset, including multi-board animations where render-local
+	// Markdown layout state is not available here.
+	for _, match := range nativeMarkdownTextPattern.FindAllStringSubmatch(source, -1) {
+		corpus += html.UnescapeString(match[1])
+	}
+	fmt.Fprint(buf, `<style type="text/css"><![CDATA[`)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`class="text"`,
+			`class="text `,
+			`class="md"`,
+			`class="md `,
+		},
+		fmt.Sprintf(`
+.%s .text {
+	font-family: "%s-font-regular";
+}
+@font-face {
+	font-family: %s-font-regular;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			fontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-semibold`,
+		},
+		fmt.Sprintf(`
+.%s .text-semibold {
+	font-family: "%s-font-semibold";
+}
+@font-face {
+	font-family: %s-font-semibold;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			fontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-underline`,
+		},
+		`
+.text-underline {
+	text-decoration: underline;
+}`,
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-link`,
+		},
+		`
+.text-link {
+	fill: blue;
+}
+
+.text-link:visited {
+	fill: purple;
+}`,
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`animated-connection`,
+		},
+		`
+@keyframes dashdraw {
+	from {
+		stroke-dashoffset: 0;
+	}
+}
+`,
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`animated-shape`,
+		},
+		`
+@keyframes shapeappear {
+    0%, 100% { transform: translateY(0); filter: drop-shadow(0px 0px 0px rgba(0,0,0,0)); }
+    50% { transform: translateY(-4px); filter: drop-shadow(0px 12.6px 25.2px rgba(50,50,93,0.25)) drop-shadow(0px 7.56px 15.12px rgba(0,0,0,0.1)); }
+}
+.animated-shape {
+	animation: shapeappear 1s linear infinite;
+}
+`,
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`appendix-icon`,
+		},
+		`
+.appendix-icon {
+	filter: drop-shadow(0px 0px 32px rgba(31, 36, 58, 0.1));
+}`,
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-bold`,
+			`<b>`,
+			`<strong>`,
+		},
+		fmt.Sprintf(`
+.%s .text-bold {
+	font-family: "%s-font-bold";
+}
+@font-face {
+	font-family: %s-font-bold;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			fontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-italic`,
+			`<em>`,
+			`<dfn>`,
+		},
+		fmt.Sprintf(`
+.%s .text-italic {
+	font-family: "%s-font-italic";
+}
+@font-face {
+	font-family: %s-font-italic;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			fontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-mono`,
+			`<pre>`,
+			`<code>`,
+			`<kbd>`,
+			`<samp>`,
+		},
+		fmt.Sprintf(`
+.%s .text-mono {
+	font-family: "%s-font-mono";
+}
+@font-face {
+	font-family: %s-font-mono;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			monoFontFamily.Font(0, d2fonts.FONT_STYLE_REGULAR).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-mono-semibold`,
+		},
+		fmt.Sprintf(`
+.%s .text-mono-semibold {
+	font-family: "%s-font-mono-semibold";
+}
+@font-face {
+	font-family: %s-font-mono-semibold;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			monoFontFamily.Font(0, d2fonts.FONT_STYLE_SEMIBOLD).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-mono-bold`,
+		},
+		fmt.Sprintf(`
+.%s .text-mono-bold {
+	font-family: "%s-font-mono-bold";
+}
+@font-face {
+	font-family: %s-font-mono-bold;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			monoFontFamily.Font(0, d2fonts.FONT_STYLE_BOLD).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`text-mono-italic`,
+		},
+		fmt.Sprintf(`
+.%s .text-mono-italic {
+	font-family: "%s-font-mono-italic";
+}
+@font-face {
+	font-family: %s-font-mono-italic;
+	src: url("%s");
+}`,
+			diagramHash,
+			diagramHash,
+			diagramHash,
+			monoFontFamily.Font(0, d2fonts.FONT_STYLE_ITALIC).GetEncodedSubset(corpus),
+		),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`sketch-overlay-bright`,
+		},
+		fmt.Sprintf(`
+.sketch-overlay-bright {
+	fill: url(#streaks-bright-%s);
+	mix-blend-mode: darken;
+}`, diagramHash),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`sketch-overlay-normal`,
+		},
+		fmt.Sprintf(`
+.sketch-overlay-normal {
+	fill: url(#streaks-normal-%s);
+	mix-blend-mode: color-burn;
+}`, diagramHash),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`sketch-overlay-dark`,
+		},
+		fmt.Sprintf(`
+.sketch-overlay-dark {
+	fill: url(#streaks-dark-%s);
+	mix-blend-mode: overlay;
+}`, diagramHash),
+	)
+
+	legacyAppendOnTrigger(
+		buf,
+		source,
+		[]string{
+			`sketch-overlay-darker`,
+		},
+		fmt.Sprintf(`
+.sketch-overlay-darker {
+	fill: url(#streaks-darker-%s);
+	mix-blend-mode: lighten;
+}`, diagramHash),
+	)
+
+	fmt.Fprint(buf, `]]></style>`)
+}
+
+func legacyAppendOnTrigger(buf *bytes.Buffer, source string, triggers []string, newContent string) {
+	for _, trigger := range triggers {
+		if strings.Contains(source, trigger) {
+			fmt.Fprint(buf, newContent)
+			break
+		}
+	}
+}

--- a/d2renderers/d2svg/font_embedding_test.go
+++ b/d2renderers/d2svg/font_embedding_test.go
@@ -1,0 +1,83 @@
+package d2svg
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+)
+
+func TestEmbedFontsMatchesLegacy(t *testing.T) {
+	for _, source := range []string{
+		`<svg/>`,
+		`<text class="text">Hello</text>`,
+		`<text class="text another-class">Hello</text>`,
+		`<text class="text-mono-bold">Code</text>`,
+		`<text class="text text-semibold text-bold text-italic text-mono text-mono-semibold text-mono-bold text-mono-italic">All styles</text>`,
+		`<text class="md md-text">&#x2022; A &amp; B</text><b>bold</b><strong>strong</strong><em>italic</em><dfn>definition</dfn><pre>pre</pre><code>code</code><kbd>key</kbd><samp>sample</samp>`,
+		`text-underline text-link text-strikethrough text-italic text-bold text-mono sketch-overlay-bright sketch-overlay-normal sketch-overlay-dark text-animated`,
+	} {
+		for _, family := range []d2fonts.FontFamily{d2fonts.SourceSansPro, d2fonts.HandDrawn} {
+			mono := d2fonts.SourceCodePro
+			var want, got bytes.Buffer
+			legacyEmbedFonts(&want, "diagram-hash", source, &family, &mono, "Hello Àéß Ω Ж 中 😀 e\u0301")
+			EmbedFonts(&got, "diagram-hash", source, &family, &mono, "Hello Àéß Ω Ж 中 😀 e\u0301")
+			if !bytes.Equal(got.Bytes(), want.Bytes()) {
+				t.Fatalf("font CSS differs for %s and source %q", family, source)
+			}
+		}
+	}
+}
+
+func TestAppendOnTriggerLazy(t *testing.T) {
+	for _, source := range []string{"no matching class", "first", "second first", "prefix-first-suffix"} {
+		var want, got bytes.Buffer
+		triggers := []string{"first", "second"}
+		appendOnTrigger(&want, source, triggers, "content")
+		calls := 0
+		appendOnTriggerLazy(&got, source, triggers, func() string {
+			calls++
+			return "content"
+		})
+		if got.String() != want.String() {
+			t.Fatalf("trigger output differs for %q", source)
+		}
+		wantCalls := 0
+		if strings.Contains(source, "first") || strings.Contains(source, "second") {
+			wantCalls = 1
+		}
+		if calls != wantCalls {
+			t.Fatalf("content built %d times, want %d", calls, wantCalls)
+		}
+	}
+}
+
+func BenchmarkEmbedFonts(b *testing.B) {
+	for _, source := range []struct{ name, text string }{
+		{"no_text", `<svg/>`},
+		{"regular", `<text class="text">Hello</text>`},
+		{"all_styles", `class="text" text-semibold text-bold text-italic text-mono text-mono-semibold text-mono-bold text-mono-italic`},
+	} {
+		b.Run(source.name, func(b *testing.B) {
+			for _, legacy := range []bool{true, false} {
+				name := "lazy"
+				if legacy {
+					name = "legacy"
+				}
+				b.Run(name, func(b *testing.B) {
+					family, mono := d2fonts.SourceSansPro, d2fonts.SourceCodePro
+					b.ReportAllocs()
+					for range b.N {
+						var out bytes.Buffer
+						if legacy {
+							legacyEmbedFonts(&out, "diagram", source.text, &family, &mono, "Hello D2 diagrams 0123 -> []")
+						} else {
+							EmbedFonts(&out, "diagram", source.text, &family, &mono, "Hello D2 diagrams 0123 -> []")
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/lib/font/subsetFont.go
+++ b/lib/font/subsetFont.go
@@ -36,7 +36,7 @@ type utf8FontFile struct {
 	fileReader           *fileReader
 	tableDescriptions    map[string]*tableDescription
 	outTablesData        map[string][]byte
-	symbolPosition       []int
+	symbolOffsets        locaOffsets
 	charSymbolDictionary map[int]int
 }
 
@@ -392,8 +392,8 @@ func (utf *utf8FontFile) GenerateCutFont(usedRunes map[int]int) []byte {
 		hmtxData = append(hmtxData, hm...)
 
 		offsets = append(offsets, pos)
-		symbolPos := utf.symbolPosition[originalSymbolIdx]
-		symbolLen := utf.symbolPosition[originalSymbolIdx+1] - symbolPos
+		symbolPos := utf.symbolOffsets.at(originalSymbolIdx)
+		symbolLen := utf.symbolOffsets.at(originalSymbolIdx+1) - symbolPos
 		data := symbolData[symbolPos : symbolPos+symbolLen]
 		var up int
 		if symbolLen > 0 {
@@ -472,8 +472,8 @@ func (utf *utf8FontFile) GenerateCutFont(usedRunes map[int]int) []byte {
 }
 
 func (utf *utf8FontFile) getSymbols(originalSymbolIdx int, start *int, symbolSet map[int]int, SymbolsCollection map[int]int, SymbolsCollectionKeys []int) (*int, map[int]int, map[int]int, []int) {
-	symbolPos := utf.symbolPosition[originalSymbolIdx]
-	symbolSize := utf.symbolPosition[originalSymbolIdx+1] - symbolPos
+	symbolPos := utf.symbolOffsets.at(originalSymbolIdx)
+	symbolSize := utf.symbolOffsets.at(originalSymbolIdx+1) - symbolPos
 	if symbolSize == 0 {
 		return start, symbolSet, SymbolsCollection, SymbolsCollectionKeys
 	}
@@ -527,25 +527,46 @@ func (utf *utf8FontFile) getMetrics(metricCount, gid int) []byte {
 	return metrics
 }
 
+// locaOffsets keeps the original table snapshot while decoding only the glyphs
+// selected for the subset. A font can have far more glyphs than a diagram uses.
+type locaOffsets struct {
+	data  []byte
+	width int
+}
+
+func (offsets locaOffsets) at(index int) int {
+	count := 0
+	if offsets.width != 0 {
+		count = len(offsets.data) / offsets.width
+	}
+	// Preserve the decoded array's glyph-index bounds check before computing a
+	// byte offset, including invalid glyph IDs in malformed composite glyphs.
+	_ = offsets.data[:count][index]
+	data := offsets.data[index*offsets.width:]
+	if offsets.width == 2 {
+		return int(binary.BigEndian.Uint16(data)) * 2
+	}
+	return int(binary.BigEndian.Uint32(data))
+}
+
 func (utf *utf8FontFile) parseLOCATable(format, numSymbols int) {
 	start := utf.SeekTable("loca")
-	utf.symbolPosition = make([]int, 0)
-	if format == 0 {
-		data := utf.getRange(start, (numSymbols*2)+2)
-		arr := unpackUint16Array(data)
-		for n := 0; n <= numSymbols; n++ {
-			utf.symbolPosition = append(utf.symbolPosition, arr[n+1]*2)
-		}
-	} else if format == 1 {
-		data := utf.getRange(start, (numSymbols*4)+4)
-		arr := unpackUint32Array(data)
-		for n := 0; n <= numSymbols; n++ {
-			utf.symbolPosition = append(utf.symbolPosition, arr[n+1])
-		}
-	} else {
+	utf.symbolOffsets = locaOffsets{}
+	width := 0
+	switch format {
+	case 0:
+		width = 2
+	case 1:
+		width = 4
+	default:
 		fmt.Printf("Unknown loca table format %d\n", format)
 		return
 	}
+	// Read the full table now, retaining the original truncation check and reader
+	// position. Copy the bytes because later metric extraction can mutate the
+	// input; even overlapping custom-font tables must retain the old snapshot.
+	data := utf.getRange(start, (numSymbols+1)*width)
+	utf.symbolOffsets = locaOffsets{data: bytes.Clone(data), width: width}
 }
 
 func (utf *utf8FontFile) generateCharSymbolDictionary(runeCmapPosition int, charSymbolDictionary map[int]int) {
@@ -638,34 +659,6 @@ func (utf *utf8FontFile) assembleTables() []byte {
 	checksum := utf.generateChecksum([]byte(answer))
 	checksum = utf.calcInt32([]int{0xB1B0, 0xAFBA}, checksum)
 	answer = utf.splice(answer, (begin + 8), pack2Uint16(checksum[0], checksum[1]))
-	return answer
-}
-
-func unpackUint16Array(data []byte) []int {
-	answer := make([]int, 1)
-	r := bytes.NewReader(data)
-	bs := make([]byte, 2)
-	var e error
-	var c int
-	c, e = r.Read(bs)
-	for e == nil && c > 0 {
-		answer = append(answer, int(binary.BigEndian.Uint16(bs)))
-		c, e = r.Read(bs)
-	}
-	return answer
-}
-
-func unpackUint32Array(data []byte) []int {
-	answer := make([]int, 1)
-	r := bytes.NewReader(data)
-	bs := make([]byte, 4)
-	var e error
-	var c int
-	c, e = r.Read(bs)
-	for e == nil && c > 0 {
-		answer = append(answer, int(binary.BigEndian.Uint32(bs)))
-		c, e = r.Read(bs)
-	}
 	return answer
 }
 

--- a/lib/font/subset_fingerprints_test.go
+++ b/lib/font/subset_fingerprints_test.go
@@ -1,0 +1,486 @@
+package font
+
+// Frozen subset fingerprints from 0515f60e985ad829d652456e07831170583011a0.
+const subsetFingerprintJSON = `[
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": "",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "acd8631cdc398e2f68d5e66ab46be7c0b9437e90da49a06ba937d866aaffcd4f",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "aabc9f94598dfeed1f17841e7a2fffbbccfa3f8f30806f22880336da969486a5"
+  },
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "06074918463886c1743fbbcabf84f92903d43d358ccf85d0bad6277fc0dab1b2",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "bb290db066358e5c5db53b33ef4f108b8890acc643223f77a64cb4d3950aa393"
+  },
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "b41f8de516ce9edad0dfc491a75a7aada26b471736fb7ed764cce3a7e655a6c1",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "80093aaae1cb50df1e11cf0b32300e6b102012d5aa1bb80b03e7865fe84de125"
+  },
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "23fb4782dede7ef590082abc4895dfe1bbf3d7f5d9b63168827bb0978d1122ff",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "3924f80a945196bd36ec5600729827a352bf47219db149a7eb9bda076c4196ab"
+  },
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "b8c3c354dcab3aa83678aa8192f7cf407cf56a361901b85d87335ea469bd769b",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "babc1e790a9f474319a6d6ce628733f89978298bf2efb57f8d80c5081bf8c5bd"
+  },
+  {
+    "font": "FuzzyBubbles-Bold.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "subset_sha256": "f9f37c60c50caf79681efc29e5d15a8141cf827b26d50ba8eb60c48c8ac82f52",
+    "input_sha256": "92478cf4c07457181b46ea7d6a5535af984c9f05fccbefc8a7ea343ec630d711",
+    "woff_sha256": "5a4d0079b36f0c4b2469b6640b8c2b44e7feb073e147497c7c1766f0cd3710e8"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": "",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "3031996918c65845c781b1d690bd28c624c2c04148ac1f674588bed47012a9f4",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "5b90103347ccf9dd48995f7a6cb5415505aa632bef37a3e798f2a8d9f658cf49"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "0c37e849272f46b69a7eb279162941273e013c0f77b56bbacb517c5df5f668cc",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "12edf3f1661baa941133f74f6caf9e35f37d5cead9af74db09e5cbe22d17674f"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "23435a38f4529a599a84759ac19b261d71c1dbd8a25ff6ac5334d1038bc7eba3",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "d151a67988a1b4b81d6f834d2da1907ecc1357333e5ead0f19f7fcc96852491d"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "7def3923c0a88cb92de75e57860cc7966e0b60ef89c33f306661ed88e2d4c8a5",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "c770e407857434f86b7480b74fd1f021cbf3f7b4e3971d35814701133973abf0"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "e884b076c02f93e8e44bda37555e6cdd471ac03c0d2b362bc5b64e88ce27dea4",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "39e15f3801b29df5d3d2273160ae235aa46c71683c16cd8501c645760a16047a"
+  },
+  {
+    "font": "FuzzyBubbles-Regular.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "subset_sha256": "9fb185e32eb71d2dc5cc277e4e56f2a6a75f8359561a99153296dfed671edb38",
+    "input_sha256": "3d2e4938c48dca0484bff9b746d0935048548072ebb1a89bc3933a65540e7b98",
+    "woff_sha256": "f27da85a7467e5bf934188cce6dd35e6a43854d89dc475077999ee56bda52df6"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": "",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "5af6ad3526d5dd0d4bc0a51a107e6f5afd33b9a643a5b7584845b54427c41444",
+    "input_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "woff_sha256": "fd85b3699d1e7315957a77e5867c44153fd0600963452d1f359af7aa8a6d0588"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "7686c2d8e2cc6fd69d702448dd489174741b902043e5d39f75da75886a2238d7",
+    "input_sha256": "3f8490be8d39ac0a13b701ca1c7e85189e3cafebe02dd8d07521a09edc1f01b0",
+    "woff_sha256": "aa4c803300f5ed0435644934d947d9eadcb8dcd6cfc8ed862b81ab9db87b1c35"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "2c310f06065d1c3e05685f4968177b18db33661d689eb63bb370f02b85b5b478",
+    "input_sha256": "25c49d86c31b3bfdd312908474e89b4f7c0d922c20436852f188dd5904112188",
+    "woff_sha256": "d708dc2f93fc4260662066407d4b23838cfa4dadcb677825e3d2bad56ffaaba7"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "c3875d527c7380e2c2edaf4a02a0477f39cfca8052ab844f8498811f6e3cf65c",
+    "input_sha256": "089f25bd41df5b33c5bad73891a860e045b28e5f81224ded958bcbf32eacb43b",
+    "woff_sha256": "a4037acc781bc0721ee1cd569150b9e48c56d89e0ce0370b82bcce1d3069779a"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "260661fd09136271ccc7cf2f3a15a389b7f25d7a26825a3807f70d48495c2598",
+    "input_sha256": "0953b42a97e71fda8d488343208b762dc66fe25a71d0e7ca67e6436a29dd00f2",
+    "woff_sha256": "089be02814446ae3f93d91c290331a411b86f326b8c758186e3e735556dd2f8c"
+  },
+  {
+    "font": "SourceCodePro-Bold.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "c2aabd3830bd19420670a395c4df30596e950c53f4616445107a114046b9e618",
+    "subset_sha256": "9aa9a73c142a820e2a367c0f49a70caa9e88c7dc74118be2dad9a84a417156eb",
+    "input_sha256": "2553de151272141f7afde9fa6e73f939748d695dedc4adb3efe0f816c747b04a",
+    "woff_sha256": "d4d64c1b63bb866aee5f6cad0209316b2391fb5a485312b9c2e75142970764ce"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": "",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "ff91017f8486cfdd203a21ac06af5db6edab58326d82e48214cc58ad2fc36e32",
+    "input_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "woff_sha256": "b8dcc0a091a39b58d363200e1fbd8ff74f2c399cff64a7999640dd44ebddb5c6"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "3492dce7f1374270fe6a7a32cce128c6fed302b470156a92665cdae505ddecfe",
+    "input_sha256": "0df00e87657e030325b33c38ac9c3f5cdb4e17bd00f9a7f6a478ace893e12ba2",
+    "woff_sha256": "cf3036abd122488e4072261cb2e4dde633684041e7909fec6ff2dd895154bf59"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "fe891ad41bce1ed38ff2fd847f5f62f6708025898c2b1eb20408324f874ad630",
+    "input_sha256": "ce85fa25d274c38bcde9036a27de60fd7330a27b401b073ce0edcd0d39409a8b",
+    "woff_sha256": "e7c3637f03d0474bf14b1ba9bce81a7d06052d8a5c3ca040e3b183976518fd46"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "adfbbb7911ace004c0c7ad532e0e412edea8e675d20c12341a0ab9be9e703380",
+    "input_sha256": "b7fd44175fc2bd135f25615994df636d6bd1704ea3fa2d373826ea31e6c19024",
+    "woff_sha256": "b84dcbd4125bf2e15a812c980cb15ce48be97a5cbf899e9e572c9c38dbf91a73"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "4c543ad6ff3d45bbc03733a1fb67c9b0b0b1de7d2b8617609e322f40544c4dfc",
+    "input_sha256": "133b9bcd075a3db0641d5b9be54d27cd17a2f6361c643062bd44346def61e518",
+    "woff_sha256": "b60c25c036277395bd54b9faf4d296c457534a0d398e29b4b834cb6419bd052b"
+  },
+  {
+    "font": "SourceCodePro-Italic.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "c33aca4e40836061acb34f47653db900f1030c82310a2ed08a6dcbf3cec33705",
+    "subset_sha256": "cc2af9867c6018e7c2a3ba5df1fb1e19058e10a9495bd1213e246a1e0bc3ea2f",
+    "input_sha256": "1b4dafad51d07f0237f74e4ab52852523c30ee43e8249c65e02527e6482629c5",
+    "woff_sha256": "8cde7047440cc53f791fb1429bb43c2f36ea9d4539a90e160c8a55510bf82bb6"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": "",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "823e1398f4d9c084f081363f2dac547724769ae698bbfb3318bf16eda5f16886",
+    "input_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "woff_sha256": "d68a6e2e5ca537526455a4ee8ab5fef8379df26a1c4b5fdbc3f8933cf92afd95"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "bc77ba71721ab6beb298e9f460e425ff690a4ddfb30379b5c061aa83d5001c2b",
+    "input_sha256": "9b46acbb43f941ef0d6196119c5197291ff1e82a18ebe1c66bd6a3ff67e873fa",
+    "woff_sha256": "66103744673b71e7dcccc7560edf6b77353c1fe446ffae75adeecd467df2bab3"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "4c8dc3dc835e75c0c1efce0a9bbefe77605b41d80efde1ccc3d577583ded9325",
+    "input_sha256": "a013572e7fa64422d219f01ac715101de2be14752c6820a54558927250c4ef50",
+    "woff_sha256": "60ee8b40fe88f3e6143d2c8886266ae27eab883838757379db9a6f92927ccaf0"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "c6e5b46d333b1ebb1be4a4fc2b6658aa5bf561908b2240eb27056b3af4d54e2d",
+    "input_sha256": "c0dfd51675456156371846cefd04927fc75aab329f4d7d3e8ffda0eeb0c5b376",
+    "woff_sha256": "889ed491d91520e9f0958e51307430ee7e6b7c4138bcd37eeb02f15377f1c15a"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "cc5e945f6e59de735d7aa7180c6e5436aa7e3002fb767cf762b24e78a3920e3b",
+    "input_sha256": "d4e47fb0937775d7208b47ea05cb58935f734a74d8415f1fce990ef74fb81f66",
+    "woff_sha256": "d1419fd97c0026c5301dd504c4d19c604c71b9e103bc874e9adf43c42fb8db76"
+  },
+  {
+    "font": "SourceCodePro-Regular.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "f144137f557805c7327fc4b14d1d730f6e1822e0124170251ff1bcd723a693f1",
+    "subset_sha256": "fc74637a73ac21de76368632fcb049a2beaf99ccf2a507e663b51312d9263747",
+    "input_sha256": "b25b941b5ab368fe4b3b0f6feae40af4b129d4fb71a8d54edc831bd29d143903",
+    "woff_sha256": "d81379d864315df3bb0ad1eb473bff69376ef4bfd7be116ddb594157ee350665"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": "",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "404eb9fb8772a57031455779d5cb78cdf4d5570420382dcb46b953a904b3b7e2",
+    "input_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "woff_sha256": "112d59154806adbded85c26f54ca4ac8e2a627d1717b39fe36fe91371a35e9f0"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "9e1de62b770e056eb3001f3369c21c6ea4b3cff6bce35a182ace88350d1ea0cf",
+    "input_sha256": "e170d70062895a79c2d6bf6fe5833b751d0df3e06b087fe3eca5fc8f156b3b2d",
+    "woff_sha256": "fc243ca0d9db7b2b9561daad6ee178f2284211a939a545106e0617bf6750b0d8"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "55e215e60a7c3496dbe6fe7f40a9f9d38aaa587036298d217a028cf3b787ddf6",
+    "input_sha256": "5d5b25438d2bbe996c7ea40861b97dc6372e4f88a6f62993a2584e804a02876e",
+    "woff_sha256": "29d34cba2b4ca906d829a7d92d05a7e168f15c4b301fc091d5122f320b65dbb6"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "cba9930eb09d391d9f98df3c88c5b5a61a297d52dd42d7332cfee2c24247362e",
+    "input_sha256": "1c7be4172bd01fee1030a7b2b162f5e90f14e1e797692819d14a7b51f68d2307",
+    "woff_sha256": "c96b52bd16d886de4f8b46e15456b49c10c818017465f6ec2058c234651a9b38"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "7f045dc5585b27071ac5c38b0513be7e853cb14964146b03ce4678cb9264ec06",
+    "input_sha256": "0a3b7d8c6a5ff49d00f1e205b494bc1e52ff1fbb68b02db91b035d9fc03f1864",
+    "woff_sha256": "548489f0e7cc8d39d5b6599c0be6b5f73e40baf81e8bd996b9f65a8562a1b003"
+  },
+  {
+    "font": "SourceCodePro-Semibold.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "1b61c980d75de8216228a2603bcabe51394013452df26a04c99326bbc035c5a5",
+    "subset_sha256": "a33309b0718c45ecca4c43d3799048dca20136540c7585da64dd24f80412243e",
+    "input_sha256": "b6bfe03a307348d966ac351c69e54ca82375e2daef9c2484478b748b46d83310",
+    "woff_sha256": "428477e5adab526e83b9e73fcf0f7160d1e343669d0f3aa5a1b22483331b1f9d"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": "",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "0ed5eb44110f48faff518cd2d145eeff09f4ee250648b79cf4cda054d14c5467",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "e86acd4f247d208b499ed23ee12ab5378d343945ac380a8c10794c08c44ca493"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "9455224f154001fb710663e72ced190d03c23be978590b3a847c0d6138cc2ec4",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "48a6d7d6832aec6d6ea62e54ba95410a8bdb24337c529ce59b75da87ddc9cef3"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "d102c593590b37fa1cc266df597fa8b10eb71d1e02f986c736b75c3a520afd27",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "5c9b7c7bfaa1ddf78ed437769e4eeddf81d912f3d63d1df07b6d30e80afaacd6"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "151537010f3f51ecfdba98034807785e52f28a3370b0037651c4ff6e697a4bd8",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "64bad5eba8175f4a9ad49deaafb5ac9bebebc856132507be6986ee637f2be765"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "475af17049c15291703e360b5e954446f9ddfe1f2926b6b43bd4918ad6a5f9bf",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "55fb4f2400436b5085f66e2d8ea08896267e3b0ced464ce77c460e207a4c3166"
+  },
+  {
+    "font": "SourceSansPro-Bold.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "subset_sha256": "f47b0187ddb9bc9dd973a0c911bc36c7d876bcb697a7f1dc99cfa77b065301a6",
+    "input_sha256": "f205fb64af917c37b60b64a95e0eac3a9e5bb9849fa07c2f2c2a0463d55589e8",
+    "woff_sha256": "bdd856b58c7a2ad3b505eacfb5be65e89cc4b7122b810569fc52b702d8e7637c"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": "",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "77f862aebbf0b65c1d4089acd2b52c740f8f9b92d43b3e7ef1eae627bde1d801",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "7217f84f29ce1398c14a370e6a2b2740ab2b929fb5a2d3a6f926ce715c82b9a6"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "3421441c2699cad16952aaa4a0d73f98cc30cad01027eccdf3fa0a2a810ea777",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "d7be614bd6db7be9835e4b219b9f28dcd25213cdc8c6086bc826562d0fda5ce5"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "61f3e7b88a427c9ea65dca081476165fce30ebc75ba06c734c8d341e3236ef40",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "ac99ebc61a9dfebbc706bfbf037fde9416feef75c025d0d00b19ca34b04c8cb2"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "5b639e9377832923ff85960ee137fcc9d38bef409a69d6af4cca055887fddee0",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "2283ccc1acaa660f51aa3dca5c30ace62766057d7813262f46ee9d000b09eef5"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "97502e4f2d71311bad10813d4401f3cf425c2d70fa2451354870f03b954e7623",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "3086d41cfbcf02ae5466cc0f24a6d49f3e063b61ae592fc1732bd61158dc0261"
+  },
+  {
+    "font": "SourceSansPro-Italic.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "subset_sha256": "d5d8940538c7a8ebd75c8347b82690c3c0e9cb946c11813ad3053e02764d3485",
+    "input_sha256": "bd77181e59a8f0f3ea2bae01ba13102e4cd8f3b4ce3a7fa29be4bda9b3c9fa9c",
+    "woff_sha256": "532c9c0962136c7b6ef78b491b4ec58a24883ff40c5320f835b643833586bc4f"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": "",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "ff8e58d29880e144ca821e372bcc96d977599e18e27f2b8b49949d2d5324cc72",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "2b28b4b7a360f01c3709e129407aef0c8a97f30c0e706d7fd1ada2560387ef22"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "5f0a17176b18400b80c29eee5d83f3a1db79ce1089629ad5f09f070054c6f6f1",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "682680632aa8c4966dff47e9567570165dd41d8591209c10773e2e35df033f74"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "0413a4d76d63e00fa80c3ab07ef201746c95533504a00e01b469522874d6c133",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "2f4c6825c02fb9cb1ab9353fe36cea44d192c47970d270283ab0b818dcffb7b4"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "a4367e73a879562b32ea6a34f45a16345c2f04afeaf9d6ce8b8951c89888f848",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "4074d3da6b5279724b3845b67f20978892151a0c30db2be826ddf60e3d297162"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "5123bdefb734b6ad3660dda2e4ef431748a4c696878bf92feab868ad1ae53e0d",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "5a7b190f20a28ac5371d89fe3a94bafce7dab6c4dd9e026caaafc81dde2aa360"
+  },
+  {
+    "font": "SourceSansPro-Regular.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "subset_sha256": "6eb4c7f7a0d759f6fc9bf4a8745a42cbfe24b7f52952ee2a36c109fac08cc618",
+    "input_sha256": "a4c07a3a09edc71a053d3ed78d69ff1ad42f2f1f6b9f11090bde7cf618355c78",
+    "woff_sha256": "019b55595554eaa6c07f0546b5026a093395589b2c74c1a3c4b81287dbfe1377"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": "",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "a9ece27e133b6c2dedb344eb2f7754495a4b33aa4250c74755b03e9dda73229b",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "65927d4506f2222f3036b175752d8cf4d2c005b7e2ee117333e8134a89472a37"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": "D2 diagrams 0123 -\u003e []",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "08046f04a6e125efb8a5846a3ce3d524df301b986121bfb024c52311d12f03ca",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "d7429098cd797216f7ac3c180e13af8cdb3d93be26b3a6bf793eebfe76d2742e"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": "\u0000\t\n AAAaaa A",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "4d464a080c018d5ac84dedb336ab87085fdfb2cd8e0f8d8b93f62b891f04795d",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "2c17d40d627f98257da1f1ac68daa8b5f650e127f3f6b13576be219c83b4cc0f"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": "ÀÄÅÇÉÊÑÖÜàäçǺǻḈḉ",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "1952090a04863245847aea819ad4b6e58a184aec975478eafc9b4f1845b104fc",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "18775b4a66040a8bd72c7f18cb8b22e286a0ef6f83d59de035c56b21250f13a1"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": "Ω Ж 中 😀 é �",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "eb6867e5f05bcbdeb0a716b9b95a5723e3ab9d91a3aef369174c5cb1ba536f63",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "879188afe1f86b04520191c2fded133cec4fca3bd74208e798403422b47a5be6"
+  },
+  {
+    "font": "SourceSansPro-Semibold.ttf",
+    "cutset": " !\"#$%\u0026'()*+,-./:;\u003c=\u003e?@[\\]^_` + "`" + `{|}~",
+    "font_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "subset_sha256": "a3c2a54ff87a4e2330d85854243b5d5e5dea7bb19e257ef68f2f8483102bc601",
+    "input_sha256": "72bf9aa2e78b8c78444ae74b6be09411d5fb5bf0eb9bcdfd47082cc5d9b536df",
+    "woff_sha256": "a53f384de64e2d8ff9eda54789f770d956c7d07707343572e8e2fb3618db8a06"
+  }
+]
+`

--- a/lib/font/subset_loca_test.go
+++ b/lib/font/subset_loca_test.go
@@ -1,0 +1,230 @@
+/*
+ * The following code is part of https://github.com/jung-kurt/gofpdf
+ *
+ * Copyright (c) 2019 Arteom Korotkiy (Gmail: arteomkorotkiy)
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package font
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Frozen from 0515f60e985ad829d652456e07831170583011a0. The original
+// decoder eagerly produced two offset arrays; retain that independent oracle.
+func legacyParseLOCA(utf *utf8FontFile, format, numSymbols int) []int {
+	start := utf.SeekTable("loca")
+	positions := make([]int, 0)
+	if format == 0 {
+		data := utf.getRange(start, numSymbols*2+2)
+		arr := legacyUnpackOffsets(data, 2)
+		for n := 0; n <= numSymbols; n++ {
+			positions = append(positions, arr[n+1]*2)
+		}
+	} else if format == 1 {
+		data := utf.getRange(start, numSymbols*4+4)
+		arr := legacyUnpackOffsets(data, 4)
+		for n := 0; n <= numSymbols; n++ {
+			positions = append(positions, arr[n+1])
+		}
+	} else {
+		fmt.Printf("Unknown loca table format %d\n", format)
+	}
+	return positions
+}
+func legacyUnpackOffsets(data []byte, width int) []int {
+	answer := make([]int, 1)
+	reader := bytes.NewReader(data)
+	buf := make([]byte, width)
+	count, err := reader.Read(buf)
+	for err == nil && count > 0 {
+		if width == 2 {
+			answer = append(answer, int(binary.BigEndian.Uint16(buf)))
+		} else {
+			answer = append(answer, int(binary.BigEndian.Uint32(buf)))
+		}
+		count, err = reader.Read(buf)
+	}
+	return answer
+}
+
+func locaFixture(data []byte, start int) *utf8FontFile {
+	return &utf8FontFile{fileReader: &fileReader{array: data}, tableDescriptions: map[string]*tableDescription{"loca": {position: start}}}
+}
+func recoverLOCA(operation func()) (message string) {
+	defer func() {
+		if value := recover(); value != nil {
+			message = fmt.Sprint(value)
+		}
+	}()
+	operation()
+	return ""
+}
+
+func TestLOCAOffsetsMatchLegacy(t *testing.T) {
+	random := rand.New(rand.NewSource(532))
+	for _, format := range []int{0, 1} {
+		for _, count := range []int{0, 1, 127, 2048, 65535} {
+			width := 2 * (format + 1)
+			data := make([]byte, 7+(count+1)*width)
+			random.Read(data)
+			old := locaFixture(bytes.Clone(data), 7)
+			current := locaFixture(bytes.Clone(data), 7)
+			expected := legacyParseLOCA(old, format, count)
+			current.parseLOCATable(format, count)
+			if old.fileReader.readerPosition != current.fileReader.readerPosition {
+				t.Fatal("reader position changed")
+			}
+			for i, want := range expected {
+				if got := current.symbolOffsets.at(i); got != want {
+					t.Fatalf("format=%d count=%d index=%d got=%d want=%d", format, count, i, got, want)
+				}
+			}
+			// Existing malformed-font behavior checks glyph indexes against the number
+			// of decoded offsets, not the byte length of the source table.
+			for _, index := range []int{-1, count + 1, count + 2, int(^uint(0) >> 1)} {
+				want := recoverLOCA(func() { _ = expected[index] })
+				got := recoverLOCA(func() { _ = current.symbolOffsets.at(index) })
+				if got != want {
+					t.Fatalf("invalid index=%d panic=%q want=%q", index, got, want)
+				}
+			}
+			// A later font operation can overwrite input bytes; decoded offsets were
+			// snapshots and must not start observing those writes after this change.
+			clear(current.fileReader.array)
+			for i, want := range expected {
+				if got := current.symbolOffsets.at(i); got != want {
+					t.Fatalf("snapshot changed at index %d", i)
+				}
+			}
+		}
+	}
+}
+
+func TestLOCATruncationMatchesLegacy(t *testing.T) {
+	for _, format := range []int{0, 1} {
+		const count = 8
+		fullLength := 7 + (count+1)*2*(format+1)
+		for length := 0; length <= fullLength; length++ {
+			data := make([]byte, length)
+			old := locaFixture(bytes.Clone(data), 7)
+			current := locaFixture(bytes.Clone(data), 7)
+			want := recoverLOCA(func() { legacyParseLOCA(old, format, count) })
+			got := recoverLOCA(func() { current.parseLOCATable(format, count) })
+			if got != want || old.fileReader.readerPosition != current.fileReader.readerPosition {
+				t.Fatalf("format=%d length=%d panic=%q/%q position=%d/%d", format, length, got, want, current.fileReader.readerPosition, old.fileReader.readerPosition)
+			}
+		}
+	}
+	for _, format := range []int{-1, 2, 65535} {
+		old, current := locaFixture(make([]byte, 20), 7), locaFixture(make([]byte, 20), 7)
+		expected := legacyParseLOCA(old, format, 3)
+		current.parseLOCATable(format, 3)
+		want := recoverLOCA(func() { _ = expected[0] })
+		got := recoverLOCA(func() { _ = current.symbolOffsets.at(0) })
+		if got != want || old.fileReader.readerPosition != current.fileReader.readerPosition {
+			t.Fatal("unknown format behavior changed")
+		}
+	}
+}
+
+// The fingerprints were generated with both subsetFont.go and font.go frozen
+// at 0515f60e985ad829d652456e07831170583011a0, before these optimizations.
+func TestSubsetFontFingerprints(t *testing.T) {
+	var cases []struct {
+		Font         string `json:"font"`
+		Cutset       string `json:"cutset"`
+		FontSHA256   string `json:"font_sha256"`
+		SubsetSHA256 string `json:"subset_sha256"`
+		InputSHA256  string `json:"input_sha256"`
+		WoffSHA256   string `json:"woff_sha256"`
+	}
+	if err := json.Unmarshal([]byte(subsetFingerprintJSON), &cases); err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 60 {
+		t.Fatalf("got %d fingerprints, want 60", len(cases))
+	}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%s/%d", tc.Font, i), func(t *testing.T) {
+			input, err := os.ReadFile(filepath.Join("../../d2renderers/d2fonts/ttf", tc.Font))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if subsetDigest(input) != tc.FontSHA256 {
+				t.Fatal("source font changed")
+			}
+			subset := UTF8CutFont(input, tc.Cutset)
+			if subsetDigest(subset) != tc.SubsetSHA256 {
+				t.Fatal("subset bytes changed")
+			}
+			if subsetDigest(input) != tc.InputSHA256 {
+				t.Fatal("input mutation changed")
+			}
+			woff, err := Sfnt2Woff(subset)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if subsetDigest(woff) != tc.WoffSHA256 {
+				t.Fatal("WOFF bytes changed")
+			}
+		})
+	}
+}
+func subsetDigest(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func BenchmarkLOCAOffsets(b *testing.B) {
+	for _, count := range []int{2048, 16384, 65535} {
+		data := make([]byte, (count+1)*4)
+		for i := 0; i <= count; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], uint32(i*12))
+		}
+		for _, legacy := range []bool{true, false} {
+			b.Run(fmt.Sprintf("glyphs=%d/legacy=%v", count, legacy), func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					font := locaFixture(data, 0)
+					total := 0
+					if legacy {
+						positions := legacyParseLOCA(font, 1, count)
+						for i := 0; i < 64; i++ {
+							total += positions[i*count/64]
+						}
+					} else {
+						font.parseLOCATable(1, count)
+						for i := 0; i < 64; i++ {
+							total += font.symbolOffsets.at(i * count / 64)
+						}
+					}
+					if total == 0 {
+						b.Fatal("offsets not read")
+					}
+				}
+			})
+		}
+	}
+}

--- a/lib/font/woff_compression.go
+++ b/lib/font/woff_compression.go
@@ -1,0 +1,53 @@
+package font
+
+import (
+	"bytes"
+	"compress/zlib"
+	"sync"
+)
+
+// Pool compressor workspace, never font inputs or completed WOFF output.
+// Large custom-font tables must not increase the retained output buffer size.
+const maxRetainedWoffBuffer = 64 << 10
+
+type woffCompression struct {
+	buffer bytes.Buffer
+	writer *zlib.Writer
+}
+
+var woffCompressionPool = sync.Pool{
+	New: func() any { return new(woffCompression) },
+}
+
+func acquireWoffCompression() *woffCompression {
+	return woffCompressionPool.Get().(*woffCompression)
+}
+
+func releaseWoffCompression(compression *woffCompression) {
+	resetWoffCompression(compression)
+	woffCompressionPool.Put(compression)
+}
+
+func resetWoffCompression(compression *woffCompression) {
+	if compression.buffer.Cap() > maxRetainedWoffBuffer {
+		compression.buffer = bytes.Buffer{}
+	} else {
+		compression.buffer.Reset()
+		clear(compression.buffer.Bytes()[:compression.buffer.Cap()])
+	}
+}
+
+// compressTable starts an independent zlib stream, retaining only the working buffers.
+// The returned bytes must be copied before another table or release.
+func (compression *woffCompression) compressTable(data []byte) []byte {
+	compression.buffer.Reset()
+	if compression.writer == nil {
+		compression.writer = zlib.NewWriter(&compression.buffer)
+	} else {
+		compression.writer.Reset(&compression.buffer)
+	}
+	compression.writer.Write(data)
+	compression.writer.Flush()
+	compression.writer.Close()
+	return compression.buffer.Bytes()
+}

--- a/lib/font/woff_compression_test.go
+++ b/lib/font/woff_compression_test.go
@@ -1,0 +1,111 @@
+package font
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestWoffCompressionRetainedBuffer(t *testing.T) {
+	for _, capacity := range []int{0, 1024, maxRetainedWoffBuffer, maxRetainedWoffBuffer + 1} {
+		compression := acquireWoffCompression()
+		compression.buffer = *bytes.NewBuffer(bytes.Repeat([]byte{0x7f}, capacity))
+		// Inspect cleanup while this test still owns the workspace. Pool.Get is
+		// not required to return the item most recently released.
+		backing := compression.buffer.Bytes()
+		retained := compression.buffer.Cap() <= maxRetainedWoffBuffer
+		resetWoffCompression(compression)
+		if compression.buffer.Len() != 0 || compression.buffer.Cap() > maxRetainedWoffBuffer {
+			t.Fatalf("retained buffer len/cap = %d/%d", compression.buffer.Len(), compression.buffer.Cap())
+		}
+		if !retained && compression.buffer.Cap() != 0 {
+			t.Fatal("oversized table buffer retained")
+		}
+		if retained && !bytes.Equal(backing, make([]byte, len(backing))) {
+			t.Fatal("retained table bytes were not cleared")
+		}
+		releaseWoffCompression(compression)
+	}
+}
+
+func TestWoffCompressionIndependentStreams(t *testing.T) {
+	testWoffCompressionIndependentStreams(t)
+}
+
+func testWoffCompressionIndependentStreams(t *testing.T) {
+	t.Helper()
+	compression := acquireWoffCompression()
+	defer releaseWoffCompression(compression)
+	rng := rand.New(rand.NewSource(2))
+	for _, size := range []int{262144, 1, 0, 65536, 8, 32768} {
+		data := make([]byte, size)
+		rng.Read(data)
+		var want bytes.Buffer
+		writer := zlib.NewWriter(&want)
+		writer.Write(data)
+		writer.Flush()
+		writer.Close()
+		got := compression.compressTable(data)
+		if !bytes.Equal(got, want.Bytes()) {
+			t.Fatalf("compressed stream differs at size %d", size)
+		}
+	}
+}
+
+func TestSfnt2WoffConcurrentAndOwnedOutput(t *testing.T) {
+	face, err := os.ReadFile("../../d2renderers/d2fonts/ttf/SourceSansPro-Regular.ttf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	face = UTF8CutFont(face, "D2 diagram Ω À 0123456789")
+	want, err := legacySfnt2Woff(bytes.Clone(face))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workers sync.WaitGroup
+	for range 8 {
+		workers.Go(func() {
+			var outputs [][]byte
+			for range 8 {
+				got, err := Sfnt2Woff(bytes.Clone(face))
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				outputs = append(outputs, got)
+			}
+			for _, output := range outputs {
+				if !bytes.Equal(output, want) {
+					t.Error("conversion differs or later pool use modified returned WOFF")
+				}
+			}
+		})
+	}
+	workers.Wait()
+}
+
+func TestSfnt2WoffPoolAfterMalformedInput(t *testing.T) {
+	// The first table is valid and borrows a compressor. The short head table
+	// panics afterwards, exercising deferred return of that workspace.
+	buf := make([]byte, SIZE_OF_SFNT_HEADER+2*SIZE_OF_SFNT_TABLE_ENTRY+8)
+	binary.BigEndian.PutUint16(buf[4:], 2)
+	for i, tag := range []string{"aaaa", "head"} {
+		record := buf[SIZE_OF_SFNT_HEADER+i*SIZE_OF_SFNT_TABLE_ENTRY:]
+		copy(record, tag)
+		binary.BigEndian.PutUint32(record[SFNT_OFFSET_OFFSET:], uint32(SIZE_OF_SFNT_HEADER+2*SIZE_OF_SFNT_TABLE_ENTRY+4*i))
+		binary.BigEndian.PutUint32(record[SFNT_OFFSET_LENGTH:], 4)
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("malformed head unexpectedly accepted")
+			}
+		}()
+		Sfnt2Woff(buf)
+	}()
+	testWoffCompressionIndependentStreams(t)
+}

--- a/lib/font/woff_oracle_test.go
+++ b/lib/font/woff_oracle_test.go
@@ -1,85 +1,17 @@
-// Sfnt2Woff is a native go port of the JS library
-// https://github.com/fontello/ttf2woff
-// that converts sfnt fonts (.ttf and .otf) to .woff fonts
-
 package font
 
+// Frozen conversion from 0515f60e985ad829d652456e07831170583011a0.
+// Keep this independent of the production compressor lifecycle.
 import (
+	"bytes"
+	"compress/zlib"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"sort"
 )
 
-var (
-	// sfnt2Woff offset
-	SFNT_OFFSET_TAG      = 0
-	SFNT_OFFSET_CHECKSUM = 4
-	SFNT_OFFSET_OFFSET   = 8
-	SFNT_OFFSET_LENGTH   = 12
-
-	// sfnt2Woff entry offset
-	SFNT_ENTRY_OFFSET_FLAVOR              = 0
-	SFNT_ENTRY_OFFSET_VERSION_MAJ         = 4
-	SFNT_ENTRY_OFFSET_VERSION_MIN         = 6
-	SFNT_ENTRY_OFFSET_CHECKSUM_ADJUSTMENT = 8
-
-	// woff offset
-	WOFF_OFFSET_MAGIC            = 0
-	WOFF_OFFSET_FLAVOR           = 4
-	WOFF_OFFSET_SIZE             = 8
-	WOFF_OFFSET_NUM_TABLES       = 12
-	WOFF_OFFSET_RESERVED         = 14
-	WOFF_OFFSET_SFNT_SIZE        = 16
-	WOFF_OFFSET_VERSION_MAJ      = 20
-	WOFF_OFFSET_VERSION_MIN      = 22
-	WOFF_OFFSET_META_OFFSET      = 24
-	WOFF_OFFSET_META_LENGTH      = 28
-	WOFF_OFFSET_META_ORIG_LENGTH = 32
-	WOFF_OFFSET_PRIV_OFFSET      = 36
-	WOFF_OFFSET_PRIV_LENGTH      = 40
-
-	// woff entry offset
-	WOFF_ENTRY_OFFSET_TAG          = 0
-	WOFF_ENTRY_OFFSET_OFFSET       = 4
-	WOFF_ENTRY_OFFSET_COMPR_LENGTH = 8
-	WOFF_ENTRY_OFFSET_LENGTH       = 12
-	WOFF_ENTRY_OFFSET_CHECKSUM     = 16
-
-	// magic
-	MAGIC_WOFF                uint32 = 0x774f4646
-	MAGIC_CHECKSUM_ADJUSTMENT uint32 = 0xb1b0afba
-
-	// sizes
-	SIZE_OF_WOFF_HEADER      = 44
-	SIZE_OF_WOFF_ENTRY       = 20
-	SIZE_OF_SFNT_HEADER      = 12
-	SIZE_OF_SFNT_TABLE_ENTRY = 16
-)
-
-type TableEntry struct {
-	Tag      []byte
-	CheckSum uint32
-	Offset   uint32
-	Length   uint32
-}
-
-func longAlign(n uint32) uint32 {
-	return (n + 3) & ^uint32(3)
-}
-
-func calcChecksum(buf []byte) uint32 {
-	var sum uint32 = 0
-	var nlongs = len(buf) / 4
-
-	for i := 0; i < nlongs; i++ {
-		var t = binary.BigEndian.Uint32(buf[i*4:])
-		sum = sum + t
-	}
-	return sum
-}
-
-func Sfnt2Woff(fontBuf []byte) ([]byte, error) {
+func legacySfnt2Woff(fontBuf []byte) ([]byte, error) {
 	numTables := binary.BigEndian.Uint16(fontBuf[4:])
 
 	woffHeader := make([]byte, SIZE_OF_WOFF_HEADER)
@@ -153,12 +85,6 @@ func Sfnt2Woff(fontBuf []byte) ([]byte, error) {
 	flavor := uint32(0)
 	offset := SIZE_OF_WOFF_HEADER + int(numTables)*SIZE_OF_WOFF_ENTRY
 	var tableBytes []byte
-	var compression *woffCompression
-	defer func() {
-		if compression != nil {
-			releaseWoffCompression(compression)
-		}
-	}()
 
 	for i := 0; i < len(entries); i++ {
 		tableEntry := entries[i]
@@ -171,20 +97,21 @@ func Sfnt2Woff(fontBuf []byte) ([]byte, error) {
 			binary.BigEndian.PutUint32(sfntData[SFNT_ENTRY_OFFSET_CHECKSUM_ADJUSTMENT:], uint32(checksumAdjustment))
 		}
 
-		if compression == nil {
-			compression = acquireWoffCompression()
-		}
-		compressed := compression.compressTable(sfntData)
+		var res bytes.Buffer
+		w := zlib.NewWriter(&res)
+		w.Write(sfntData)
+		w.Flush()
+		w.Close()
 
-		compLength := math.Min(float64(len(compressed)), float64(len(sfntData)))
+		compLength := math.Min(float64(len(res.Bytes())), float64(len(sfntData)))
 		length := longAlign(uint32(compLength))
 
 		table := make([]byte, length)
 		// only deflate data if the deflated data is actually smaller
-		if len(compressed) >= len(sfntData) {
+		if len(res.Bytes()) >= len(sfntData) {
 			copy(table, sfntData)
 		} else {
-			copy(table, compressed)
+			copy(table, res.Bytes())
 		}
 
 		binary.BigEndian.PutUint32(tableInfo[i*SIZE_OF_WOFF_ENTRY+WOFF_ENTRY_OFFSET_OFFSET:], uint32(offset))

--- a/lib/font/woff_test.go
+++ b/lib/font/woff_test.go
@@ -1,0 +1,95 @@
+package font
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSfnt2WoffMatchesLegacy(t *testing.T) {
+	paths, err := filepath.Glob("../../d2renderers/d2fonts/ttf/*.ttf")
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("find bundled fonts: %v (%d files)", err, len(paths))
+	}
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			face, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			checkWoffLegacy(t, face)
+			for _, corpus := range []string{"", "D2 diagrams 0123 -> []", "Àéß Ω Ж 中 😀 e\u0301"} {
+				checkWoffLegacy(t, UTF8CutFont(bytes.Clone(face), corpus))
+			}
+		})
+	}
+}
+
+func TestSfnt2WoffIndependentCompressionStreams(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for _, lengths := range [][]int{
+		{}, {0}, {1, 2, 3, 4, 8, 16, 64},
+		{65536, 16, 32768, 0, 1, 131072, 1024},
+	} {
+		buf := make([]byte, SIZE_OF_SFNT_HEADER+len(lengths)*SIZE_OF_SFNT_TABLE_ENTRY)
+		binary.BigEndian.PutUint16(buf[4:], uint16(len(lengths)))
+		for i, length := range lengths {
+			data := make([]byte, longAlign(uint32(length)))
+			if i%2 == 0 {
+				rng.Read(data[:length])
+			} else {
+				for j := range data[:length] {
+					data[j] = byte(j % 7)
+				}
+			}
+			record := buf[SIZE_OF_SFNT_HEADER+i*SIZE_OF_SFNT_TABLE_ENTRY:]
+			copy(record, fmt.Sprintf("%04d", len(lengths)-i))
+			binary.BigEndian.PutUint32(record[SFNT_OFFSET_CHECKSUM:], calcChecksum(data))
+			binary.BigEndian.PutUint32(record[SFNT_OFFSET_OFFSET:], uint32(len(buf)))
+			binary.BigEndian.PutUint32(record[SFNT_OFFSET_LENGTH:], uint32(length))
+			buf = append(buf, data...)
+		}
+		checkWoffLegacy(t, buf)
+	}
+}
+
+func checkWoffLegacy(t *testing.T, face []byte) {
+	t.Helper()
+	wantInput, gotInput := bytes.Clone(face), bytes.Clone(face)
+	want, wantErr := legacySfnt2Woff(wantInput)
+	got, gotErr := Sfnt2Woff(gotInput)
+	if fmt.Sprint(gotErr) != fmt.Sprint(wantErr) {
+		t.Fatalf("errors differ: got %v, want %v", gotErr, wantErr)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("WOFF differs: got %d bytes, want %d", len(got), len(want))
+	}
+	if !bytes.Equal(gotInput, wantInput) {
+		t.Fatal("input checksum adjustment differs")
+	}
+}
+
+func BenchmarkSfnt2Woff(b *testing.B) {
+	face, err := os.ReadFile("../../d2renderers/d2fonts/ttf/SourceSansPro-Regular.ttf")
+	if err != nil {
+		b.Fatal(err)
+	}
+	face = UTF8CutFont(face, "D2 diagrams 0123 -> []")
+	for _, tc := range []struct {
+		name    string
+		convert func([]byte) ([]byte, error)
+	}{{"legacy", legacySfnt2Woff}, {"reuse", Sfnt2Woff}} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if _, err := tc.convert(bytes.Clone(face)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/lib/textmeasure/atlas.go
+++ b/lib/textmeasure/atlas.go
@@ -178,6 +178,9 @@ type fixedGlyph struct {
 // makeSquareMapping finds an optimal glyph arrangement of the given runes, so that their common
 // bounding box is as square as possible.
 func makeSquareMapping(face font.Face, runes []rune, padding fixed.Int26_6) (map[rune]fixedGlyph, fixed.Rectangle26_6) {
+	if _, ok := face.(*metricPreservingFace); ok {
+		return makeMetricsSquareMapping(face, runes, padding)
+	}
 	width := sort.Search(int(fixed.I(1024*1024)), func(i int) bool {
 		width := fixed.Int26_6(i)
 		_, bounds := makeMapping(face, runes, padding, width)

--- a/lib/textmeasure/atlas_metrics.go
+++ b/lib/textmeasure/atlas_metrics.go
@@ -1,0 +1,69 @@
+package textmeasure
+
+import (
+	"sort"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/math/fixed"
+)
+
+type atlasGlyphMetrics struct {
+	rune    rune
+	frame   fixed.Rectangle26_6
+	advance fixed.Int26_6
+}
+
+// Ruler faces have immutable metrics. Measure each glyph once, then search for
+// the packing width using bounds alone. Only the chosen width needs a mapping.
+// Arbitrary font.Face implementations retain makeSquareMapping's original
+// method-call sequence, including repeated metric queries during the search.
+func makeMetricsSquareMapping(face font.Face, runes []rune, padding fixed.Int26_6) (map[rune]fixedGlyph, fixed.Rectangle26_6) {
+	glyphs := make([]atlasGlyphMetrics, 0, len(runes))
+	for _, r := range runes {
+		bounds, advance, ok := face.GlyphBounds(r)
+		if !ok {
+			continue
+		}
+		glyphs = append(glyphs, atlasGlyphMetrics{
+			rune: r,
+			frame: fixed.Rectangle26_6{
+				Min: fixed.P(bounds.Min.X.Floor(), bounds.Min.Y.Floor()),
+				Max: fixed.P(bounds.Max.X.Ceil(), bounds.Max.Y.Ceil()),
+			},
+			advance: advance,
+		})
+	}
+	metrics := face.Metrics()
+	lineHeight := metrics.Ascent + metrics.Descent
+	width := sort.Search(int(fixed.I(1024*1024)), func(i int) bool {
+		bounds := arrangeAtlasGlyphs(glyphs, padding, fixed.Int26_6(i), lineHeight, nil)
+		return bounds.Max.X-bounds.Min.X >= bounds.Max.Y-bounds.Min.Y
+	})
+	mapping := make(map[rune]fixedGlyph, len(glyphs))
+	bounds := arrangeAtlasGlyphs(glyphs, padding, fixed.Int26_6(width), lineHeight, mapping)
+	return mapping, bounds
+}
+
+func arrangeAtlasGlyphs(glyphs []atlasGlyphMetrics, padding, width, lineHeight fixed.Int26_6, mapping map[rune]fixedGlyph) fixed.Rectangle26_6 {
+	bounds := fixed.Rectangle26_6{}
+	dot := fixed.P(0, 0)
+	for _, glyph := range glyphs {
+		frame := glyph.frame
+		dot.X -= frame.Min.X
+		frame = frame.Add(dot)
+		if mapping != nil {
+			mapping[glyph.rune] = fixedGlyph{dot: dot, frame: frame, advance: glyph.advance}
+		}
+		bounds = bounds.Union(frame)
+		dot.X = frame.Max.X
+		dot.X += padding
+		dot.X = fixed.I(dot.X.Ceil())
+		if frame.Max.X >= width {
+			dot.X = 0
+			dot.Y += lineHeight
+			dot.Y += padding
+			dot.Y = fixed.I(dot.Y.Ceil())
+		}
+	}
+	return bounds
+}

--- a/lib/textmeasure/atlas_metrics_test.go
+++ b/lib/textmeasure/atlas_metrics_test.go
@@ -1,0 +1,179 @@
+package textmeasure
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"testing"
+	"unicode"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/math/fixed"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+)
+
+// These two functions retain the pre-optimization packing algorithm as an
+// independent oracle, including all rounding, wrapping and duplicate handling.
+func legacySquareMapping(face font.Face, runes []rune, padding fixed.Int26_6) (map[rune]fixedGlyph, fixed.Rectangle26_6) {
+	width := sort.Search(int(fixed.I(1024*1024)), func(i int) bool {
+		width := fixed.Int26_6(i)
+		_, bounds := legacyAtlasMapping(face, runes, padding, width)
+		return bounds.Max.X-bounds.Min.X >= bounds.Max.Y-bounds.Min.Y
+	})
+	return legacyAtlasMapping(face, runes, padding, fixed.Int26_6(width))
+}
+
+// makeMapping arranges glyphs of the given runes into rows in such a way, that no glyph is located
+// fully to the right of the specified width. Specifically, it places glyphs in a row one by one and
+// once it reaches the specified width, it starts a new row.
+func legacyAtlasMapping(face font.Face, runes []rune, padding, width fixed.Int26_6) (map[rune]fixedGlyph, fixed.Rectangle26_6) {
+	mapping := make(map[rune]fixedGlyph)
+	bounds := fixed.Rectangle26_6{}
+
+	dot := fixed.P(0, 0)
+
+	for _, r := range runes {
+		b, advance, ok := face.GlyphBounds(r)
+		if !ok {
+			continue
+		}
+
+		// this is important for drawing, artifacts arise otherwise
+		frame := fixed.Rectangle26_6{
+			Min: fixed.P(b.Min.X.Floor(), b.Min.Y.Floor()),
+			Max: fixed.P(b.Max.X.Ceil(), b.Max.Y.Ceil()),
+		}
+
+		dot.X -= frame.Min.X
+		frame = frame.Add(dot)
+
+		mapping[r] = fixedGlyph{
+			dot:     dot,
+			frame:   frame,
+			advance: advance,
+		}
+		bounds = bounds.Union(frame)
+
+		dot.X = frame.Max.X
+
+		// padding + align to integer
+		dot.X += padding
+		dot.X = fixed.I(dot.X.Ceil())
+
+		// width exceeded, new row
+		if frame.Max.X >= width {
+			dot.X = 0
+			dot.Y += face.Metrics().Ascent + face.Metrics().Descent
+
+			// padding + align to integer
+			dot.Y += padding
+			dot.Y = fixed.I(dot.Y.Ceil())
+		}
+	}
+
+	return mapping, bounds
+}
+
+func TestAtlasMetricsMatchesLegacy(t *testing.T) {
+	runeSets := [][]rune{
+		{}, {unicode.ReplacementChar}, {'A', 'g', ' ', '\t', 'A', unicode.ReplacementChar, unicode.ReplacementChar, '界', '🙂'},
+		append([]rune{unicode.ReplacementChar}, Runes...),
+	}
+	for _, family := range d2fonts.FontFamilies {
+		for _, style := range d2fonts.FontStyles {
+			data, ok := d2fonts.FontFaces.Lookup(d2fonts.Font{Family: family, Style: style})
+			if !ok {
+				continue
+			}
+			parsed, err := parseFont(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, size := range []float64{0, 1, 13, 16.25, 72, 256} {
+				face := parsed.newFace(size)
+				for set, runes := range runeSets {
+					for _, padding := range []fixed.Int26_6{0, 1, fixed.I(2)} {
+						expected, expectedBounds := legacySquareMapping(face, runes, padding)
+						actual, actualBounds := makeSquareMapping(face, runes, padding)
+						if expectedBounds != actualBounds || !reflect.DeepEqual(expected, actual) {
+							t.Fatalf("family=%s style=%s size=%v set=%d padding=%v bounds=%v/%v", family, style, size, set, padding, expectedBounds, actualBounds)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+type atlasCountingFace struct {
+	font.Face
+	boundsCalls, metricsCalls int
+}
+
+func (face *atlasCountingFace) GlyphBounds(r rune) (fixed.Rectangle26_6, fixed.Int26_6, bool) {
+	face.boundsCalls++
+	return face.Face.GlyphBounds(r)
+}
+func (face *atlasCountingFace) Metrics() font.Metrics {
+	face.metricsCalls++
+	return face.Face.Metrics()
+}
+
+func TestAtlasMetricsQueriesEachGlyphOnce(t *testing.T) {
+	parsed, err := parseFont(d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	face := &atlasCountingFace{Face: parsed.newFace(16)}
+	_, _ = makeMetricsSquareMapping(face, Runes, fixed.I(2))
+	if face.boundsCalls != len(Runes) || face.metricsCalls != 1 {
+		t.Fatalf("bounds calls=%d, metrics calls=%d", face.boundsCalls, face.metricsCalls)
+	}
+	// Custom public faces retain the original observation/call sequence.
+	oldFace := &atlasCountingFace{Face: parsed.newFace(16)}
+	newFace := &atlasCountingFace{Face: parsed.newFace(16)}
+	oldMapping, oldBounds := legacySquareMapping(oldFace, Runes, fixed.I(2))
+	newMapping, newBounds := makeSquareMapping(newFace, Runes, fixed.I(2))
+	if oldFace.boundsCalls != newFace.boundsCalls || oldFace.metricsCalls != newFace.metricsCalls || oldBounds != newBounds || !reflect.DeepEqual(oldMapping, newMapping) {
+		t.Fatal("custom font.Face behavior changed")
+	}
+}
+
+func TestAtlasMetricsPreservesFixedArithmetic(t *testing.T) {
+	parsed, err := parseFont(d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	face := parsed.newFace(16)
+	runes := []rune{'A', 'g', ' ', 'A', unicode.ReplacementChar}
+	for _, padding := range []fixed.Int26_6{-fixed.I(2), math.MaxInt32, math.MinInt32} {
+		oldMapping, oldBounds := legacySquareMapping(face, runes, padding)
+		newMapping, newBounds := makeSquareMapping(face, runes, padding)
+		if oldBounds != newBounds || !reflect.DeepEqual(oldMapping, newMapping) {
+			t.Fatalf("padding=%v fixed arithmetic changed", padding)
+		}
+	}
+}
+
+func BenchmarkAtlasMetrics(b *testing.B) {
+	parsed, err := parseFont(d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, legacy := range []bool{true, false} {
+		b.Run(fmt.Sprintf("legacy=%v", legacy), func(b *testing.B) {
+			face := parsed.newFace(16)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if legacy {
+					_, _ = legacySquareMapping(face, Runes, fixed.I(2))
+				} else {
+					_, _ = makeSquareMapping(face, Runes, fixed.I(2))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

Fresh complete diagram E2E measurements with both speed changes show **26.280 → 11.342 s (2.32×)** for the full test process, including layout and golden checks, and **12.146 → 1.141 s (10.64×)** for SVG rendering alone. These use six fresh processes per variant in mirrored order, the same pinned Git binary, Apple M4, Go 1.27.0, and GOMAXPROCS=1; all 672 SVG/ASCII fingerprints and 7,257 phase event keys/counts match in every run. Separately, the verified real-world runs give a **3.12× median per-fixture improvement including layout** (4.82× excluding layout), combining Dagre and ELK within each of ten fixtures before taking the median of fixture speedup ratios. The release note rounds these to approximately 10× SVG rendering and 3× real-world processing. These measurements exclude the separate SVG-size changes. Signing the compiler commit changes no source bytes.

Compilation repeatedly built temporary key-path ASTs, copied single-board IR, and scheduled glob work without active rules. Rendering eagerly processed unused font styles and rebuilt glyph data. This removes that repeated work while preserving source references, geometry, SVG/font bytes, error behavior, and public customization semantics.

- Compile ordinary root boards directly; retain independent copies for nested boards and roots with board declarations. Run folder comparison only when child boards exist.
- Format canonical graph/glob IDs without constructing temporary ASTs; retain original quoting/escaping for unusual strings and customized public syntax settings.
- Skip empty glob worklists while preserving deferred targets and settled generations; only resolve ancestor shapes when a glob can use the answer.
- Consume parser read-ahead with a cursor instead of shifting its unread suffix. Build raw token text only after a real escape, preserving mutable raw/decoded pointer ownership and reader/error order.
- Generate font CSS/subsets only after their existing trigger matches; reuse bounded independent zlib compressor scratch and decode only selected LOCA offsets.
- Measure immutable ruler glyphs once and search atlas widths using bounds; keep the existing path for arbitrary public font faces.

Real-world measurements use the ten fixtures in #2871, each through Dagre and ELK: 20 engine cases. Medians of six fresh, unprofiled processes per variant, with mirrored original/font/compiler/compiler/font/original order, Apple M4, Go 1.27.0, GOMAXPROCS=1. All variants use the same fixtures, toolchain, Git binary, and golden assertions.

| Measurement across 20 cases | Original | Font changes | Compiler follow-up | Gain this round |
| --- | ---: | ---: | ---: | ---: |
| Raw compiler | 34.41 ms | 35.45 ms | 21.11 ms | **1.68×** |
| Compilation including sizing, excluding layout | 54.07 ms | 54.96 ms | 41.52 ms | **1.32×** |
| Compile + render, excluding layout | 460.89 ms | 132.56 ms | 118.57 ms | **1.12×** |
| All timed non-layout work including setup/serde/XML | 790.58 ms | 257.95 ms | 238.91 ms | **1.08×** |
| Full test process including layout and goldens | 1224.83 ms | 686.03 ms | 656.15 ms | **1.05×** |

Product compile + render is **3.89×** faster cumulatively on these real-world cases. The raw-compiler throughput runner independently measures **15.892 → 9.931 ms per ten-source pass (1.60×)**, with allocated bytes **14.878 → 7.717 MB (48.1% lower)**. That runner compiles each source anew 200 times per fresh process; it measures repeated compilation throughput, excludes serialization/layout/rendering, and checks each process's final graph/configuration. These are not universal 10× claims. Sizing/SVG source did not change in the compiler follow-up; no separate sizing/SVG optimization is claimed. Compiler allocations can affect later garbage collection. Each aggregate is a median of per-run sums; component medians need not add exactly to the median product total.

The cursor also removes quadratic lookahead consumption. A separate synthetic parser case with 16,384 spaces and 16,384 tabs after a quoted scalar improves **38.983 → 0.484 ms (80.62×)**. This stress case is not part of the real-world corpus.

The preceding font-only commit, `a8ba8ae2`, separately measured the original 624-case renderer replay at **7.451 → 0.860 s (8.67×)**, with all 652 original SVG/ASCII fingerprints unchanged. Its renderer implementation remains unchanged by the compiler follow-up.

Behavior proof: all 360 real-world SVG records from 18 final E2E runs match the original oracle/current goldens; all 220 phase event keys/counts match. All 120 final raw graph/config records match. An independent audit recomputed 2,268 numerical values without discrepancies. Added full-graph/AST/config/reference/ownership oracles, 22 frozen parser observations, canonical-ID/customized-syntax cases, and late/nested/imported glob regressions. Formatter equivalence also passed over one million randomized inputs. No existing E2E tests, goldens, or dependency files changed.

Validation: changed packages, compiler/oracle coverage, and complete diagram E2E (672 SVG/ASCII fingerprints) pass under the race detector; vet, native CGO-disabled build, and WASM build pass. The full Go suite was attempted, but socket/remote-asset tests cannot run in this local sandbox; they remain for hosted CI. The prior font-only full race run also identified an existing CLI `stderrWrapper` race in `watch-imported-file`, reproduced on untouched baseline.

Reproduce phase measurements with `ci/nonlayout-perf/README.md`, integrating fixture PR #2871 into both the old font head and this candidate, and selecting `--test '^TestE2E$/^real_world$'`. The phase boundary excludes all of `d2layouts.LayoutNested`, and component compiler/sizing measurements are nested rather than added twice. Shared test setup/serde and whole-process wall time are reported separately. Baselines: original `0515f60e985ad829d652456e07831170583011a0`, fixtures `5ab6c1a34453f07e590533afdbc95628caa2525f`, font head `a8ba8ae2ee8daa962f002f104dbc1404556860a9`. No diagram-output cache or layout algorithm change.

