### PR TITLE
ci: remove Discord notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [master]
   workflow_dispatch:
   workflow_call:
-    secrets:
-      DISCORD_WEBHOOK_URL:
-        required: false
 permissions:
   actions: read
   contents: read
@@ -31,8 +28,9 @@ jobs:
           package-manager-cache: false
       - run: COLOR=1 ./make.sh
         env:
+          # Disable chat notifications from the shared CI helper.
+          CI_MAKE_ROOT: "0"
           GITHUB_TOKEN: ${{ github.token }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - name: Verify representative release archive and size budget
         run: ./ci/release/build.sh --rebuild --run=linux/amd64 --version=v0.0.0-ci
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -49,7 +47,6 @@ jobs:
       - run: COLOR=1 ./ci/sub/bin/nofixups.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   signed:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -59,4 +56,3 @@ jobs:
       - run: COLOR=1 ./ci/sub/bin/ensure_signed.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/release-archives.yml
+++ b/.github/workflows/release-archives.yml
@@ -29,8 +29,6 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/ci.yml
-    secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Human

---

## AI

Remove Discord notifications from CI and release validation by removing the webhook secret declaration and forwarding. Set `CI_MAKE_ROOT=0` on the main build step to disable the shared CI helper's chat notifications; otherwise it fails protected-branch builds when no webhook is configured. This opt-out is already used elsewhere in the repository and preserves build, clean-tree, and no-fixup checks.

Validation: actionlint v1.7.12 passes for both changed workflows (shellcheck and pyflakes disabled); `git diff --check` passes. A focused shell harness using the pinned helper verifies successful protected-branch CI and distinct build, background-job, dirty-tree, and no-fixup failures preserve their exit codes with zero network requests. No Discord webhook references remain in `.github`.

Merged to master as `b52ceac7eacac13775f07e514ed40a9f7954c682`; the repository `DISCORD_WEBHOOK_URL` secret has been deleted and its absence verified. All PR checks passed.
