### PR TITLE
cli: stream PNG rendering to reduce memory usage

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Improvements 🧹
 
+- exports: reduce PNG memory usage and support images above the previous 67-megapixel limit
 - performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.
 - renders: SVG exports are approximately 24% smaller across the E2E corpus and 18% smaller across real-world fixtures, with unchanged appearance.
 - renders: render Markdown labels as native SVG instead of HTML `foreignObject` content

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -45,6 +45,8 @@ Pass - to have
 .Nm
 read from stdin or write to stdout.
 .Pp
+PNG exports support up to 32768 pixels per dimension, subject to rendering resource limits.
+.Pp
 Never use the presence of the output file to check for success.
 Always use the exit status of
 .Nm d2

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -30,6 +30,8 @@ It defaults to file.svg if an output path is not provided.
 
 Use - to have d2 read from stdin or write to stdout.
 
+PNG exports support up to 32768 pixels per dimension, subject to rendering resource limits.
+
 See man d2 for more detailed docs.
 
 Flags:

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/d2lang/d2/lib/imgbundler"
 	"github.com/d2lang/d2/lib/log"
 	"github.com/d2lang/d2/lib/pdf"
-	"github.com/d2lang/d2/lib/png"
 	"github.com/d2lang/d2/lib/pptx"
 	"github.com/d2lang/d2/lib/simplelog"
 	"github.com/d2lang/d2/lib/textmeasure"
@@ -1014,33 +1013,18 @@ func _renderWithPNGEncoder(ctx context.Context, ms *xmain.State, plugin d2plugin
 			return svg, false, err
 		}
 		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
-		out, err := renderPNGWithEncoder(ctx, inputPath, cacheImages, diagram, *renderOpts, pngEncoder)
-		if err != nil {
-			return svg, false, err
-		}
-		var withExif []byte
-		err = runFinalizer(ctx, func() error {
-			var finalizeErr error
-			withExif, finalizeErr = png.AddExifToEncoderOutputInPlace(out)
-			return finalizeErr
-		})
-		if err != nil {
-			return svg, false, err
-		}
-		out = withExif
 		if opts.MasterID == "" {
-			if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-				return svg, false, err
-			}
-			written, err := runStatusFinalizer(ctx, func() (bool, error) {
-				return writeWithStatus(ms, outputPath, out)
+			written, err := writePNGWithStatus(ctx, ms, outputPath, func(output io.Writer) error {
+				return renderPNGToWriter(ctx, inputPath, cacheImages, diagram, *renderOpts, pngEncoder, output)
 			})
 			if err != nil {
 				return svg, written, err
 			}
 			return svg, written, nil
 		}
-		return svg, false, nil
+		// Animated SVG composition only needs validation, not retained PNG bytes.
+		err = renderPNGToWriter(ctx, inputPath, cacheImages, diagram, *renderOpts, pngEncoder, io.Discard)
+		return svg, false, err
 	}
 
 	svg, err := d2svg.Render(diagram, renderOpts)

--- a/d2cli/raster.go
+++ b/d2cli/raster.go
@@ -71,8 +71,8 @@ func renderRasterSVG(ctx context.Context, plugin d2plugin.Plugin, diagram *d2tar
 const (
 	// These production safety ceilings bound raster work independently
 	// of the caller's input source.
-	// Admit long, narrow diagrams while rasterMaxPixels remains the hard bound
-	// on final-frame area and therefore prevents unbounded canvas allocation.
+	// Admit long, narrow diagrams while rasterMaxPixels bounds complete-frame
+	// allocations. Streaming PNG uses these dimensions with a bounded strip.
 	rasterMaxDimension                = 32_768
 	rasterMaxPixels             int64 = 64 * 1024 * 1024
 	rasterMaxNodes                    = 1_000_000

--- a/d2cli/raster_png_encoder.go
+++ b/d2cli/raster_png_encoder.go
@@ -12,6 +12,9 @@ import (
 	"image"
 	stdpng "image/png"
 	"io"
+	"math"
+
+	d2png "github.com/d2lang/d2/lib/png"
 )
 
 // rasterPNGEncoder retains compression and row workspaces for the lifetime of
@@ -22,6 +25,7 @@ import (
 // pixels, discards the partial attempt, and falls back to the generic encoder.
 type rasterPNGEncoder struct {
 	native        rasterOpaquePNGEncoder
+	bands         rasterPNGBandEncoder
 	generic       rasterPNGEncoderBufferPool
 	genericWriter rasterPNGContextWriter
 	genericImage  image.NRGBA
@@ -145,11 +149,30 @@ type rasterOpaquePNGEncoder struct {
 	zw         *zlib.Writer
 	bw         *bufio.Writer
 	stream     rasterPNGIDATStream
+	channels   int
 }
 
 func (e *rasterOpaquePNGEncoder) encode(output io.Writer, source *image.NRGBA) error {
 	bounds := source.Bounds()
-	rowSize := 1 + 3*bounds.Dx()
+	if err := e.start(output, bounds.Dx(), bounds.Dy(), true); err != nil {
+		return err
+	}
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		sourceOffset := (y - bounds.Min.Y) * source.Stride
+		sourceRow := source.Pix[sourceOffset : sourceOffset+bounds.Dx()*4]
+		if err := e.writeRow(sourceRow); err != nil {
+			return err
+		}
+	}
+	return e.finish()
+}
+
+func (e *rasterOpaquePNGEncoder) start(output io.Writer, width, height int, opaque bool) error {
+	e.channels = 4
+	if opaque {
+		e.channels = 3
+	}
+	rowSize := 1 + e.channels*width
 	storageSize := 4 * rowSize
 	if cap(e.storage) < storageSize {
 		e.storage = make([]byte, storageSize)
@@ -165,14 +188,19 @@ func (e *rasterOpaquePNGEncoder) encode(output io.Writer, source *image.NRGBA) e
 
 	e.stream.output = output
 	e.stream.err = nil
-	if _, err := io.WriteString(output, "\x89PNG\r\n\x1a\n"); err != nil {
+	if n, err := io.WriteString(output, "\x89PNG\r\n\x1a\n"); err != nil {
 		return err
+	} else if n != 8 {
+		return io.ErrShortWrite
 	}
 	var ihdr [13]byte
-	binary.BigEndian.PutUint32(ihdr[0:4], uint32(bounds.Dx()))
-	binary.BigEndian.PutUint32(ihdr[4:8], uint32(bounds.Dy()))
+	binary.BigEndian.PutUint32(ihdr[0:4], uint32(width))
+	binary.BigEndian.PutUint32(ihdr[4:8], uint32(height))
 	ihdr[8] = 8
 	ihdr[9] = 2
+	if !opaque {
+		ihdr[9] = 6
+	}
 	e.stream.emit(0x49484452, ihdr[:]) // IHDR
 	if e.stream.err != nil {
 		return e.stream.err
@@ -191,11 +219,14 @@ func (e *rasterOpaquePNGEncoder) encode(output io.Writer, source *image.NRGBA) e
 	} else {
 		e.zw.Reset(e.bw)
 	}
+	return nil
+}
 
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		sourceOffset := (y - bounds.Min.Y) * source.Stride
-		sourceRow := source.Pix[sourceOffset : sourceOffset+bounds.Dx()*4]
-		destination := e.raw[1:]
+func (e *rasterOpaquePNGEncoder) writeRow(sourceRow []byte) error {
+	destination := e.raw[1:]
+	if e.channels == 4 {
+		copy(destination, sourceRow)
+	} else {
 		for len(sourceRow) >= 16 {
 			if sourceRow[3]&sourceRow[7]&sourceRow[11]&sourceRow[15] != 0xff {
 				return errRasterPNGTranslucent
@@ -215,13 +246,17 @@ func (e *rasterOpaquePNGEncoder) encode(output io.Writer, source *image.NRGBA) e
 			sourceRow = sourceRow[4:]
 			destination = destination[3:]
 		}
-		row := rasterPNGFilteredRow(e.raw, e.prior, &e.candidates)
-		if _, err := e.zw.Write(row); err != nil {
-			return err
-		}
-		e.prior, e.raw = e.raw, e.prior
-		e.raw[0] = 0
 	}
+	row := rasterPNGFilteredRow(e.raw, e.prior, &e.candidates, e.channels)
+	if _, err := e.zw.Write(row); err != nil {
+		return err
+	}
+	e.prior, e.raw = e.raw, e.prior
+	e.raw[0] = 0
+	return nil
+}
+
+func (e *rasterOpaquePNGEncoder) finish() error {
 	if err := e.zw.Close(); err != nil {
 		return err
 	}
@@ -237,6 +272,119 @@ func (e *rasterOpaquePNGEncoder) encode(output io.Writer, source *image.NRGBA) e
 // the operation, but the caller's frame and encoded bytes do not.
 func (e *rasterOpaquePNGEncoder) releaseOutput() {
 	e.stream.output = nil
+}
+
+// rasterPNGBandEncoder writes a PNG as consecutive full-width bands arrive.
+// Its retained memory depends on the row width, never the image height. The
+// caller may reuse a band's pixel storage as soon as append returns.
+//
+// Opaque mode must be established before start: the stream cannot fall back
+// to RGBA after an RGB header has been written. Unknown backgrounds use RGBA.
+type rasterPNGBandEncoder struct {
+	native rasterOpaquePNGEncoder
+	writer rasterPNGContextWriter
+	width  int
+	height int
+	nextY  int
+	active bool
+	err    error
+}
+
+func (e *rasterPNGBandEncoder) start(ctx context.Context, output io.Writer, width, height int, opaque bool) error {
+	if e.active {
+		return fmt.Errorf("d2raster: PNG stream already started")
+	}
+	e.close()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if output == nil {
+		return fmt.Errorf("d2raster: cannot write PNG to a nil writer")
+	}
+	// PNG dimensions are limited to 31 bits. Four working RGBA rows also
+	// have to fit in an int before their storage size can be computed.
+	if width <= 0 || height <= 0 || uint64(width) > math.MaxInt32 || uint64(height) > math.MaxInt32 || width > (math.MaxInt/4-1)/4 {
+		return fmt.Errorf("d2raster: invalid PNG dimensions %dx%d", width, height)
+	}
+	e.writer = rasterPNGContextWriter{ctx: ctx, output: output}
+	e.width, e.height, e.active = width, height, true
+	if e.err = e.native.start(&e.writer, width, height, opaque); e.err != nil {
+		return e.err
+	}
+	e.err = d2png.WriteExif(&e.writer)
+	return e.err
+}
+
+func (e *rasterPNGBandEncoder) append(band *image.NRGBA) error {
+	if e.err != nil {
+		return e.err
+	}
+	if !e.active {
+		return fmt.Errorf("d2raster: PNG stream is not started")
+	}
+	if e.err = e.writer.ctx.Err(); e.err != nil {
+		return e.err
+	}
+	if band == nil {
+		e.err = fmt.Errorf("d2raster: cannot encode a nil PNG band")
+		return e.err
+	}
+	bounds := band.Bounds()
+	if bounds.Min.X != 0 || bounds.Max.X != e.width || bounds.Min.Y != e.nextY || bounds.Max.Y <= bounds.Min.Y || bounds.Max.Y > e.height {
+		e.err = fmt.Errorf("d2raster: PNG band %v must have width %d and begin at row %d within height %d", bounds, e.width, e.nextY, e.height)
+		return e.err
+	}
+	rowBytes := 4 * e.width
+	// Divide before multiplying so hostile stride/dimension values cannot
+	// overflow and turn malformed image storage into an indexing panic.
+	if band.Stride < rowBytes || len(band.Pix) < rowBytes || bounds.Dy()-1 > (len(band.Pix)-rowBytes)/band.Stride {
+		e.err = fmt.Errorf("d2raster: PNG band has invalid pixel storage")
+		return e.err
+	}
+	for row := 0; row < bounds.Dy(); row++ {
+		if e.err = e.writer.ctx.Err(); e.err != nil {
+			return e.err
+		}
+		offset := row * band.Stride
+		if e.err = e.native.writeRow(band.Pix[offset : offset+rowBytes]); e.err != nil {
+			return e.err
+		}
+		e.nextY++
+	}
+	e.err = e.writer.ctx.Err()
+	return e.err
+}
+
+func (e *rasterPNGBandEncoder) finish() error {
+	if e.err != nil {
+		return e.err
+	}
+	if !e.active {
+		return fmt.Errorf("d2raster: PNG stream is not started")
+	}
+	if e.nextY != e.height {
+		e.err = fmt.Errorf("d2raster: PNG stream has %d rows, want %d", e.nextY, e.height)
+		return e.err
+	}
+	if e.err = e.writer.ctx.Err(); e.err != nil {
+		return e.err
+	}
+	e.err = e.native.finish()
+	if e.err == nil {
+		e.err = e.writer.ctx.Err()
+	}
+	e.active = false
+	return e.err
+}
+
+// close drops the output writer, context, and band state while retaining row
+// and compression workspaces for the next board in this export operation.
+func (e *rasterPNGBandEncoder) close() {
+	e.native.releaseOutput()
+	*e = rasterPNGBandEncoder{native: e.native}
 }
 
 type rasterPNGIDATStream struct {
@@ -262,13 +410,21 @@ func (w *rasterPNGIDATStream) emit(kind uint32, data []byte) {
 	checksum := crc32.Update(0, crc32.IEEETable, w.frame[4:8])
 	checksum = crc32.Update(checksum, crc32.IEEETable, data)
 	binary.BigEndian.PutUint32(w.frame[8:12], checksum)
-	if _, w.err = w.output.Write(w.frame[:8]); w.err != nil {
+	if w.err = rasterPNGWriteAll(w.output, w.frame[:8]); w.err != nil {
 		return
 	}
-	if _, w.err = w.output.Write(data); w.err != nil {
+	if w.err = rasterPNGWriteAll(w.output, data); w.err != nil {
 		return
 	}
-	_, w.err = w.output.Write(w.frame[8:])
+	w.err = rasterPNGWriteAll(w.output, w.frame[8:])
+}
+
+func rasterPNGWriteAll(output io.Writer, data []byte) error {
+	n, err := output.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	return err
 }
 
 func rasterPNGAbs8(value byte) int {
@@ -283,24 +439,24 @@ const rasterPNGIntSize = 32 << (^uint(0) >> 63)
 // alternating candidate rows. Each candidate is scored as it is materialized;
 // the winning row stays untouched while the other buffer is reused. Together
 // with raw and prior rows, this retains four rows instead of six.
-func rasterPNGFilteredRow(rawRow, priorRow []byte, candidates *[2][]byte) []byte {
+func rasterPNGFilteredRow(rawRow, priorRow []byte, candidates *[2][]byte, channels int) []byte {
 	raw := rawRow[1:]
 	prior := priorRow[1:]
 	winner, scratch := candidates[0], candidates[1]
 	best := rasterPNGUpFilter(winner, raw, prior)
 	selected := byte(2) // Up wins ties, followed by Paeth, None, Sub, Average.
-	if cost := rasterPNGPaethFilter(scratch, raw, prior, best); cost < best {
+	if cost := rasterPNGPaethFilter(scratch, raw, prior, best, channels); cost < best {
 		best, selected = cost, 4
 		winner, scratch = scratch, winner
 	}
 	if cost := rasterPNGNoneCost(raw, best); cost < best {
 		best, selected = cost, 0
 	}
-	if cost := rasterPNGSubFilter(scratch, raw, best); cost < best {
+	if cost := rasterPNGSubFilter(scratch, raw, best, channels); cost < best {
 		best, selected = cost, 1
 		winner, scratch = scratch, winner
 	}
-	if cost := rasterPNGAverageFilter(scratch, raw, prior, best); cost < best {
+	if cost := rasterPNGAverageFilter(scratch, raw, prior, best, channels); cost < best {
 		selected = 3
 		winner = scratch
 	}
@@ -333,19 +489,19 @@ func rasterPNGUpFilter(destination, raw, prior []byte) int {
 	return cost
 }
 
-func rasterPNGSubFilter(destination, raw []byte, stopAt int) int {
+func rasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
 	destination[0] = 1
 	destination = destination[1:]
 	cost := 0
-	for index := 0; index < 3; index++ {
+	for index := 0; index < channels; index++ {
 		destination[index] = raw[index]
 		cost += rasterPNGAbs8(destination[index])
 		if cost >= stopAt {
 			return cost
 		}
 	}
-	for index := 3; index < len(raw); index++ {
-		destination[index] = raw[index] - raw[index-3]
+	for index := channels; index < len(raw); index++ {
+		destination[index] = raw[index] - raw[index-channels]
 		cost += rasterPNGAbs8(destination[index])
 		if cost >= stopAt {
 			break
@@ -354,20 +510,20 @@ func rasterPNGSubFilter(destination, raw []byte, stopAt int) int {
 	return cost
 }
 
-func rasterPNGAverageFilter(destination, raw, prior []byte, stopAt int) int {
+func rasterPNGAverageFilter(destination, raw, prior []byte, stopAt, channels int) int {
 	_ = prior[len(raw)-1]
 	destination[0] = 3
 	destination = destination[1:]
 	cost := 0
-	for index := 0; index < 3; index++ {
+	for index := 0; index < channels; index++ {
 		destination[index] = raw[index] - prior[index]/2
 		cost += rasterPNGAbs8(destination[index])
 		if cost >= stopAt {
 			return cost
 		}
 	}
-	for index := 3; index < len(raw); index++ {
-		destination[index] = raw[index] - byte((int(raw[index-3])+int(prior[index]))/2)
+	for index := channels; index < len(raw); index++ {
+		destination[index] = raw[index] - byte((int(raw[index-channels])+int(prior[index]))/2)
 		cost += rasterPNGAbs8(destination[index])
 		if cost >= stopAt {
 			break
@@ -376,21 +532,21 @@ func rasterPNGAverageFilter(destination, raw, prior []byte, stopAt int) int {
 	return cost
 }
 
-func rasterPNGPaethFilter(destination, raw, prior []byte, stopAt int) int {
+func rasterPNGPaethFilter(destination, raw, prior []byte, stopAt, channels int) int {
 	_ = prior[len(raw)-1]
 	destination[0] = 4
 	destination = destination[1:]
 	cost := 0
-	for index := 0; index < 3; index++ {
+	for index := 0; index < channels; index++ {
 		destination[index] = raw[index] - prior[index]
 		cost += rasterPNGAbs8(destination[index])
 		if cost >= stopAt {
 			return cost
 		}
 	}
-	for index := 3; index < len(raw); index++ {
-		left := raw[index-3]
-		upperLeft := prior[index-3]
+	for index := channels; index < len(raw); index++ {
+		left := raw[index-channels]
+		upperLeft := prior[index-channels]
 		upper := prior[index]
 		leftDistance := rasterPNGByteDistance(upper, upperLeft)
 		upperDistance := rasterPNGByteDistance(left, upperLeft)

--- a/d2cli/raster_png_encoder_test.go
+++ b/d2cli/raster_png_encoder_test.go
@@ -442,8 +442,11 @@ func TestFolderPNGExportMatchesStatelessOutput(t *testing.T) {
 	pooledDirectory := t.TempDir()
 	var encoder rasterPNGEncoder
 	renderFolder(pooledDirectory, &encoder, false)
-	if encoder.native.storage == nil || encoder.native.zw == nil || encoder.native.bw == nil {
+	if encoder.bands.native.storage == nil || encoder.bands.native.zw == nil || encoder.bands.native.bw == nil {
 		t.Fatal("folder render retained no reusable workspace between boards")
+	}
+	if encoder.bands.native.stream.output != nil || encoder.bands.writer.output != nil || encoder.bands.writer.ctx != nil {
+		t.Fatal("folder render retained its last output or context")
 	}
 	statelessDirectory := t.TempDir()
 	renderFolder(statelessDirectory, nil, false)
@@ -471,7 +474,7 @@ func TestFolderPNGExportMatchesStatelessOutput(t *testing.T) {
 		}
 	}
 	encoder.close()
-	if encoder.native.storage != nil || encoder.native.zw != nil || encoder.native.bw != nil || encoder.native.stream.output != nil {
+	if encoder.bands.native.storage != nil || encoder.bands.native.zw != nil || encoder.bands.native.bw != nil || encoder.bands.native.stream.output != nil {
 		t.Fatal("completed folder export retained operation state")
 	}
 }

--- a/d2cli/raster_png_output.go
+++ b/d2cli/raster_png_output.go
@@ -1,0 +1,150 @@
+package d2cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+
+	"github.com/d2lang/util-go/xmain"
+
+	"github.com/d2lang/d2/d2renderers/d2raster"
+	"github.com/d2lang/d2/d2renderers/d2scene"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+const pngBandHeight = 256
+
+func pngFrameOptions() d2raster.FrameOptions {
+	options := rasterFrameOptions(2, 0)
+	// PNG retains one strip instead of a complete frame. Keep the dimension
+	// and aggregate work limits, without imposing the full-canvas storage cap.
+	options.MaxPixels = int64(rasterMaxDimension) * int64(rasterMaxDimension)
+	return options
+}
+
+func renderPNGToWriter(ctx context.Context, inputPath string, cacheImages bool, diagram *d2target.Diagram, opts d2svg.RenderOpts, encoder *rasterPNGEncoder, output io.Writer) error {
+	document, err := buildScene(ctx, inputPath, cacheImages, diagram, opts)
+	if err != nil {
+		return err
+	}
+	var localEncoder rasterPNGEncoder
+	if encoder == nil {
+		encoder = &localEncoder
+		defer localEncoder.close()
+	}
+	return encodePNGBands(ctx, output, document, &encoder.bands)
+}
+
+func encodePNGBands(ctx context.Context, output io.Writer, document *d2scene.Document, encoder *rasterPNGBandEncoder) error {
+	options := pngFrameOptions()
+	started := false
+	defer encoder.close()
+	err := d2raster.RenderBands(ctx, document, options, pngBandHeight, func(band *image.NRGBA) error {
+		if !started {
+			// RenderBands validates the complete dimensions and resource budget
+			// before this callback. Its opaque background guarantees RGB output.
+			height := int(math.Ceil(document.LogicalHeight * options.Scale))
+			if err := encoder.start(ctx, output, band.Bounds().Dx(), height, true); err != nil {
+				return err
+			}
+			started = true
+		}
+		return encoder.append(band)
+	})
+	if err != nil {
+		return err
+	}
+	if !started {
+		return fmt.Errorf("d2raster: PNG renderer produced no rows")
+	}
+	return encoder.finish()
+}
+
+// writePNGWithStatus stages file output for atomic replacement, with Write's
+// copy fallback when rename is unavailable. The renderer and encoder release
+// each strip immediately. A failed render never replaces an existing
+// destination. Stdout is streamed directly and can contain a prefix
+// when its writer fails or the command is canceled after encoding begins.
+func writePNGWithStatus(ctx context.Context, ms *xmain.State, path string, render func(io.Writer) error) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if path == "-" {
+		output := &pngStatusWriter{output: ms.Stdout}
+		if err := render(output); err != nil {
+			return output.written, err
+		}
+		return output.written, runFinalizer(ctx, ms.Stdout.Close)
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return false, err
+	}
+	output, err := os.CreateTemp(directory, "tmp-"+filepath.Base(path)+"-")
+	if err != nil {
+		// A writable destination can live in a directory that does not allow
+		// creating siblings (for example a special output device). Spool to
+		// the system temporary directory before using the non-atomic fallback.
+		output, err = os.CreateTemp("", "d2-png-")
+		if err != nil {
+			return false, err
+		}
+	}
+	defer os.Remove(output.Name())
+	defer output.Close()
+	if err := render(output); err != nil {
+		return false, err
+	}
+	if err := output.Close(); err != nil {
+		return false, err
+	}
+	return runStatusFinalizer(ctx, func() (bool, error) {
+		if err := os.Rename(output.Name(), path); err != nil {
+			// Match Write's fallback for destinations that cannot be replaced
+			// atomically, without buffering the compressed PNG in memory.
+			return copyPNGWithStatus(ctx, output.Name(), path)
+		}
+		return true, nil
+	})
+}
+
+func copyPNGWithStatus(ctx context.Context, sourcePath, destinationPath string) (bool, error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return false, err
+	}
+	defer source.Close()
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	destination, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return false, err
+	}
+	writer := &rasterPNGContextWriter{ctx: ctx, output: destination}
+	_, copyErr := io.Copy(writer, source)
+	return true, errors.Join(copyErr, destination.Close())
+}
+
+type pngStatusWriter struct {
+	output  io.Writer
+	written bool
+}
+
+func (w *pngStatusWriter) Write(p []byte) (int, error) {
+	n, err := w.output.Write(p)
+	w.written = w.written || n > 0
+	if n != len(p) {
+		err = errors.Join(err, io.ErrShortWrite)
+	}
+	return n, err
+}

--- a/d2cli/raster_png_output_test.go
+++ b/d2cli/raster_png_output_test.go
@@ -1,0 +1,244 @@
+package d2cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/util-go/go2"
+	"github.com/d2lang/util-go/xmain"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+	d2png "github.com/d2lang/d2/lib/png"
+)
+
+func TestPNGStreamMatchesCompleteFrame(t *testing.T) {
+	var encoder rasterPNGEncoder
+	defer encoder.close()
+	for _, shadow := range []bool{false, true} {
+		for _, scale := range []float64{0.5, 1, 1.25} {
+			diagram := simpleRasterDiagramWithSize(230, 590)
+			diagram.Shapes[0].Shadow = shadow
+			diagram.Shapes[0].BorderRadius = 13
+			diagram.Shapes[0].Stroke = "#234567"
+			diagram.Shapes[0].StrokeWidth = 3
+			diagram.Shapes[0].Opacity = 0.73
+			opts := d2svg.RenderOpts{Pad: go2.Pointer(int64(11)), Scale: &scale}
+			want, err := renderPNGWithEncoder(context.Background(), "-", false, diagram, opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err = d2png.AddExif(want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got bytes.Buffer
+			if err := renderPNGToWriter(context.Background(), "-", false, diagram, opts, &encoder, &got); err != nil {
+				t.Fatalf("shadow=%v scale=%v: %v", shadow, scale, err)
+			}
+			// Identical encoded bytes also verify PNG filtering across strip
+			// boundaries and the position and contents of the EXIF chunk.
+			if !bytes.Equal(got.Bytes(), want) {
+				t.Logf("shadow=%v scale=%v", shadow, scale)
+				assertPNGOutputPixels(t, got.Bytes(), want)
+				t.Fatalf("shadow=%v scale=%v: PNG bytes differ despite equal pixels", shadow, scale)
+			}
+		}
+	}
+}
+
+func TestPNGStreamDiagramFixtures(t *testing.T) {
+	fixtures := []string{
+		"txtar/gradient", "txtar/sketch-cross-arrowhead",
+		"txtar/sequence-diagram-note-md", "regression/sql_table_overflow",
+		"regression/md_font_weight", "themes/terminal",
+		"real_world/queue_workers", "real_world/mocha_soc",
+		"real_world/spyre_encoder", "real_world/ross_overview",
+	}
+	for _, fixture := range fixtures {
+		for _, layout := range []string{"dagre", "elk"} {
+			t.Run(fixture+"/"+layout, func(t *testing.T) {
+				path := filepath.Join("..", "e2etests", "testdata", fixture, layout, "board.exp.json")
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var diagram d2target.Diagram
+				if err := json.Unmarshal(data, &diagram); err != nil {
+					t.Fatal(err)
+				}
+				opts := d2svg.RenderOpts{}
+				if config := diagram.Config; config != nil {
+					opts.Pad, opts.ThemeID, opts.ThemeOverrides = config.Pad, config.ThemeID, config.ThemeOverrides
+					opts.Center, opts.Sketch = config.Center, config.Sketch
+				}
+				want, err := renderPNGWithEncoder(context.Background(), "-", false, &diagram, opts, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want, err = d2png.AddExif(want)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var got bytes.Buffer
+				if err := renderPNGToWriter(context.Background(), "-", false, &diagram, opts, nil, &got); err != nil {
+					t.Fatal(err)
+				}
+				assertPNGOutputPixels(t, got.Bytes(), want)
+			})
+		}
+	}
+}
+
+func assertPNGOutputPixels(t *testing.T, got, want []byte) {
+	t.Helper()
+	// The common path is byte-identical and needs no decoded frame allocation.
+	// If compression changes, still require every decoded pixel to match.
+	if bytes.Equal(got, want) {
+		return
+	}
+	gotImage, err := png.Decode(bytes.NewReader(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantImage, err := png.Decode(bytes.NewReader(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotImage.Bounds() != wantImage.Bounds() {
+		t.Fatalf("image bounds %v, want %v", gotImage.Bounds(), wantImage.Bounds())
+	}
+	for y := 0; y < wantImage.Bounds().Dy(); y++ {
+		for x := 0; x < wantImage.Bounds().Dx(); x++ {
+			gr, gg, gb, ga := gotImage.At(x, y).RGBA()
+			wr, wg, wb, wa := wantImage.At(x, y).RGBA()
+			if gr != wr || gg != wg || gb != wb || ga != wa {
+				t.Fatalf("different pixel (%d,%d): %v, want %v", x, y, gotImage.At(x, y), wantImage.At(x, y))
+			}
+		}
+	}
+}
+
+func TestPNGStreamAdmitsAreaBeyondCompleteFrameLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("encodes a 67 megapixel image")
+	}
+	// A sparse scene just over the old area limit must no longer require a
+	// complete 256 MiB canvas. Decode only its header to keep this test bounded.
+	document := d2scene.NewDocument(d2scene.Box{Width: 4097, Height: 4096}, d2scene.NewNode(nil))
+	var output pngHeaderCapture
+	var encoder rasterPNGBandEncoder
+	if err := encodePNGBands(context.Background(), &output, document, &encoder); err != nil {
+		t.Fatal(err)
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(output.header))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Width != 8194 || config.Height != 8192 {
+		t.Fatalf("dimensions %dx%d, want 8194x8192", config.Width, config.Height)
+	}
+	if int64(config.Width)*int64(config.Height) <= rasterMaxPixels {
+		t.Fatal("test did not cross the old area limit")
+	}
+}
+
+type pngHeaderCapture struct{ header []byte }
+
+func (w *pngHeaderCapture) Write(p []byte) (int, error) {
+	if len(w.header) < 128 {
+		w.header = append(w.header, p[:min(len(p), 128-len(w.header))]...)
+	}
+	return len(p), nil
+}
+
+func TestPNGStreamRejectsOversizeBeforeWriting(t *testing.T) {
+	document := d2scene.NewDocument(d2scene.Box{Width: rasterMaxDimension, Height: 1}, d2scene.NewNode(nil))
+	var output bytes.Buffer
+	var encoder rasterPNGBandEncoder
+	err := encodePNGBands(context.Background(), &output, document, &encoder)
+	if err == nil || !strings.Contains(err.Error(), "frame width") {
+		t.Fatalf("error %v, want dimension limit", err)
+	}
+	if output.Len() != 0 {
+		t.Fatal("invalid image wrote PNG header")
+	}
+}
+
+func TestPNGStreamFilePublication(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "output.png")
+		if err := os.WriteFile(path, []byte("existing"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		failure := errors.New("render failed")
+		written, err := writePNGWithStatus(context.Background(), &xmain.State{}, path, func(w io.Writer) error {
+			if _, err := io.WriteString(w, "replacement"); err != nil {
+				return err
+			}
+			if fail {
+				return failure
+			}
+			return nil
+		})
+		if fail && (!errors.Is(err, failure) || written) {
+			t.Fatalf("failed render: written=%v err=%v", written, err)
+		}
+		if !fail && (err != nil || !written) {
+			t.Fatalf("successful render: written=%v err=%v", written, err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "replacement"
+		if fail {
+			want = "existing"
+		}
+		if string(got) != want {
+			t.Fatalf("destination %q, want %q", got, want)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil || len(entries) != 1 {
+			t.Fatalf("temporary output leaked: %v, %v", entries, err)
+		}
+	}
+}
+
+func TestPNGStreamCanceledBeforePublication(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "output.png")
+	ctx, cancel := context.WithCancel(context.Background())
+	written, err := writePNGWithStatus(ctx, &xmain.State{}, path, func(w io.Writer) error {
+		_, err := io.WriteString(w, "encoded")
+		cancel()
+		return err
+	})
+	if written || !errors.Is(err, context.Canceled) {
+		t.Fatalf("written=%v error=%v", written, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("canceled render published destination: %v", err)
+	}
+}
+
+func BenchmarkPNGStreamLarge(b *testing.B) {
+	document := d2scene.NewDocument(d2scene.Box{Width: 2048, Height: 2048}, d2scene.NewNode(nil))
+	var encoder rasterPNGBandEncoder
+	b.ReportAllocs()
+	b.SetBytes(4096 * 4096 * 4)
+	for b.Loop() {
+		if err := encodePNGBands(context.Background(), io.Discard, document, &encoder); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/d2cli/raster_png_stream_test.go
+++ b/d2cli/raster_png_stream_test.go
@@ -1,0 +1,361 @@
+package d2cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	stdpng "image/png"
+	"io"
+	"math"
+	"math/rand"
+	"testing"
+
+	d2png "github.com/d2lang/d2/lib/png"
+)
+
+func TestRasterPNGBandsMatchImageEncoder(t *testing.T) {
+	for _, opaque := range []bool{true, false} {
+		for _, width := range []int{1, 2, 7, 257} {
+			t.Run(fmt.Sprintf("opaque=%t/width=%d", opaque, width), func(t *testing.T) {
+				const height = 37
+				// Cropping a wider image exercises stride padding and nonzero
+				// storage offsets independently of the bands' absolute Y values.
+				storage := image.NewNRGBA(image.Rect(-3, -2, width+5, height+4))
+				full := storage.SubImage(image.Rect(0, 0, width, height)).(*image.NRGBA)
+				random := rand.New(rand.NewSource(21))
+				for y := 0; y < height; y++ {
+					for x := 0; x < width; x++ {
+						value := random.Uint32()
+						alpha := byte(value >> 24)
+						if opaque {
+							alpha = 255
+						} else if y == height-1 {
+							// Keep RGB values even when alpha is zero.
+							alpha = 0
+						}
+						full.SetNRGBA(x, y, color.NRGBA{byte(value), byte(value >> 8), byte(value >> 16), alpha})
+					}
+				}
+				var reference bytes.Buffer
+				encoder := stdpng.Encoder{CompressionLevel: stdpng.BestSpeed}
+				if err := encoder.Encode(&reference, full); err != nil {
+					t.Fatal(err)
+				}
+				want, err := d2png.AddExif(reference.Bytes())
+				if err != nil {
+					t.Fatal(err)
+				}
+				var out bytes.Buffer
+				var stream rasterPNGBandEncoder
+				defer stream.close()
+				if err := stream.start(context.Background(), &out, width, height, opaque); err != nil {
+					t.Fatal(err)
+				}
+				for y := 0; y < height; {
+					end := min(height, y+1+random.Intn(7))
+					band := full.SubImage(image.Rect(0, y, width, end)).(*image.NRGBA)
+					if err := stream.append(band); err != nil {
+						t.Fatal(err)
+					}
+					y = end
+				}
+				if err := stream.finish(); err != nil {
+					t.Fatal(err)
+				}
+				decoded, err := stdpng.Decode(bytes.NewReader(out.Bytes()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if decoded.Bounds() != full.Bounds() {
+					t.Fatalf("decoded bounds %v, want %v", decoded.Bounds(), full.Bounds())
+				}
+				for y := 0; y < height; y++ {
+					for x := 0; x < width; x++ {
+						if got := color.NRGBAModel.Convert(decoded.At(x, y)).(color.NRGBA); got != full.NRGBAAt(x, y) {
+							t.Fatalf("pixel (%d,%d) = %v, want %v", x, y, got, full.NRGBAAt(x, y))
+						}
+					}
+				}
+				if !bytes.Equal(out.Bytes(), want) {
+					t.Fatal("streamed bands differ from the standard image encoder with D2 EXIF")
+				}
+			})
+		}
+	}
+}
+
+func TestRasterPNGBandsValidateSequenceAndStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		band *image.NRGBA
+	}{
+		{"nil", nil},
+		{"gap", image.NewNRGBA(image.Rect(0, 1, 4, 2))},
+		{"offset X", image.NewNRGBA(image.Rect(1, 0, 5, 1))},
+		{"wrong width", image.NewNRGBA(image.Rect(0, 0, 3, 1))},
+		{"past height", image.NewNRGBA(image.Rect(0, 0, 4, 4))},
+		{"empty", image.NewNRGBA(image.Rect(0, 0, 4, 0))},
+		{"short pixels", &image.NRGBA{Rect: image.Rect(0, 0, 4, 1), Stride: 16, Pix: make([]byte, 15)}},
+		{"short last row", &image.NRGBA{Rect: image.Rect(0, 0, 4, 2), Stride: 16, Pix: make([]byte, 31)}},
+		{"small stride", &image.NRGBA{Rect: image.Rect(0, 0, 4, 1), Stride: 15, Pix: make([]byte, 16)}},
+		{"negative stride", &image.NRGBA{Rect: image.Rect(0, 0, 4, 1), Stride: -1, Pix: make([]byte, 16)}},
+		{"overflow stride", &image.NRGBA{Rect: image.Rect(0, 0, 4, 3), Stride: math.MaxInt, Pix: make([]byte, 16)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stream rasterPNGBandEncoder
+			defer stream.close()
+			if err := stream.start(context.Background(), io.Discard, 4, 3, false); err != nil {
+				t.Fatal(err)
+			}
+			err := stream.append(test.band)
+			if err == nil {
+				t.Fatal("invalid band accepted")
+			}
+			if got := stream.finish(); got != err {
+				t.Fatalf("finish lost band error: %v, want %v", got, err)
+			}
+		})
+	}
+	t.Run("duplicate rows", func(t *testing.T) {
+		var stream rasterPNGBandEncoder
+		defer stream.close()
+		if err := stream.start(nil, io.Discard, 4, 3, false); err != nil {
+			t.Fatal(err)
+		}
+		band := image.NewNRGBA(image.Rect(0, 0, 4, 1))
+		if err := stream.append(band); err != nil {
+			t.Fatal(err)
+		}
+		if err := stream.append(band); err == nil {
+			t.Fatal("duplicate rows accepted")
+		}
+	})
+	t.Run("incomplete", func(t *testing.T) {
+		var stream rasterPNGBandEncoder
+		defer stream.close()
+		if err := stream.start(nil, io.Discard, 4, 3, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := stream.finish(); err == nil {
+			t.Fatal("incomplete PNG accepted")
+		}
+	})
+}
+
+func TestRasterPNGBandsValidateStartAndOpaquePromise(t *testing.T) {
+	invalidSizes := [][2]int{{0, 1}, {1, 0}, {-1, 1}, {1, -1}, {math.MaxInt, 1}}
+	if uint64(math.MaxInt) > math.MaxInt32 {
+		invalidSizes = append(invalidSizes, [2]int{1, math.MaxInt})
+	}
+	for _, size := range invalidSizes {
+		var stream rasterPNGBandEncoder
+		var out bytes.Buffer
+		if err := stream.start(nil, &out, size[0], size[1], false); err == nil {
+			t.Fatalf("invalid size %v accepted", size)
+		}
+		if out.Len() != 0 {
+			t.Fatal("invalid size wrote output")
+		}
+	}
+	var stream rasterPNGBandEncoder
+	defer stream.close()
+	if err := stream.start(nil, nil, 1, 1, false); err == nil {
+		t.Fatal("nil writer accepted")
+	}
+	if err := stream.append(image.NewNRGBA(image.Rect(0, 0, 1, 1))); err == nil {
+		t.Fatal("append without start accepted")
+	}
+	if err := stream.finish(); err == nil {
+		t.Fatal("finish without start accepted")
+	}
+	if err := stream.start(nil, io.Discard, 1, 1, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.start(nil, io.Discard, 1, 1, true); err == nil {
+		t.Fatal("start on active stream accepted")
+	}
+	if err := stream.append(image.NewNRGBA(image.Rect(0, 0, 1, 1))); !errors.Is(err, errRasterPNGTranslucent) {
+		t.Fatalf("opaque promise violation = %v", err)
+	}
+}
+
+func TestRasterPNGBandsWriterErrorsAndReuse(t *testing.T) {
+	img := opaqueRasterPNGTestImage(image.Rect(0, 0, 31, 7))
+	var stream rasterPNGBandEncoder
+	defer stream.close()
+	encode := func(output io.Writer) error {
+		defer stream.close()
+		if err := stream.start(nil, output, 31, 7, true); err != nil {
+			return err
+		}
+		if err := stream.append(img); err != nil {
+			return err
+		}
+		return stream.finish()
+	}
+	var expected bytes.Buffer
+	if err := encode(&expected); err != nil {
+		t.Fatal(err)
+	}
+	storage := &stream.native.storage[0]
+	compressor := stream.native.zw
+	writerErr := errors.New("test output failed")
+	for _, failure := range []error{writerErr, nil} {
+		for _, limit := range []int{0, 8, 12, 30, 33, 60, expected.Len() - 12, expected.Len() - 2} {
+			writer := &rasterPNGLimitedWriter{remaining: limit, err: failure}
+			want := failure
+			if want == nil {
+				want = io.ErrShortWrite
+			}
+			if err := encode(writer); !errors.Is(err, want) {
+				t.Fatalf("limit %d: %v, want %v", limit, err, want)
+			}
+			if stream.writer.ctx != nil || stream.writer.output != nil || stream.native.stream.output != nil {
+				t.Fatal("closed stream retained context or output")
+			}
+			var out bytes.Buffer
+			if err := encode(&out); err != nil {
+				t.Fatalf("reuse after limit %d: %v", limit, err)
+			}
+			if !bytes.Equal(out.Bytes(), expected.Bytes()) {
+				t.Fatalf("reuse after limit %d corrupted PNG", limit)
+			}
+			if storage != &stream.native.storage[0] || compressor != stream.native.zw {
+				t.Fatal("stream failed to reuse its working memory")
+			}
+		}
+	}
+}
+
+func TestRasterPNGBandsCancellation(t *testing.T) {
+	for _, cancelBefore := range []string{"start", "append", "finish"} {
+		t.Run(cancelBefore, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var stream rasterPNGBandEncoder
+			defer stream.close()
+			steps := []struct {
+				name string
+				run  func() error
+			}{
+				{"start", func() error { return stream.start(ctx, io.Discard, 3, 2, false) }},
+				{"append", func() error { return stream.append(image.NewNRGBA(image.Rect(0, 0, 3, 2))) }},
+				{"finish", stream.finish},
+			}
+			for _, step := range steps {
+				if step.name == cancelBefore {
+					cancel()
+				}
+				err := step.run()
+				if step.name == cancelBefore {
+					if !errors.Is(err, context.Canceled) {
+						t.Fatalf("%s = %v, want cancellation", step.name, err)
+					}
+					break
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+	t.Run("during band", func(t *testing.T) {
+		ctx := &rasterPNGCancelAfterChecksContext{cancelAt: math.MaxInt}
+		var stream rasterPNGBandEncoder
+		defer stream.close()
+		if err := stream.start(ctx, io.Discard, 3, 100, false); err != nil {
+			t.Fatal(err)
+		}
+		ctx.cancelAt = ctx.checks + 5
+		if err := stream.append(image.NewNRGBA(image.Rect(0, 0, 3, 100))); !errors.Is(err, context.Canceled) {
+			t.Fatalf("append = %v, want cancellation", err)
+		}
+		if stream.nextY == 0 || stream.nextY >= 100 {
+			t.Fatalf("cancellation stopped at row %d, want partial progress", stream.nextY)
+		}
+	})
+}
+
+func TestRasterPNGBandsAllowPixelBufferReuse(t *testing.T) {
+	const width, height, bandHeight = 7, 100, 3
+	band := image.NewNRGBA(image.Rect(0, 0, width, bandHeight))
+	var out bytes.Buffer
+	var stream rasterPNGBandEncoder
+	defer stream.close()
+	if err := stream.start(nil, &out, width, height, false); err != nil {
+		t.Fatal(err)
+	}
+	for y := 0; y < height; y += bandHeight {
+		band.Rect = image.Rect(0, y, width, min(height, y+bandHeight))
+		for row := band.Rect.Min.Y; row < band.Rect.Max.Y; row++ {
+			for x := 0; x < width; x++ {
+				band.SetNRGBA(x, row, color.NRGBA{uint8(x), uint8(row), 255, 128})
+			}
+		}
+		if err := stream.append(band); err != nil {
+			t.Fatal(err)
+		}
+		clear(band.Pix)
+	}
+	if err := stream.finish(); err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := stdpng.Decode(bytes.NewReader(out.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			want := color.NRGBA{uint8(x), uint8(y), 255, 128}
+			if got := color.NRGBAModel.Convert(decoded.At(x, y)).(color.NRGBA); got != want {
+				t.Fatalf("pixel (%d,%d) = %v, want %v", x, y, got, want)
+			}
+		}
+	}
+}
+
+func BenchmarkRasterPNGBands(b *testing.B) {
+	const width, bandHeight = 1024, 256
+	for _, height := range []int{256, 4096, 8192} {
+		b.Run(fmt.Sprintf("%dx%d", width, height), func(b *testing.B) {
+			band := opaqueRasterPNGTestImage(image.Rect(0, 0, width, bandHeight))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				var stream rasterPNGBandEncoder
+				if err := stream.start(nil, io.Discard, width, height, true); err != nil {
+					b.Fatal(err)
+				}
+				for y := 0; y < height; y += bandHeight {
+					band.Rect = image.Rect(0, y, width, min(height, y+bandHeight))
+					if err := stream.append(band); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := stream.finish(); err != nil {
+					b.Fatal(err)
+				}
+				stream.close()
+			}
+		})
+	}
+}
+
+type rasterPNGLimitedWriter struct {
+	remaining int
+	err       error
+}
+
+func (w *rasterPNGLimitedWriter) Write(data []byte) (int, error) {
+	if len(data) > w.remaining {
+		n := w.remaining
+		w.remaining = 0
+		return n, w.err
+	}
+	w.remaining -= len(data)
+	return len(data), nil
+}

--- a/d2renderers/d2raster/bands.go
+++ b/d2renderers/d2raster/bands.go
@@ -1,0 +1,228 @@
+package d2raster
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/draw"
+
+	"github.com/d2lang/d2/d2renderers/d2raster/internal/scanline"
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+// RenderBands renders a frame from top to bottom using a reusable canvas of at
+// most bandHeight rows. Each NRGBA band has absolute frame coordinates, full
+// frame width, and consecutive rows. Its pixels are borrowed only until consume
+// returns; a consumer that retains a band must copy it.
+//
+// Geometry and assets are prepared once. All resource limits, including the
+// aggregate scanline and even-odd work of every band and filter overlap, are
+// checked before the first callback. MaxPixels still bounds total output pixels;
+// only the band canvas, rather than the full frame, must fit platform storage.
+// MaxOffscreenBytes separately bounds retained pattern tiles and rendering
+// scratch. The final band may have fewer rows. On any error, consume receives no
+// further bands. A callback must not modify document or its assets.
+func RenderBands(ctx context.Context, document *d2scene.Document, options FrameOptions, bandHeight int, consume func(*image.NRGBA) error) error {
+	return renderBands(ctx, document, options, nil, bandHeight, consume)
+}
+
+// RenderBands reuses the session's bounded font and raster-asset cache while
+// rendering consecutive borrowed bands. Its contract is otherwise RenderBands'.
+func (s *RenderSession) RenderBands(ctx context.Context, document *d2scene.Document, options FrameOptions, bandHeight int, consume func(*image.NRGBA) error) error {
+	if s == nil {
+		return fmt.Errorf("d2raster: nil render session")
+	}
+	return renderBands(ctx, document, options, s, bandHeight, consume)
+}
+
+func renderBands(ctx context.Context, document *d2scene.Document, options FrameOptions, session *RenderSession, bandHeight int, consume func(*image.NRGBA) error) error {
+	if bandHeight <= 0 {
+		return fmt.Errorf("d2raster: band height must be positive")
+	}
+	if consume == nil {
+		return fmt.Errorf("d2raster: nil band consumer")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	prepared, err := prepareWithSessionBands(ctx, document, options, session, bandHeight)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	scratch := &rasterScratch{
+		regionFilters:     true,
+		rasterizerEdges:   prepared.resources.rasterizerEdges,
+		rasterizerBounded: true,
+		offscreen:         offscreenBudget{limit: options.MaxOffscreenBytes},
+		scanlineWork:      scanline.NewWorkBudget(prepared.resources.scanlineWork),
+		scanlineWorkSet:   true,
+	}
+	defer scratch.releasePatternTiles()
+	reservation, err := scratch.offscreen.reserveBytes(prepared.resources.rasterizerBytes, "scanline rasterizer working storage")
+	if err != nil {
+		return err
+	}
+	defer scratch.offscreen.release(reservation)
+	for _, pattern := range prepared.patterns {
+		if err := pattern.render(ctx, scratch); err != nil {
+			return err
+		}
+	}
+
+	bandHeight = min(bandHeight, prepared.height)
+	canvas := image.NewRGBA(image.Rect(0, 0, prepared.width, bandHeight))
+	for top := 0; top < prepared.height; {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		bottom := top + min(bandHeight, prepared.height-top)
+		canvas.Rect = image.Rect(0, top, prepared.width, bottom)
+		canvas.Pix = canvas.Pix[:canvas.Stride*(bottom-top)]
+		if prepared.background != nil && prepared.background.A == 0xff {
+			fillOpaquePixels(canvas.Pix, *prepared.background)
+		} else if prepared.background != nil && prepared.background.A != 0 {
+			draw.Draw(canvas, canvas.Bounds(), image.NewUniform(*prepared.background), image.Point{}, draw.Src)
+		} else {
+			clear(canvas.Pix)
+		}
+		if err := renderNode(ctx, canvas, prepared.root, scratch); err != nil {
+			return err
+		}
+		expectedLive := reservation + scratch.patternBytes
+		if scratch.offscreen.live != expectedLive {
+			return fmt.Errorf("d2raster: internal band offscreen reservation leak: %d bytes live, want %d", scratch.offscreen.live, expectedLive)
+		}
+		if scratch.offscreen.peak > prepared.resources.peakOffscreenBytes {
+			return fmt.Errorf("d2raster: internal band offscreen peak %d exceeds preflight plan %d", scratch.offscreen.peak, prepared.resources.peakOffscreenBytes)
+		}
+		conversionBounds := canvas.Bounds()
+		if prepared.background == nil || prepared.background.A == 0 {
+			conversionBounds = prepared.root.bounds.Intersect(canvas.Bounds())
+		}
+		band, err := rgbaToNRGBAInPlaceBounds(ctx, canvas, conversionBounds, prepared.background != nil && prepared.background.A == 0xff)
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := consume(band); err != nil {
+			return err
+		}
+		top = bottom
+	}
+	return ctx.Err()
+}
+
+func planBandResources(ctx context.Context, root *preparedNode, bounds image.Rectangle, patterns []*preparedPatternTile, options FrameOptions, bandHeight int) (renderResources, error) {
+	// Patterns are rendered and retained once, not re-created for every band.
+	resources, err := planRenderResourcesRegion(ctx, nil, image.Rectangle{}, patterns, options.MaxOffscreenBytes, true)
+	if err != nil {
+		return renderResources{}, err
+	}
+	pixelPeak := resources.peakOffscreenBytes - resources.rasterizerBytes
+	var patternBytes int64
+	for _, pattern := range patterns {
+		var ok bool
+		patternBytes, ok = checkedAdd(patternBytes, pattern.tileBytes)
+		if !ok {
+			return renderResources{}, fmt.Errorf("d2raster: pattern tile storage exceeds the int64 domain")
+		}
+	}
+	for top := bounds.Min.Y; top < bounds.Max.Y; {
+		if err := ctx.Err(); err != nil {
+			return renderResources{}, err
+		}
+		bottom := top + min(bandHeight, bounds.Max.Y-top)
+		band := image.Rect(bounds.Min.X, top, bounds.Max.X, bottom)
+		bandResources, err := planRenderResourcesRegion(ctx, root, band, nil, options.MaxOffscreenBytes, true)
+		if err != nil {
+			return renderResources{}, err
+		}
+		bandPixelPeak, ok := checkedAdd(patternBytes, bandResources.peakOffscreenBytes-bandResources.rasterizerBytes)
+		if !ok {
+			return renderResources{}, fmt.Errorf("d2raster: peak offscreen pixel storage exceeds the int64 domain")
+		}
+		pixelPeak = maxInt64(pixelPeak, bandPixelPeak)
+		mergeRasterizerRequirements(&resources, bandResources)
+		if err := addScanlineWork(&resources, bandResources.scanlineWork); err != nil {
+			return renderResources{}, err
+		}
+		if err := addResourceWork(&resources, bandResources.evenOddClipWork); err != nil {
+			return renderResources{}, err
+		}
+		resources.peakOffscreenBytes, ok = checkedAdd(pixelPeak, resources.rasterizerBytes)
+		if !ok {
+			return renderResources{}, fmt.Errorf("d2raster: peak offscreen pixel storage exceeds the int64 domain")
+		}
+		// Reject as soon as monotonic totals exceed their limits rather than
+		// continuing to plan a potentially very tall rejected image.
+		if resources.peakOffscreenBytes > options.MaxOffscreenBytes {
+			return renderResources{}, fmt.Errorf("d2raster: peak offscreen pixel storage %d bytes exceeds limit %d", resources.peakOffscreenBytes, options.MaxOffscreenBytes)
+		}
+		if resources.evenOddClipWork > options.MaxEvenOddClipWork {
+			return renderResources{}, fmt.Errorf("d2raster: even-odd clip work %d exceeds limit %d", resources.evenOddClipWork, options.MaxEvenOddClipWork)
+		}
+		if resources.scanlineWork > options.MaxScanlineWork {
+			return renderResources{}, fmt.Errorf("d2raster: scanline work %d exceeds limit %d", resources.scanlineWork, options.MaxScanlineWork)
+		}
+		top = bottom
+	}
+	return resources, nil
+}
+
+// setBandReferenceBounds records the canvas origins used by an ordinary full
+// render. Scanline inputs are rounded to float32 relative to those same origins
+// before translating into each band, avoiding changes to antialiased pixels.
+func setBandReferenceBounds(ctx context.Context, node *preparedNode, dst image.Rectangle) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if node == nil || node.opacity == 0 {
+		return nil
+	}
+	visible := node.bounds.Intersect(dst)
+	if visible.Empty() {
+		return nil
+	}
+	paintBounds := dst
+	if len(node.filters) != 0 {
+		paintBounds = node.contentBounds
+	} else if node.isolated || node.opacity < 1 || node.blend != d2scene.BlendNormal || node.clip != nil || node.mask != nil {
+		paintBounds = visible
+	}
+	if node.primitive != nil {
+		node.primitive.referenceBounds = paintBounds
+		if node.primitive.stroke != nil {
+			node.primitive.stroke.referenceBounds = paintBounds
+		}
+		if node.primitive.vector != nil {
+			if err := setBandReferenceBounds(ctx, node.primitive.vector, paintBounds); err != nil {
+				return err
+			}
+		}
+	}
+	for _, child := range node.children {
+		if err := setBandReferenceBounds(ctx, child, paintBounds); err != nil {
+			return err
+		}
+	}
+	if node.clip != nil {
+		node.clip.referenceBounds = visible
+	}
+	if node.mask != nil {
+		return setBandReferenceBounds(ctx, node.mask.root, visible)
+	}
+	return nil
+}
+
+func setRasterizerReference(rasterizer *scanline.Rasterizer, actualOrigin, referenceOrigin image.Point, enabled bool) image.Point {
+	if !enabled {
+		return actualOrigin
+	}
+	rasterizer.SetOriginOffset(float64(referenceOrigin.X)-float64(actualOrigin.X), float64(referenceOrigin.Y)-float64(actualOrigin.Y))
+	return referenceOrigin
+}

--- a/d2renderers/d2raster/bands_test.go
+++ b/d2renderers/d2raster/bands_test.go
@@ -1,0 +1,335 @@
+package d2raster
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+func bandEquivalenceDocument() *d2scene.Document {
+	root := d2scene.NewNode(nil)
+	root.Children = []*d2scene.Node{
+		d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 3.125, Y: 4.375, Width: 85.25, Height: 106.75}, Fill: red}),
+		d2scene.NewNode(d2scene.Ellipse{Center: d2scene.Point{X: 48.25, Y: 63.5}, RadiusX: 33.75, RadiusY: 54.125, Fill: d2scene.SolidPaint{Color: color.NRGBA{B: 255, A: 137}}}),
+		d2scene.NewNode(d2scene.Path{Fill: green, Commands: []d2scene.PathCommand{
+			d2scene.MoveTo(5.25, 109.5), d2scene.CubicTo(85.25, 7.125, 9.25, 100.125, 90.75, 4.375), d2scene.LineTo(73.75, 117.5), d2scene.ClosePath(),
+		}}),
+	}
+	return d2scene.NewDocument(d2scene.Box{Width: 96, Height: 127}, root)
+}
+
+func TestRenderBandsMatchesFullFrame(t *testing.T) {
+	for _, background := range []color.Color{nil, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, color.NRGBA{R: 20, G: 60, B: 100, A: 137}} {
+		for _, scale := range []float64{1, 1.25} {
+			options := testOptions()
+			options.Background, options.Scale = background, scale
+			document := bandEquivalenceDocument()
+			want, err := Render(context.Background(), document, options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, height := range []int{1, 7, 32, 127, 500} {
+				t.Run(fmt.Sprintf("background-%v/scale-%g/height-%d", background, scale, height), func(t *testing.T) {
+					got := image.NewNRGBA(want.Bounds())
+					nextY := 0
+					var firstPixel *uint8
+					err := RenderBands(context.Background(), document, options, height, func(band *image.NRGBA) error {
+						if band.Bounds() != image.Rect(0, nextY, want.Bounds().Dx(), min(nextY+height, want.Bounds().Dy())) {
+							t.Fatalf("band bounds = %v at row %d", band.Bounds(), nextY)
+						}
+						if firstPixel == nil {
+							firstPixel = &band.Pix[0]
+						} else if firstPixel != &band.Pix[0] {
+							t.Fatal("band canvas storage was not reused")
+						}
+						draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+						nextY = band.Bounds().Max.Y
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if nextY != want.Bounds().Dy() {
+						t.Fatalf("received %d rows, want %d", nextY, want.Bounds().Dy())
+					}
+					assertBandPixels(t, got, want)
+				})
+			}
+		}
+	}
+}
+
+func TestRenderBandsEffectsMatchFullFrame(t *testing.T) {
+	for _, mode := range []string{"blur", "shadow", "chain", "clip-mask", "even-odd", "gradient"} {
+		t.Run(mode, func(t *testing.T) {
+			document := bandEquivalenceDocument()
+			node := document.Root
+			switch mode {
+			case "blur":
+				node.Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaX: 2.5, SigmaY: 3.5}}
+			case "shadow":
+				node.Filters = []d2scene.Filter{d2scene.DropShadow{OffsetX: 2.5, OffsetY: -7.25, SigmaX: 2, SigmaY: 4, Color: color.NRGBA{A: 173}}}
+			case "chain":
+				node.Filters = []d2scene.Filter{d2scene.DropShadow{OffsetX: -2.5, OffsetY: 6.75, SigmaX: 1, SigmaY: 3, Color: color.NRGBA{A: 173}}, d2scene.GaussianBlur{SigmaX: 1.5, SigmaY: 2.5}}
+			case "clip-mask":
+				node.Opacity = .7
+				node.Mask = &d2scene.Mask{Type: d2scene.MaskAlpha, Transform: d2scene.Identity(), Root: d2scene.NewNode(d2scene.Ellipse{Center: d2scene.Point{X: 48, Y: 64}, RadiusX: 40, RadiusY: 56, Fill: red})}
+				node.Clip = &d2scene.Clip{Transform: d2scene.Identity(), Path: d2scene.Path{Commands: []d2scene.PathCommand{d2scene.MoveTo(5, 9), d2scene.LineTo(90, 9), d2scene.LineTo(85, 110), d2scene.ClosePath()}}}
+			case "even-odd":
+				node.Children[2].Primitive = d2scene.Path{Fill: blue, FillRule: d2scene.EvenOdd, Commands: []d2scene.PathCommand{d2scene.MoveTo(3, 3), d2scene.LineTo(91, 5), d2scene.LineTo(88, 123), d2scene.LineTo(9, 125), d2scene.ClosePath(), d2scene.MoveTo(21, 21), d2scene.LineTo(77, 18), d2scene.LineTo(73, 111), d2scene.LineTo(23, 112), d2scene.ClosePath()}}
+			case "gradient":
+				node.Children[0].Primitive = d2scene.Rect{Box: d2scene.Box{X: 3, Y: 4, Width: 86, Height: 109}, Fill: d2scene.LinearGradient{Transform: d2scene.Identity(), Start: d2scene.Point{}, End: d2scene.Point{X: 96, Y: 127}, Stops: gradientStops}}
+			}
+			options := testOptions()
+			want, err := Render(context.Background(), document, options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, height := range []int{1, 7, 32} {
+				got := image.NewNRGBA(want.Bounds())
+				if err := RenderBands(context.Background(), document, options, height, func(band *image.NRGBA) error {
+					draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+					return nil
+				}); err != nil {
+					t.Fatalf("height %d: %v", height, err)
+				}
+				assertBandPixels(t, got, want)
+			}
+		})
+	}
+}
+
+func assertBandPixels(t *testing.T, got, want *image.NRGBA) {
+	t.Helper()
+	if !bytes.Equal(got.Pix, want.Pix) {
+		for i := range got.Pix {
+			if got.Pix[i] != want.Pix[i] {
+				x, y := i/4%got.Bounds().Dx(), i/got.Stride
+				t.Fatalf("pixel (%d,%d) = %v, want %v", x, y, got.NRGBAAt(x, y), want.NRGBAAt(x, y))
+			}
+		}
+		t.Fatal("band pixels differ")
+	}
+}
+
+func TestRenderBandsStopsAfterConsumerErrorOrCancellation(t *testing.T) {
+	for _, cancelInstead := range []bool{false, true} {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		failure := errors.New("consumer failure")
+		calls := 0
+		err := RenderBands(ctx, bandEquivalenceDocument(), testOptions(), 7, func(*image.NRGBA) error {
+			calls++
+			if cancelInstead {
+				cancel()
+				return nil
+			}
+			return failure
+		})
+		want := failure
+		if cancelInstead {
+			want = context.Canceled
+		}
+		if !errors.Is(err, want) || calls != 1 {
+			t.Fatalf("cancel=%v: error=%v, calls=%d", cancelInstead, err, calls)
+		}
+	}
+}
+
+func TestRenderBandsPreflightsLimitsBeforeCallbacks(t *testing.T) {
+	document := bandEquivalenceDocument()
+	prepared, err := prepareWithSessionBands(context.Background(), document, testOptions(), nil, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, limit := range []string{"pixels", "scratch", "work", "band"} {
+		options := testOptions()
+		height := 7
+		switch limit {
+		case "pixels":
+			options.MaxPixels = int64(prepared.width*prepared.height - 1)
+		case "scratch":
+			options.MaxOffscreenBytes = prepared.resources.peakOffscreenBytes - 1
+		case "work":
+			options.MaxScanlineWork = prepared.resources.scanlineWork - 1
+		case "band":
+			height = 0
+		}
+		calls := 0
+		err := RenderBands(context.Background(), document, options, height, func(*image.NRGBA) error { calls++; return nil })
+		if err == nil || calls != 0 {
+			t.Fatalf("%s: error=%v callbacks=%d", limit, err, calls)
+		}
+	}
+}
+
+func TestRenderBandsScratchIndependentOfHeight(t *testing.T) {
+	options := testOptions()
+	options.MaxHeight, options.MaxPixels = 100_000, 10_000_000
+	options.MaxOffscreenBytes = 1 << 20
+	root := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{Width: 64, Height: 100_000}, Fill: red})
+	root.Opacity = .7
+	document := d2scene.NewDocument(d2scene.Box{Width: 64, Height: 100_000}, root)
+	if _, err := Render(context.Background(), document, options); err == nil || !strings.Contains(err.Error(), "offscreen") {
+		t.Fatalf("full frame error = %v, want offscreen limit", err)
+	}
+	calls := 0
+	if err := RenderBands(context.Background(), document, options, 32, func(band *image.NRGBA) error {
+		calls++
+		if cap(band.Pix) > 64*32*4 {
+			t.Fatalf("canvas capacity = %d", cap(band.Pix))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != int(math.Ceil(100_000.0/32)) {
+		t.Fatalf("callbacks = %d", calls)
+	}
+}
+
+func TestRenderBandsFractionalGeometry(t *testing.T) {
+	root := d2scene.NewNode(nil)
+	for i := 0; i < 17; i++ {
+		x := float64(i)*2.123 + .137
+		node := d2scene.NewNode(d2scene.Ellipse{Center: d2scene.Point{X: 37.123 + x, Y: 137.531 + x*7.193}, RadiusX: 29.931, RadiusY: 77.417, Fill: d2scene.SolidPaint{Color: color.NRGBA{R: byte(i * 17), B: byte(i * 7), A: 193}}})
+		node.Transform = d2scene.Matrix{A: .913, B: .037, C: -.041, D: 1.013, E: 3.127, F: -2.571}
+		root.Children = append(root.Children, node)
+	}
+	document := d2scene.NewDocument(d2scene.Box{Width: 127, Height: 511}, root)
+	options := testOptions()
+	want, err := Render(context.Background(), document, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, height := range []int{1, 7, 64} {
+		got := image.NewNRGBA(want.Bounds())
+		if err := RenderBands(context.Background(), document, options, height, func(band *image.NRGBA) error {
+			draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		assertBandPixels(t, got, want)
+	}
+}
+
+func TestRenderBandsPatternAndSessionAssets(t *testing.T) {
+	pattern := stripedPattern(d2scene.UserSpaceOnUse, d2scene.Box{X: -.25, Y: 1.5, Width: 7, Height: 5}, d2scene.Identity())
+	document := patternDocument(97, 129, pattern)
+	options := testOptions()
+	want, err := Render(context.Background(), document, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := image.NewNRGBA(want.Bounds())
+	if err := RenderBands(nil, document, options, 7, func(band *image.NRGBA) error {
+		draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertBandPixels(t, got, want)
+
+	source := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	source.SetNRGBA(0, 0, color.NRGBA{R: 255, A: 255})
+	source.SetNRGBA(1, 1, color.NRGBA{B: 255, A: 127})
+	document = rasterImageDocument("image/png", encodeRasterPNG(t, source), 2, 2, d2scene.Box{Width: 97, Height: 129}, d2scene.AspectRatio{})
+	session := newTestRenderSession(t, RenderSessionOptions{MaxCacheEntries: 8, MaxCacheBytes: 1 << 20, MaxConcurrentLoads: 1})
+	want, err = Render(context.Background(), document, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = image.NewNRGBA(want.Bounds())
+	if err := session.RenderBands(nil, document, options, 1, func(band *image.NRGBA) error {
+		draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertBandPixels(t, got, want)
+	stats := session.Stats()
+	if stats.Misses != 1 || stats.Hits != 0 {
+		t.Fatalf("asset preparation repeated for bands: stats=%+v", stats)
+	}
+}
+
+func TestRenderBandsInvalidArguments(t *testing.T) {
+	document := bandEquivalenceDocument()
+	consume := func(*image.NRGBA) error { t.Fatal("unexpected callback"); return nil }
+	if err := RenderBands(nil, document, testOptions(), 7, nil); err == nil {
+		t.Fatal("nil consumer accepted")
+	}
+	var session *RenderSession
+	if err := session.RenderBands(nil, document, testOptions(), 7, consume); err == nil {
+		t.Fatal("nil session accepted")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := RenderBands(ctx, document, testOptions(), 7, consume); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled context error = %v", err)
+	}
+	options := testOptions()
+	options.MaxEvenOddClipWork = 1
+	document.Root = d2scene.NewNode(d2scene.Path{Fill: red, FillRule: d2scene.EvenOdd, Commands: []d2scene.PathCommand{d2scene.MoveTo(0, 0), d2scene.LineTo(80, 0), d2scene.LineTo(80, 100), d2scene.ClosePath()}})
+	if err := RenderBands(nil, document, options, 7, consume); err == nil || !strings.Contains(err.Error(), "even-odd clip work") {
+		t.Fatalf("even-odd limit error = %v", err)
+	}
+}
+
+func BenchmarkRenderBandsCanvasMemory(b *testing.B) {
+	const width, height = 2048, 4096
+	document := d2scene.NewDocument(d2scene.Box{Width: width, Height: height}, d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 20, Y: 20, Width: width - 40, Height: height - 40}, Fill: red}))
+	options := testOptions()
+	options.MaxWidth, options.MaxHeight, options.MaxPixels = width, height, width*height
+	options.Background = color.NRGBA{R: 255, G: 255, B: 255, A: 255}
+	b.Run("full", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			frame, err := Render(context.Background(), document, options)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkFrame = frame
+		}
+	})
+	b.Run("256-rows", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := RenderBands(context.Background(), document, options, 256, func(band *image.NRGBA) error { return nil }); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestRenderBandsTallRoundedStrokeMatchesFullFrame(t *testing.T) {
+	node := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 2.13, Y: 3.17, Width: 33.73, Height: 32_750.41}, RadiusX: 13.27, RadiusY: 21.39, Fill: red, Stroke: &d2scene.Stroke{Paint: blue, Width: 2.73, MiterLimit: 4}})
+	node.Opacity = .73
+	document := d2scene.NewDocument(d2scene.Box{Width: 41, Height: 32_767}, node)
+	options := testOptions()
+	options.MaxHeight, options.MaxPixels = 32_767, 2_000_000
+	want, err := Render(context.Background(), document, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, height := range []int{37, 256} {
+		got := image.NewNRGBA(want.Bounds())
+		if err := RenderBands(context.Background(), document, options, height, func(band *image.NRGBA) error {
+			draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		assertBandPixels(t, got, want)
+	}
+}

--- a/d2renderers/d2raster/effects.go
+++ b/d2renderers/d2raster/effects.go
@@ -25,7 +25,8 @@ type renderResources struct {
 }
 
 type rasterizerResourcePlanner struct {
-	counter *scanline.Rasterizer
+	counter       *scanline.Rasterizer
+	regionFilters bool
 }
 
 type offscreenPixelKind uint8
@@ -253,8 +254,13 @@ func addScanlineWork(resources *renderResources, work int64) error {
 }
 
 func planRenderResources(ctx context.Context, node *preparedNode, dst image.Rectangle, patterns []*preparedPatternTile, maxOffscreenBytes int64) (renderResources, error) {
+	return planRenderResourcesRegion(ctx, node, dst, patterns, maxOffscreenBytes, false)
+}
+
+func planRenderResourcesRegion(ctx context.Context, node *preparedNode, dst image.Rectangle, patterns []*preparedPatternTile, maxOffscreenBytes int64, regionFilters bool) (renderResources, error) {
 	planner := &rasterizerResourcePlanner{
-		counter: scanline.NewCounter(0, 0, scanline.MaxEdgesForBytes(maxOffscreenBytes)),
+		counter:       scanline.NewCounter(0, 0, scanline.MaxEdgesForBytes(maxOffscreenBytes)),
+		regionFilters: regionFilters,
 	}
 	resources, err := planNodeResources(ctx, node, dst, planner)
 	if err != nil {
@@ -332,16 +338,23 @@ func planNodeResources(ctx context.Context, node *preparedNode, dst image.Rectan
 	finalLayerBytes := int64(0)
 	paintBounds := dst
 	if usesFilters {
+		filters, inputBounds := node.filters, node.contentBounds
 		var err error
-		baseBytes, err = pixelStorageBytes(node.contentBounds, 4)
+		if planner.regionFilters {
+			filters, inputBounds, err = regionalFilters(filters, inputBounds, visibleBounds)
+			if err != nil {
+				return resources, err
+			}
+		}
+		baseBytes, err = pixelStorageBytes(inputBounds, 4)
 		if err != nil {
 			return resources, fmt.Errorf("d2raster: filter input layer: %w", err)
 		}
-		resources.peakOffscreenBytes, finalLayerBytes, err = planFilterResources(node.filters, node.contentBounds)
+		resources.peakOffscreenBytes, finalLayerBytes, err = planFilterResources(filters, inputBounds)
 		if err != nil {
 			return resources, err
 		}
-		paintBounds = node.contentBounds
+		paintBounds = inputBounds
 	} else if usesEffectLayer {
 		var err error
 		baseBytes, err = pixelStorageBytes(visibleBounds, 4)
@@ -415,9 +428,12 @@ func planNodeResources(ctx context.Context, node *preparedNode, dst image.Rectan
 				return resources, err
 			}
 		} else if !node.clip.bounds.Intersect(visibleBounds).Empty() {
-			target := image.Rect(0, 0, visibleBounds.Dx(), visibleBounds.Dy())
-			shifted := d2scene.Translate(-float64(visibleBounds.Min.X), -float64(visibleBounds.Min.Y))
-			if err := planner.recordFill(ctx, &resources, target, node.clip.subpaths, shifted, "clip"); err != nil {
+			origin := visibleBounds.Min
+			if planner.regionFilters {
+				origin = node.clip.referenceBounds.Min
+			}
+			shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y))
+			if err := planner.recordFill(ctx, &resources, visibleBounds, node.clip.subpaths, shifted, "clip", origin); err != nil {
 				return resources, err
 			}
 		}
@@ -499,15 +515,22 @@ func planPrimitiveResources(ctx context.Context, primitive *preparedPrimitive, d
 				return resources, err
 			}
 		} else if primitive.fill.kind == preparedSolidPaint {
-			shifted := d2scene.Translate(-float64(dst.Min.X), -float64(dst.Min.Y)).Mul(primitive.transform)
-			if err := planner.recordFill(ctx, &resources, dst, primitive.subpaths, shifted, "solid fill"); err != nil {
+			origin := dst.Min
+			if planner.regionFilters {
+				origin = primitive.referenceBounds.Min
+			}
+			shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
+			if err := planner.recordFill(ctx, &resources, dst, primitive.subpaths, shifted, "solid fill", origin); err != nil {
 				return resources, err
 			}
 		} else {
 			if !bounds.Empty() {
-				target := image.Rect(0, 0, bounds.Dx(), bounds.Dy())
-				shifted := d2scene.Translate(-float64(bounds.Min.X), -float64(bounds.Min.Y)).Mul(primitive.transform)
-				if err := planner.recordFill(ctx, &resources, target, primitive.subpaths, shifted, "gradient fill"); err != nil {
+				origin := bounds.Min
+				if planner.regionFilters {
+					origin = subpathPixelBounds(primitive.subpaths, primitive.transform, 0, primitive.referenceBounds).Min
+				}
+				shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
+				if err := planner.recordFill(ctx, &resources, bounds, primitive.subpaths, shifted, "gradient fill", origin); err != nil {
 					return resources, err
 				}
 			}
@@ -515,16 +538,23 @@ func planPrimitiveResources(ctx context.Context, primitive *preparedPrimitive, d
 	}
 	if primitive.stroke != nil {
 		if primitive.stroke.paint.kind == preparedSolidPaint {
-			shifted := d2scene.Translate(-float64(dst.Min.X), -float64(dst.Min.Y)).Mul(primitive.transform)
-			if err := planner.recordStroke(ctx, &resources, dst, primitive.strokeRuns, shifted, primitive.stroke, "solid stroke"); err != nil {
+			origin := dst.Min
+			if planner.regionFilters {
+				origin = primitive.stroke.referenceBounds.Min
+			}
+			shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
+			if err := planner.recordStroke(ctx, &resources, dst, primitive.strokeRuns, shifted, primitive.stroke, "solid stroke", origin); err != nil {
 				return resources, err
 			}
 		} else {
 			bounds := paintedStrokePixelBounds(primitive.strokeRuns, primitive.transform, primitive.stroke, dst)
 			if !bounds.Empty() {
-				target := image.Rect(0, 0, bounds.Dx(), bounds.Dy())
-				shifted := d2scene.Translate(-float64(bounds.Min.X), -float64(bounds.Min.Y)).Mul(primitive.transform)
-				if err := planner.recordStroke(ctx, &resources, target, primitive.strokeRuns, shifted, primitive.stroke, "gradient stroke"); err != nil {
+				origin := bounds.Min
+				if planner.regionFilters {
+					origin = paintedStrokePixelBounds(primitive.strokeRuns, primitive.transform, primitive.stroke, primitive.stroke.referenceBounds).Min
+				}
+				shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
+				if err := planner.recordStroke(ctx, &resources, bounds, primitive.strokeRuns, shifted, primitive.stroke, "gradient stroke", origin); err != nil {
 					return resources, err
 				}
 			}
@@ -563,9 +593,10 @@ func updateRasterizerBytes(resources *renderResources) {
 	resources.rasterizerBytes = bytes
 }
 
-func (p *rasterizerResourcePlanner) recordFill(ctx context.Context, resources *renderResources, target image.Rectangle, paths []subpath, transform d2scene.Matrix, purpose string) error {
+func (p *rasterizerResourcePlanner) recordFill(ctx context.Context, resources *renderResources, target image.Rectangle, paths []subpath, transform d2scene.Matrix, purpose string, referenceOrigin image.Point) error {
 	recordRasterizerRequirement(resources, target)
 	p.counter.Reset(target.Dx(), target.Dy())
+	setRasterizerReference(p.counter, target.Min, referenceOrigin, p.regionFilters)
 	for index, path := range paths {
 		if index&255 == 0 {
 			if err := ctx.Err(); err != nil {
@@ -586,9 +617,10 @@ func (p *rasterizerResourcePlanner) recordFill(ctx context.Context, resources *r
 	return addScanlineWork(resources, work)
 }
 
-func (p *rasterizerResourcePlanner) recordStroke(ctx context.Context, resources *renderResources, target image.Rectangle, runs []strokeRun, transform d2scene.Matrix, stroke *preparedStroke, purpose string) error {
+func (p *rasterizerResourcePlanner) recordStroke(ctx context.Context, resources *renderResources, target image.Rectangle, runs []strokeRun, transform d2scene.Matrix, stroke *preparedStroke, purpose string, referenceOrigin image.Point) error {
 	recordRasterizerRequirement(resources, target)
 	p.counter.Reset(target.Dx(), target.Dy())
+	setRasterizerReference(p.counter, target.Min, referenceOrigin, p.regionFilters)
 	for _, run := range runs {
 		if err := addStrokeRun(ctx, p.counter, run, transform, stroke); err != nil {
 			return err
@@ -667,12 +699,20 @@ func renderFilteredEffectNode(ctx context.Context, dst *image.RGBA, node *prepar
 	if visibleBounds.Empty() || node.contentBounds.Empty() {
 		return nil
 	}
-	current, err := reserveRGBA(scratch, node.contentBounds, "filter input layer")
+	filters, inputBounds := node.filters, node.contentBounds
+	var err error
+	if scratch.regionFilters {
+		filters, inputBounds, err = regionalFilters(filters, inputBounds, visibleBounds)
+		if err != nil {
+			return err
+		}
+	}
+	current, err := reserveRGBA(scratch, inputBounds, "filter input layer")
 	if err != nil {
 		return err
 	}
 	defer func() { current.release() }()
-	if node.primitive != nil && !node.primitive.bounds.Intersect(node.contentBounds).Empty() {
+	if node.primitive != nil && !node.primitive.bounds.Intersect(inputBounds).Empty() {
 		if err := drawPrimitive(ctx, current.image, node.primitive, scratch); err != nil {
 			return err
 		}
@@ -682,7 +722,7 @@ func renderFilteredEffectNode(ctx context.Context, dst *image.RGBA, node *prepar
 			return err
 		}
 	}
-	for _, filter := range node.filters {
+	for _, filter := range filters {
 		if err := applyPreparedFilter(ctx, &current, filter, scratch); err != nil {
 			return err
 		}
@@ -738,7 +778,8 @@ func applyNonZeroClip(ctx context.Context, layer *image.RGBA, clip *preparedClip
 	}
 
 	rasterizer := scratch.reset(image.Rect(0, 0, width, height))
-	shifted := d2scene.Translate(-float64(bounds.Min.X), -float64(bounds.Min.Y))
+	origin := setRasterizerReference(rasterizer, bounds.Min, clip.referenceBounds.Min, scratch.regionFilters)
+	shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y))
 	for index, path := range clip.subpaths {
 		if index&255 == 0 {
 			if err := ctx.Err(); err != nil {

--- a/d2renderers/d2raster/filter.go
+++ b/d2renderers/d2raster/filter.go
@@ -309,6 +309,91 @@ func unionFilterBounds(left, right image.Rectangle) (image.Rectangle, error) {
 	return result, nil
 }
 
+// regionalFilters works backwards from the pixels a destination will consume.
+// Each pass keeps its original kernel and transparent-outside-input semantics,
+// but only allocates the output needed by its successor. The input rectangle
+// includes every contributing sample, so the existing integer blur arithmetic
+// and shadow interpolation produce the same pixels as the complete layers.
+// Prepared filters are shared across bands and must remain immutable.
+func regionalFilters(filters []preparedFilter, input, destination image.Rectangle) ([]preparedFilter, image.Rectangle, error) {
+	result := make([]preparedFilter, len(filters))
+	needed := destination
+	for index := len(filters) - 1; index >= 0; index-- {
+		filter := filters[index]
+		previous := input
+		if index > 0 {
+			previous = filters[index-1].output
+		}
+		filter.output = needed.Intersect(filter.output)
+		filter.passes = append([]blurPass(nil), filter.passes...)
+		blurredNeeded := filter.output
+		if filter.kind == preparedDropShadow {
+			blurredBounds := previous
+			if len(filter.passes) != 0 {
+				blurredBounds = filter.passes[len(filter.passes)-1].bounds
+			}
+			blurredNeeded = shadowSampleBounds(filter.output, blurredBounds, filter.offsetX, filter.offsetY)
+		} else if filter.kind != preparedGaussianBlur {
+			return nil, image.Rectangle{}, fmt.Errorf("d2raster: internal unknown prepared filter %d", filter.kind)
+		}
+		for passIndex := len(filter.passes) - 1; passIndex >= 0; passIndex-- {
+			pass := &filter.passes[passIndex]
+			pass.bounds = blurredNeeded.Intersect(pass.bounds)
+			previousPass := previous
+			if passIndex > 0 {
+				previousPass = filters[index].passes[passIndex-1].bounds
+			}
+			x, y := pass.radius, 0
+			if pass.axis == blurVertical {
+				x, y = 0, pass.radius
+			}
+			expanded, err := expandFilterBounds(pass.bounds, x, y)
+			if err != nil {
+				// At the platform coordinate boundary, keeping the full previous
+				// pass is conservative and avoids overflowing an intermediate ROI.
+				blurredNeeded = previousPass
+			} else {
+				blurredNeeded = expanded.Intersect(previousPass)
+			}
+		}
+		needed = blurredNeeded.Intersect(previous)
+		if filter.kind == preparedDropShadow {
+			// Source-over keeps the unshifted input in addition to its shadow.
+			// A rectangle spans both regions; extreme offsets can still require
+			// substantial storage and remain subject to MaxOffscreenBytes.
+			needed = unionRect(needed, filter.output.Intersect(previous))
+		}
+		result[index] = filter
+	}
+	return result, needed.Intersect(input), nil
+}
+
+func shadowSampleBounds(destination, source image.Rectangle, offsetX, offsetY float64) image.Rectangle {
+	if destination.Empty() || source.Empty() {
+		return image.Rectangle{}
+	}
+	// Outside the exact float-integer domain the original sampler deliberately
+	// uses floating-point coordinate arithmetic. Retain its source domain rather
+	// than infer a cropped integer domain from rounded endpoints.
+	const maxExactInteger = 1 << 53
+	if !rectangleWithinExactFloatIntegerDomain(destination) || !rectangleWithinExactFloatIntegerDomain(source) ||
+		!finite(offsetX) || !finite(offsetY) || math.Abs(offsetX) > maxExactInteger || math.Abs(offsetY) > maxExactInteger {
+		return source
+	}
+	padding := 2.0 // floor(sample) and floor(sample)+1 for bilinear interpolation.
+	if offsetX == math.Trunc(offsetX) && offsetY == math.Trunc(offsetY) {
+		padding = 1
+	}
+	minX := math.Max(math.Floor(float64(destination.Min.X)-offsetX), float64(source.Min.X))
+	minY := math.Max(math.Floor(float64(destination.Min.Y)-offsetY), float64(source.Min.Y))
+	maxX := math.Min(math.Floor(float64(destination.Max.X-1)-offsetX)+padding, float64(source.Max.X))
+	maxY := math.Min(math.Floor(float64(destination.Max.Y-1)-offsetY)+padding, float64(source.Max.Y))
+	if minX >= maxX || minY >= maxY {
+		return image.Rectangle{}
+	}
+	return image.Rect(int(minX), int(minY), int(maxX), int(maxY))
+}
+
 type ownedRGBA struct {
 	image       *image.RGBA
 	reservation int64

--- a/d2renderers/d2raster/filter_regions_test.go
+++ b/d2renderers/d2raster/filter_regions_test.go
@@ -1,0 +1,172 @@
+package d2raster
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+func TestRegionalFiltersMatchCompleteLayers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	random := rand.New(rand.NewPCG(71, 912))
+	for caseIndex := range 48 {
+		input := image.Rect(-7, -5, 19, 26)
+		source := image.NewRGBA(input)
+		for y := input.Min.Y; y < input.Max.Y; y++ {
+			for x := input.Min.X; x < input.Max.X; x++ {
+				alpha := uint8(random.IntN(256))
+				source.SetRGBA(x, y, color.RGBA{R: uint8(random.IntN(int(alpha) + 1)), G: uint8(random.IntN(int(alpha) + 1)), B: uint8(random.IntN(int(alpha) + 1)), A: alpha})
+			}
+		}
+		var normalized []normalizedFilter
+		for range 1 + caseIndex%4 {
+			filter := normalizedFilter{sigmaX: float64(random.IntN(5)) / 2, sigmaY: float64(random.IntN(5)) / 2}
+			if random.IntN(2) == 0 {
+				filter.kind = preparedDropShadow
+				filter.offsetX = float64(random.IntN(73)-36) / 2
+				filter.offsetY = float64(random.IntN(73)-36) / 2
+				filter.shadowColor = color.NRGBA{R: 117, G: 41, B: 203, A: 197}
+			}
+			normalized = append(normalized, filter)
+		}
+		filters, bounds, err := (&preflight{ctx: ctx}).prepareFilters("test", normalized, d2scene.Identity(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(filters) == 0 {
+			continue
+		}
+		fullScratch := &rasterScratch{offscreen: offscreenBudget{limit: 1 << 30}}
+		complete := renderFilterRegionForTest(t, source, filters, input, fullScratch)
+		for y := bounds.Min.Y - 2; y < bounds.Max.Y+2; y += 7 {
+			region := image.Rect(bounds.Min.X+caseIndex%11, y, bounds.Max.X-caseIndex%13, y+3).Intersect(bounds)
+			cropped, required, err := regionalFilters(filters, input, region)
+			if err != nil {
+				t.Fatal(err)
+			}
+			scratch := &rasterScratch{offscreen: offscreenBudget{limit: 1 << 30}}
+			got := renderFilterRegionForTest(t, source, cropped, required, scratch)
+			for y := region.Min.Y; y < region.Max.Y; y++ {
+				for x := region.Min.X; x < region.Max.X; x++ {
+					if got.image.RGBAAt(x, y) != complete.image.RGBAAt(x, y) {
+						t.Fatalf("case %d, region %v, pixel (%d,%d) = %v, want %v; filters %+v", caseIndex, region, x, y, got.image.RGBAAt(x, y), complete.image.RGBAAt(x, y), filters)
+					}
+				}
+			}
+			peak, finalBytes, err := planFilterResources(cropped, required)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scratch.offscreen.peak != peak || scratch.offscreen.live != finalBytes {
+				t.Fatalf("case %d: filter storage live/peak = %d/%d, want %d/%d", caseIndex, scratch.offscreen.live, scratch.offscreen.peak, finalBytes, peak)
+			}
+			got.release()
+		}
+		complete.release()
+	}
+}
+
+func renderFilterRegionForTest(t *testing.T, source *image.RGBA, filters []preparedFilter, input image.Rectangle, scratch *rasterScratch) ownedRGBA {
+	t.Helper()
+	current, err := reserveRGBA(scratch, input, "test filter input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	draw.Draw(current.image, input, source, input.Min, draw.Src)
+	for _, filter := range filters {
+		if err := applyPreparedFilter(context.Background(), &current, filter, scratch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return current
+}
+
+func TestRegionalFilterBandsNestedEffects(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for _, fillRule := range []d2scene.FillRule{d2scene.NonZero, d2scene.EvenOdd} {
+		t.Run(fmt.Sprint(fillRule), func(t *testing.T) {
+			child := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 11.25, Y: -9.5, Width: 45.75, Height: 114}, Fill: red})
+			child.Filters = []d2scene.Filter{
+				d2scene.DropShadow{OffsetX: -7.5, OffsetY: 11.25, SigmaX: 1.5, SigmaY: 2, Color: color.NRGBA{G: 199, A: 177}},
+				d2scene.GaussianBlur{SigmaX: 1, SigmaY: .5},
+			}
+			child.Opacity = .7
+			other := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 32.5, Y: 28.5, Width: 32, Height: 62}, Fill: d2scene.SolidPaint{Color: color.NRGBA{B: 255, A: 151}}})
+			root := d2scene.NewNode(nil)
+			root.Children = []*d2scene.Node{child, other}
+			root.Filters = []d2scene.Filter{
+				d2scene.GaussianBlur{SigmaX: .5, SigmaY: 1.5},
+				d2scene.DropShadow{OffsetX: 4.25, OffsetY: -6.5, SigmaX: 1, SigmaY: 1, Color: color.NRGBA{A: 215}},
+			}
+			root.Clip = &d2scene.Clip{Path: clipRect(4.5, 3.5, 70, 92, fillRule), Transform: d2scene.Identity()}
+			mask := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 2, Y: 7, Width: 71, Height: 80}, Fill: red})
+			mask.Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaX: 1, SigmaY: 1}}
+			root.Mask = &d2scene.Mask{Type: d2scene.MaskAlpha, Root: mask, Transform: d2scene.Identity()}
+			root.Opacity = .8
+			document := d2scene.NewDocument(d2scene.Box{Width: 80, Height: 100}, root)
+			want, err := Render(ctx, document, testOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, height := range []int{1, 7, 31} {
+				got := image.NewNRGBA(want.Bounds())
+				err := RenderBands(ctx, document, testOptions(), height, func(band *image.NRGBA) error {
+					draw.Draw(got, band.Bounds(), band, band.Bounds().Min, draw.Src)
+					return nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got.Pix, want.Pix) {
+					for y := range want.Bounds().Dy() {
+						for x := range want.Bounds().Dx() {
+							if got.NRGBAAt(x, y) != want.NRGBAAt(x, y) {
+								t.Fatalf("band height %d, pixel (%d,%d) = %v, want %v", height, x, y, got.NRGBAAt(x, y), want.NRGBAAt(x, y))
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRegionalFilterStorageDoesNotGrowWithImageHeight(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var previousPeak int64
+	for _, height := range []int{1_000, 100_000, 1_000_000} {
+		input := image.Rect(0, 0, 500, height)
+		filters, _, err := (&preflight{ctx: ctx}).prepareFilters("test", []normalizedFilter{
+			{kind: preparedGaussianBlur, sigmaX: 2, sigmaY: 3},
+			{kind: preparedDropShadow, sigmaX: 3, sigmaY: 4, offsetX: -3.5, offsetY: 8.25, shadowColor: color.NRGBA{A: 200}},
+		}, d2scene.Identity(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cropped, required, err := regionalFilters(filters, input, image.Rect(0, height/2, 500, height/2+32))
+		if err != nil {
+			t.Fatal(err)
+		}
+		peak, _, err := planFilterResources(cropped, required)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if peak > 500*256*4 {
+			t.Fatalf("height %d: regional peak %d exceeds bounded filter storage", height, peak)
+		}
+		if previousPeak != 0 && previousPeak != peak {
+			t.Fatalf("height %d: regional peak grew from %d to %d", height, previousPeak, peak)
+		}
+		previousPeak = peak
+	}
+}

--- a/d2renderers/d2raster/geometry.go
+++ b/d2renderers/d2raster/geometry.go
@@ -445,7 +445,8 @@ func appendDashPoint(points []d2scene.Point, point d2scene.Point) []d2scene.Poin
 func drawStroke(ctx context.Context, dst *image.RGBA, runs []strokeRun, transform d2scene.Matrix, stroke *preparedStroke, scratch *rasterScratch) error {
 	if stroke.paint.kind == preparedSolidPaint {
 		rasterizer := scratch.reset(dst.Bounds())
-		shifted := d2scene.Translate(-float64(dst.Bounds().Min.X), -float64(dst.Bounds().Min.Y)).Mul(transform)
+		origin := setRasterizerReference(rasterizer, dst.Bounds().Min, stroke.referenceBounds.Min, scratch.regionFilters)
+		shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(transform)
 		for _, run := range runs {
 			if err := ctx.Err(); err != nil {
 				return err
@@ -462,7 +463,12 @@ func drawStroke(ctx context.Context, dst *image.RGBA, runs []strokeRun, transfor
 
 	bounds := paintedStrokePixelBounds(runs, transform, stroke, dst.Bounds())
 	return drawRasterizedPaint(ctx, dst, bounds, stroke.paint, scratch, "gradient stroke", func(rasterizer *scanline.Rasterizer) error {
-		shifted := d2scene.Translate(-float64(bounds.Min.X), -float64(bounds.Min.Y)).Mul(transform)
+		reference := bounds.Min
+		if scratch.regionFilters {
+			reference = paintedStrokePixelBounds(runs, transform, stroke, stroke.referenceBounds).Min
+		}
+		origin := setRasterizerReference(rasterizer, bounds.Min, reference, scratch.regionFilters)
+		shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(transform)
 		for _, run := range runs {
 			if err := ctx.Err(); err != nil {
 				return err
@@ -830,16 +836,16 @@ func addPolygon(rasterizer *scanline.Rasterizer, transform d2scene.Matrix, point
 		firstIndex = len(points) - 1
 	}
 	first := transform.Point(points[firstIndex])
-	rasterizer.MoveTo(float32(first.X), float32(first.Y))
+	rasterizer.MoveTo64(first.X, first.Y)
 	if reverse {
 		for index := len(points) - 2; index >= 0; index-- {
 			point := transform.Point(points[index])
-			rasterizer.LineTo(float32(point.X), float32(point.Y))
+			rasterizer.LineTo64(point.X, point.Y)
 		}
 	} else {
 		for _, localPoint := range points[1:] {
 			point := transform.Point(localPoint)
-			rasterizer.LineTo(float32(point.X), float32(point.Y))
+			rasterizer.LineTo64(point.X, point.Y)
 		}
 	}
 	rasterizer.ClosePath()
@@ -866,23 +872,23 @@ func addCircle(rasterizer *scanline.Rasterizer, transform d2scene.Matrix, center
 	// form a non-zero union instead of cancelling one another.
 	k := 0.5522847498307936 * radius
 	start := transform.Point(d2scene.Point{X: center.X + radius, Y: center.Y})
-	rasterizer.MoveTo(float32(start.X), float32(start.Y))
+	rasterizer.MoveTo64(start.X, start.Y)
 	c1 := transform.Point(d2scene.Point{X: center.X + radius, Y: center.Y - k})
 	c2 := transform.Point(d2scene.Point{X: center.X + k, Y: center.Y - radius})
 	end := transform.Point(d2scene.Point{X: center.X, Y: center.Y - radius})
-	rasterizer.CubeTo(float32(c1.X), float32(c1.Y), float32(c2.X), float32(c2.Y), float32(end.X), float32(end.Y))
+	rasterizer.CubeTo64(c1.X, c1.Y, c2.X, c2.Y, end.X, end.Y)
 	c1 = transform.Point(d2scene.Point{X: center.X - k, Y: center.Y - radius})
 	c2 = transform.Point(d2scene.Point{X: center.X - radius, Y: center.Y - k})
 	end = transform.Point(d2scene.Point{X: center.X - radius, Y: center.Y})
-	rasterizer.CubeTo(float32(c1.X), float32(c1.Y), float32(c2.X), float32(c2.Y), float32(end.X), float32(end.Y))
+	rasterizer.CubeTo64(c1.X, c1.Y, c2.X, c2.Y, end.X, end.Y)
 	c1 = transform.Point(d2scene.Point{X: center.X - radius, Y: center.Y + k})
 	c2 = transform.Point(d2scene.Point{X: center.X - k, Y: center.Y + radius})
 	end = transform.Point(d2scene.Point{X: center.X, Y: center.Y + radius})
-	rasterizer.CubeTo(float32(c1.X), float32(c1.Y), float32(c2.X), float32(c2.Y), float32(end.X), float32(end.Y))
+	rasterizer.CubeTo64(c1.X, c1.Y, c2.X, c2.Y, end.X, end.Y)
 	c1 = transform.Point(d2scene.Point{X: center.X + k, Y: center.Y + radius})
 	c2 = transform.Point(d2scene.Point{X: center.X + radius, Y: center.Y + k})
 	end = transform.Point(d2scene.Point{X: center.X + radius, Y: center.Y})
-	rasterizer.CubeTo(float32(c1.X), float32(c1.Y), float32(c2.X), float32(c2.Y), float32(end.X), float32(end.Y))
+	rasterizer.CubeTo64(c1.X, c1.Y, c2.X, c2.Y, end.X, end.Y)
 	rasterizer.ClosePath()
 }
 

--- a/d2renderers/d2raster/internal/scanline/origin_test.go
+++ b/d2renderers/d2raster/internal/scanline/origin_test.go
@@ -1,0 +1,77 @@
+package scanline
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestReferenceOriginPreservesFullTargetRounding(t *testing.T) {
+	const width, height = 24, 30_020
+	full := NewRasterizer(width, height)
+	full.MoveTo(3, float32(30_000.002))
+	full.LineTo(20, float32(30_000.002))
+	full.LineTo(20, float32(30_010.002))
+	full.LineTo(3, float32(30_010.002))
+	full.ClosePath()
+	want := image.NewRGBA(image.Rect(0, 0, width, height))
+	work := NewWorkBudget(1 << 30)
+	if err := full.DrawRGBA(context.Background(), &work, want, color.NRGBA{R: 255, A: 255}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, top := range []int{29_995, 30_000, 30_007} {
+		band := NewRasterizer(width, 7)
+		band.SetOriginOffset(0, -float64(top))
+		band.MoveTo64(3, 30_000.002)
+		band.LineTo64(20, 30_000.002)
+		band.LineTo64(20, 30_010.002)
+		band.LineTo64(3, 30_010.002)
+		band.ClosePath()
+		got := image.NewRGBA(image.Rect(0, top, width, top+7))
+		work := NewWorkBudget(1 << 30)
+		if err := band.DrawRGBA(context.Background(), &work, got, color.NRGBA{R: 255, A: 255}); err != nil {
+			t.Fatal(err)
+		}
+		for y := top; y < top+7; y++ {
+			for x := range width {
+				if got.RGBAAt(x, y) != want.RGBAAt(x, y) {
+					t.Fatalf("band %d pixel (%d,%d) = %v, want %v", top, x, y, got.RGBAAt(x, y), want.RGBAAt(x, y))
+				}
+			}
+		}
+	}
+}
+
+func TestReferenceOriginCurveAndReset(t *testing.T) {
+	full := NewRasterizer(50, 30_050)
+	full.MoveTo(3, float32(30_000.002))
+	full.CubeTo(4, float32(30_015.129), 31, float32(30_028.321), 45, float32(30_000.417))
+	full.ClosePath()
+	band := NewRasterizer(50, 17)
+	band.SetOriginOffset(0, -30_000)
+	band.MoveTo64(3, 30_000.002)
+	band.CubeTo64(4, 30_015.129, 31, 30_028.321, 45, 30_000.417)
+	band.ClosePath()
+	if len(band.edges) != len(full.edges) {
+		t.Fatalf("translated curve edges = %d, want %d", len(band.edges), len(full.edges))
+	}
+	for index, original := range full.edges {
+		original.from.y -= 30_000
+		original.to.y -= 30_000
+		if band.edges[index] != original {
+			t.Fatalf("translated curve edge %d = %+v, want %+v", index, band.edges[index], original)
+		}
+	}
+	band.Reset(50, 50)
+	band.MoveTo64(3, 4)
+	if band.current != (point{x: 3, y: 4}) {
+		t.Fatalf("Reset retained origin offset: %+v", band.current)
+	}
+	band.SetOriginOffset(100, 200)
+	band.MoveTo(3, 4)
+	if band.current != (point{x: 3, y: 4}) {
+		t.Fatalf("float32 API used reference translation: %+v", band.current)
+	}
+}

--- a/d2renderers/d2raster/internal/scanline/rasterizer.go
+++ b/d2renderers/d2raster/internal/scanline/rasterizer.go
@@ -107,9 +107,10 @@ type Rasterizer struct {
 	partial    []float32
 	difference []float32
 
-	first   point
-	current point
-	hasPath bool
+	first        point
+	current      point
+	hasPath      bool
+	originOffset point
 
 	touchedMin int
 	touchedMax int
@@ -166,6 +167,7 @@ func (r *Rasterizer) Reset(width, height int) {
 	r.scanEdges = r.scanEdges[:0]
 	r.active = r.active[:0]
 	r.hasPath = false
+	r.originOffset = point{}
 	r.edgeCount = 0
 	r.pathErr = nil
 	r.workVisibleEdges = 0
@@ -229,7 +231,28 @@ func (r *Rasterizer) resizeRows(width int) {
 
 // MoveTo starts a new subpath at x, y.
 func (r *Rasterizer) MoveTo(x, y float32) {
-	p := point{x: float64(x), y: float64(y)}
+	r.moveTo(point{x: float64(x), y: float64(y)})
+}
+
+// SetOriginOffset sets the translation applied by the 64-bit path methods
+// after their coordinates have been rounded to float32. This lets a cropped
+// target preserve the coordinate rounding of a larger reference target.
+// Reset clears the translation; the original float32 methods ignore it.
+func (r *Rasterizer) SetOriginOffset(x, y float64) {
+	r.originOffset = point{x: x, y: y}
+}
+
+func (r *Rasterizer) referencePoint(x, y float64) point {
+	return point{x: float64(float32(x)) + r.originOffset.x, y: float64(float32(y)) + r.originOffset.y}
+}
+
+// MoveTo64 starts a subpath, rounding relative to the reference origin before
+// applying the translation configured by SetOriginOffset.
+func (r *Rasterizer) MoveTo64(x, y float64) {
+	r.moveTo(r.referencePoint(x, y))
+}
+
+func (r *Rasterizer) moveTo(p point) {
 	r.first = p
 	r.current = p
 	r.hasPath = true
@@ -237,7 +260,16 @@ func (r *Rasterizer) MoveTo(x, y float32) {
 
 // LineTo appends a straight edge to the current subpath.
 func (r *Rasterizer) LineTo(x, y float32) {
-	next := point{x: float64(x), y: float64(y)}
+	r.lineTo(point{x: float64(x), y: float64(y)})
+}
+
+// LineTo64 appends an edge using the reference rounding and origin translation
+// described by MoveTo64.
+func (r *Rasterizer) LineTo64(x, y float64) {
+	r.lineTo(r.referencePoint(x, y))
+}
+
+func (r *Rasterizer) lineTo(next point) {
 	if !r.hasPath {
 		r.first = next
 		r.current = next
@@ -252,14 +284,24 @@ func (r *Rasterizer) LineTo(x, y float32) {
 // the tolerance is independent of the source transform.
 func (r *Rasterizer) CubeTo(cx0, cy0, cx1, cy1, x, y float32) {
 	end := point{x: float64(x), y: float64(y)}
+	c0 := point{x: float64(cx0), y: float64(cy0)}
+	c1 := point{x: float64(cx1), y: float64(cy1)}
+	r.cubeTo(c0, c1, end)
+}
+
+// CubeTo64 appends a cubic curve using reference rounding for its control and
+// end points before applying the configured origin translation.
+func (r *Rasterizer) CubeTo64(cx0, cy0, cx1, cy1, x, y float64) {
+	r.cubeTo(r.referencePoint(cx0, cy0), r.referencePoint(cx1, cy1), r.referencePoint(x, y))
+}
+
+func (r *Rasterizer) cubeTo(c0, c1, end point) {
 	if !r.hasPath {
 		r.first = end
 		r.current = end
 		r.hasPath = true
 		return
 	}
-	c0 := point{x: float64(cx0), y: float64(cy0)}
-	c1 := point{x: float64(cx1), y: float64(cy1)}
 	r.flattenCube(r.current, c0, c1, end, 0)
 	r.current = end
 }

--- a/d2renderers/d2raster/raster.go
+++ b/d2renderers/d2raster/raster.go
@@ -107,6 +107,7 @@ type preparedNode struct {
 }
 
 type preparedPrimitive struct {
+	referenceBounds image.Rectangle
 	subpaths        []subpath
 	strokeRuns      []strokeRun
 	transform       d2scene.Matrix
@@ -121,10 +122,11 @@ type preparedPrimitive struct {
 }
 
 type preparedClip struct {
-	subpaths []subpath
-	fillRule d2scene.FillRule
-	bounds   image.Rectangle
-	edges    int64
+	referenceBounds image.Rectangle
+	subpaths        []subpath
+	fillRule        d2scene.FillRule
+	bounds          image.Rectangle
+	edges           int64
 }
 
 type preparedMask struct {
@@ -133,13 +135,14 @@ type preparedMask struct {
 }
 
 type preparedStroke struct {
-	paint      *preparedPaint
-	width      float64
-	cap        d2scene.LineCap
-	join       d2scene.LineJoin
-	miterLimit float64
-	dashes     []float64
-	dashOffset float64
+	referenceBounds image.Rectangle
+	paint           *preparedPaint
+	width           float64
+	cap             d2scene.LineCap
+	join            d2scene.LineJoin
+	miterLimit      float64
+	dashes          []float64
+	dashOffset      float64
 }
 
 type animationOverrides struct {
@@ -176,6 +179,7 @@ type preflight struct {
 }
 
 type rasterScratch struct {
+	regionFilters     bool
 	rasterizer        *scanline.Rasterizer
 	rasterizerEdges   int
 	rasterizerBounded bool
@@ -605,6 +609,10 @@ func (w contextWriter) Write(data []byte) (int, error) {
 }
 
 func prepareWithSession(ctx context.Context, document *d2scene.Document, options FrameOptions, session *RenderSession) (*preparedDocument, error) {
+	return prepareWithSessionBands(ctx, document, options, session, 0)
+}
+
+func prepareWithSessionBands(ctx context.Context, document *d2scene.Document, options FrameOptions, session *RenderSession, bandHeight int) (*preparedDocument, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -664,7 +672,11 @@ func prepareWithSession(ctx context.Context, document *d2scene.Document, options
 	if int64(width) > options.MaxPixels/int64(height) {
 		return nil, fmt.Errorf("d2raster: frame pixels exceed limit %d", options.MaxPixels)
 	}
-	if _, err := finalFrameStorageBytes(width, height); err != nil {
+	storageHeight := height
+	if bandHeight > 0 {
+		storageHeight = min(height, bandHeight)
+	}
+	if _, err := finalFrameStorageBytes(width, storageHeight); err != nil {
 		return nil, err
 	}
 	if document.Root == nil {
@@ -713,7 +725,20 @@ func prepareWithSession(ctx context.Context, document *d2scene.Document, options
 	if err != nil {
 		return nil, err
 	}
-	resources, err := planRenderResources(ctx, root, p.frameBounds, patterns, options.MaxOffscreenBytes)
+	var resources renderResources
+	if bandHeight > 0 {
+		if err := setBandReferenceBounds(ctx, root, p.frameBounds); err != nil {
+			return nil, err
+		}
+		for _, pattern := range patterns {
+			if err := setBandReferenceBounds(ctx, pattern.root, pattern.bounds); err != nil {
+				return nil, err
+			}
+		}
+		resources, err = planBandResources(ctx, root, p.frameBounds, patterns, options, bandHeight)
+	} else {
+		resources, err = planRenderResources(ctx, root, p.frameBounds, patterns, options.MaxOffscreenBytes)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1509,7 +1534,7 @@ func prepareAnimatedStrokeWithPaint(stroke *d2scene.Stroke, animatedColor *color
 }
 
 func renderNode(ctx context.Context, dst *image.RGBA, node *preparedNode, scratch *rasterScratch) error {
-	if node == nil || node.opacity == 0 || node.bounds.Empty() {
+	if node == nil || node.opacity == 0 || node.bounds.Intersect(dst.Bounds()).Empty() {
 		return nil
 	}
 	if err := ctx.Err(); err != nil {
@@ -1552,7 +1577,8 @@ func drawPrimitive(ctx context.Context, dst *image.RGBA, primitive *preparedPrim
 			}
 		} else if primitive.fill.kind == preparedSolidPaint {
 			rasterizer := scratch.reset(dst.Bounds())
-			shifted := d2scene.Translate(-float64(dst.Bounds().Min.X), -float64(dst.Bounds().Min.Y)).Mul(primitive.transform)
+			origin := setRasterizerReference(rasterizer, dst.Bounds().Min, primitive.referenceBounds.Min, scratch.regionFilters)
+			shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
 			for _, path := range primitive.subpaths {
 				addFillSubpath(rasterizer, path, shifted)
 			}
@@ -1562,7 +1588,12 @@ func drawPrimitive(ctx context.Context, dst *image.RGBA, primitive *preparedPrim
 		} else {
 			bounds := subpathPixelBounds(primitive.subpaths, primitive.transform, 0, dst.Bounds())
 			err := drawRasterizedPaint(ctx, dst, bounds, primitive.fill, scratch, "gradient fill", func(rasterizer *scanline.Rasterizer) error {
-				shifted := d2scene.Translate(-float64(bounds.Min.X), -float64(bounds.Min.Y)).Mul(primitive.transform)
+				reference := bounds.Min
+				if scratch.regionFilters {
+					reference = subpathPixelBounds(primitive.subpaths, primitive.transform, 0, primitive.referenceBounds).Min
+				}
+				origin := setRasterizerReference(rasterizer, bounds.Min, reference, scratch.regionFilters)
+				shifted := d2scene.Translate(-float64(origin.X), -float64(origin.Y)).Mul(primitive.transform)
 				for _, path := range primitive.subpaths {
 					addFillSubpath(rasterizer, path, shifted)
 				}
@@ -1589,10 +1620,10 @@ func addFillSubpath(rasterizer *scanline.Rasterizer, path subpath, transform d2s
 		return
 	}
 	first := transform.Point(path.points[0])
-	rasterizer.MoveTo(float32(first.X), float32(first.Y))
+	rasterizer.MoveTo64(first.X, first.Y)
 	for _, point := range path.points[1:] {
 		point = transform.Point(point)
-		rasterizer.LineTo(float32(point.X), float32(point.Y))
+		rasterizer.LineTo64(point.X, point.Y)
 	}
 	// SVG fill closes open subpaths implicitly.
 	rasterizer.ClosePath()

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"math"
 
 	"github.com/d2lang/d2/lib/version"
@@ -24,6 +25,22 @@ const (
 	pngChunkIEND     = uint32(0x49454e44) // IEND
 	d2ExifIFDSize    = 38
 )
+
+// WriteExif writes D2's complete eXIf chunk. A streaming PNG encoder calls it
+// after IHDR, before emitting image data, without retaining the encoded image.
+func WriteExif(w io.Writer) error {
+	dataSize, err := d2ExifDataSize(version.Version)
+	if err != nil {
+		return err
+	}
+	chunk := make([]byte, pngChunkOverhead+dataSize)
+	writeD2ExifChunk(chunk, 0, version.Version, dataSize)
+	n, err := w.Write(chunk)
+	if err == nil && n != len(chunk) {
+		return io.ErrShortWrite
+	}
+	return err
+}
 
 // AddExif returns png with D2's EXIF metadata inserted after IHDR. An existing
 // EXIF chunk is replaced at its original position. The input is validated


### PR DESCRIPTION
## Human

---

## AI

PNG exports above 67,108,864 pixels currently fail because the renderer allocates the complete image before encoding it. This changes CLI PNG export to render reusable 256-row strips and stream them into one PNG compression stream. It addresses the oversized-image error reported in [#2761](https://github.com/d2lang/d2/issues/2761#issuecomment-5569969297).

Scene geometry and assets are prepared once. Blur/shadow processing retains only the contributing regions around each strip, and the original coordinate rounding is preserved so antialiasing does not change. File output is staged until rendering succeeds; PNG metadata and compression workspaces no longer require retaining the complete output.

PNG remains limited to 32,768 output pixels per axis, with the existing effect, asset, and rendering-work budgets. The complete-image API and PDF/PPTX/GIF frame paths retain their existing limits.

### Local measurements

Peak process RSS, including layout and encoding; median of three fresh processes on Apple M4, Go 1.27.0, `CGO_ENABLED=0`, default PNG density, and `--pad 0`:

| Input | Output dimensions | Before | After | Time before → after |
|---|---:|---:|---:|---:|
| Large rounded rectangle | 7,804 × 7,804 | 271.2 MiB | 44.0 MiB | 0.44 → 0.33 s |
| Large shadowed rectangle | 5,410 × 5,414 | 373.1 MiB | 84.6 MiB | 0.27 → 0.26 s |
| Queue workers fixture, Dagre | 7,600 × 3,052 | 180.9 MiB | 78.8 MiB | 0.51 → 0.53 s |
| Oversized rounded rectangle | 12,004 × 12,004 | Rejected | 47.9 MiB | — → 0.82 s |

The three comparable PNGs are byte-identical, including metadata. The oversized case contains 144,096,016 pixels. These are local measurements; strip processing can repeat geometry/filter work and is not a universal speed improvement.

### Validation

- `CGO_ENABLED=0 go test ./... -count=1`
- `go test -race -short ./d2renderers/d2raster/... ./d2cli ./lib/png -count=1`
- `CGO_ENABLED=0 go vet --composites=false ./...`
- WASM build and Linux/386 raster-test compilation
- Exact output comparisons across 20 Dagre/ELK fixtures and tests for fractional/tall geometry, filters, masks, patterns, alpha, cancellation, output failures, and resource budgets
