### PR TITLE
perf: reduce repeated work in imports, grid layout, and PNG rendering

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Improvements 🧹
 
+- performance: reduce repeated work in selective imports, dynamic grid layout, and PNG connection rendering
 - exports: reduce PNG memory usage and support images above the previous 67-megapixel limit
 - performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.
 - renders: SVG exports are approximately 24% smaller across the E2E corpus and 18% smaller across real-world fixtures, with unchanged appearance.

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -40,7 +40,7 @@ type compiler struct {
 	// Callers always receive deep copies so importer substitutions, references,
 	// and glob state cannot leak between import sites.
 	parsedImports   map[string]*d2ast.Map
-	importTemplates map[string]*Map
+	importTemplates map[string]*importTemplate
 	utf16Pos        bool
 
 	// Stack of globs that must be recomputed at each new object in and below the current scope.
@@ -83,7 +83,7 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 
 		seenImports:     make(map[string]struct{}),
 		parsedImports:   make(map[string]*d2ast.Map),
-		importTemplates: make(map[string]*Map),
+		importTemplates: make(map[string]*importTemplate),
 		utf16Pos:        opts.UTF16Pos,
 	}
 	m := &Map{}

--- a/d2ir/import.go
+++ b/d2ir/import.go
@@ -54,15 +54,16 @@ func formatCyclicChain(cyclicChain []string) string {
 
 // Returns either *Map or *Field.
 func (c *compiler) _import(imp *d2ast.Import, importer Node) (Node, bool) {
-	ir, ok := c.__import(imp, importTemplateSafeAt(importer))
-	if !ok {
-		return nil, false
-	}
+	_, fieldImport := importer.(*Field)
+	return c.__import(imp, importTemplateSafeAt(importer), fieldImport)
+}
+
+func (c *compiler) selectImport(ir *Map, imp *d2ast.Import) (Node, bool) {
 	nilScopeMap(ir)
-	if len(imp.IDA()) > 0 {
-		f := ir.getFieldIndexed(imp.IDA()...)
+	if ida := imp.IDA(); len(ida) > 0 {
+		f := ir.getFieldIndexed(ida...)
 		if f == nil {
-			c.errorf(imp, "import key %q doesn't exist inside import", imp.IDA())
+			c.errorf(imp, "import key %q doesn't exist inside import", ida)
 			return nil, false
 		}
 		return f, true
@@ -70,7 +71,7 @@ func (c *compiler) _import(imp *d2ast.Import, importer Node) (Node, bool) {
 	return ir, true
 }
 
-func (c *compiler) __import(imp *d2ast.Import, templateSafe bool) (*Map, bool) {
+func (c *compiler) __import(imp *d2ast.Import, templateSafe, fieldImport bool) (Node, bool) {
 	impPath, ok := c.pushImportStack(imp)
 	if !ok {
 		return nil, false
@@ -88,7 +89,17 @@ func (c *compiler) __import(imp *d2ast.Import, templateSafe bool) (*Map, bool) {
 	if cacheable {
 		if template := c.importTemplates[impPath]; template != nil {
 			c.seenImports[impPath] = struct{}{}
-			return cloneImportMap(template), true
+			if ida := imp.IDA(); fieldImport && !imp.Spread && len(ida) > 0 && template.canSelect() {
+				selected := template.ir.getFieldIndexed(ida...)
+				if selected == nil {
+					c.errorf(imp, "import key %q doesn't exist inside import", ida)
+					return nil, false
+				}
+				field := cloneImportField(selected)
+				nilScopeMap(field)
+				return field, true
+			}
+			return c.selectImport(cloneImportMap(template.ir), imp)
 		}
 	}
 
@@ -117,10 +128,10 @@ func (c *compiler) __import(imp *d2ast.Import, templateSafe bool) (*Map, bool) {
 
 	c.seenImports[impPath] = struct{}{}
 	if cacheable && len(c.err.Errors) == errCount {
-		c.importTemplates[impPath] = cloneImportMap(ir)
+		c.importTemplates[impPath] = &importTemplate{ir: cloneImportMap(ir)}
 	}
 
-	return ir, true
+	return c.selectImport(ir, imp)
 }
 
 // Imported IR templates are context independent for ordinary maps. Board

--- a/d2ir/import_cache.go
+++ b/d2ir/import_cache.go
@@ -215,12 +215,81 @@ func cloneASTInterpolation(src []d2ast.InterpolationBox) []d2ast.InterpolationBo
 	return dst
 }
 
+// A selective non-spread import only copies the chosen field into its
+// destination. Once the complete library has been compiled and validated, its
+// unrelated siblings need not be copied again for each use. Keep full copies
+// for boards, globs, and maps in arrays, whose retained contexts can refer
+// outside that field. Imports into arrays also retain the source ancestry.
+type importTemplate struct {
+	ir               *Map
+	selective        bool
+	selectionChecked bool
+}
+
+func (t *importTemplate) canSelect() bool {
+	if !t.selectionChecked {
+		t.selective = canSelectImport(t.ir)
+		t.selectionChecked = true
+	}
+	return t.selective
+}
+
+func canSelectImport(n Node) bool {
+	return canSelectImportNode(n, false)
+}
+
+func canSelectImportNode(n Node, inArray bool) bool {
+	switch n := n.(type) {
+	case *Map:
+		// nilScopeMap does not descend into arrays. Those references retain
+		// the complete imported ancestry, so use the complete clone for them.
+		if inArray || len(n.globs) != 0 {
+			return false
+		}
+		for _, f := range n.Fields {
+			if !canSelectImport(f) {
+				return false
+			}
+		}
+		for _, e := range n.Edges {
+			if !canSelectImport(e) {
+				return false
+			}
+		}
+	case *Field:
+		if NodeBoardKind(n) != "" {
+			return false
+		}
+		return n.Composite == nil || canSelectImport(n.Composite)
+	case *Edge:
+		return n.Map_ == nil || canSelectImport(n.Map_)
+	case *Array:
+		for _, value := range n.Values {
+			if !canSelectImportNode(value, true) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func cloneImportField(src *Field) *Field {
+	dst := src.Copy(nil).(*Field)
+	cloneImportContexts(src, dst)
+	return dst
+}
+
 // cloneImportMap deep-copies mutable IR and remaps reference/glob contexts to
 // the copy. The ordinary Map.Copy intentionally shares source contexts; import
 // templates need stronger isolation because nilScopeMap and substitutions
 // mutate them after each import.
 func cloneImportMap(src *Map) *Map {
 	dst := src.Copy(nil).(*Map)
+	cloneImportContexts(src, dst)
+	return dst
+}
+
+func cloneImportContexts(src, dst Node) {
 	mapCopies := make(map[*Map]*Map)
 	collectMapCopies(src, dst, mapCopies)
 	contextCopies := make(map[*RefContext]*RefContext)
@@ -241,7 +310,6 @@ func cloneImportMap(src *Map) *Map {
 
 	cloneNodeReferences(src, dst, cloneContext)
 	cloneGlobContexts(src, dst, mapCopies, cloneContext)
-	return dst
 }
 
 func collectMapCopies(src, dst Node, copies map[*Map]*Map) {

--- a/d2ir/import_selection_test.go
+++ b/d2ir/import_selection_test.go
@@ -1,0 +1,352 @@
+package d2ir
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2parser"
+)
+
+func TestSelectiveImportMatchesWholeLibraryCopies(t *testing.T) {
+	cases := []struct {
+		name, library, source string
+	}{
+		{
+			name: "maps and overlay",
+			library: `unused: { spare: { label: unused } }
+component: Original {
+  a: { style.fill: red }
+  b
+  a -> b: linked
+}
+`,
+			source: `one: @library.component
+two: @library.component
+one.a.style.fill: green
+two.a.style.stroke: blue
+three: before { a.style.stroke: purple }
+three: @library.component
+three: @library.component
+`,
+		},
+		{
+			name: "scalars arrays and nested selection",
+			library: `group: {
+  number: 42
+  text: hello
+  values: [one; two; [3; true]; { nested: yes }]
+}
+`,
+			source: `a: @library.group.number
+b: @library.group.text
+c: @library.group.values
+d: @library.group.values
+e: @library.group
+f: @library.group._.group.text
+`,
+		},
+		{
+			name: "substitutions retain importer scope",
+			library: `vars: { local: library }
+group: { first: ${local}; second: ${outside} }
+`,
+			source: `vars: { outside: main }
+a: @library.group
+b: @library.group
+a.first: override
+`,
+		},
+		{
+			name: "quoted names and Unicode folding",
+			library: `"style": quoted
+style.fill: red
+Kelvin: { label: symbol }
+`,
+			source: "a: @library.\"style\"\nb: @library.style\nc: @library.KELVIN\nd: @library.kelvin\n",
+		},
+		{
+			name: "spread keeps complete source ancestry",
+			library: `group: titled { a; b; a -> b }
+`,
+			source: `a: @library.group
+...@library.group
+b: @library.group
+`,
+		},
+		{
+			name: "missing selected key",
+			library: `group: { a }
+`,
+			source: `a: @library.group
+b: @library.missing
+`,
+		},
+		{
+			name: "missing nested selected key",
+			library: `group: { a }
+`,
+			source: `a: @library.group
+b: @library.group.missing
+`,
+		},
+		{
+			name: "imports inside arrays",
+			library: `vars: { item: { value: library } }
+item: [one; two]
+`,
+			source: `items: [@library.vars.item; @library.vars.item; @library.item]
+`,
+		},
+		{
+			name: "retained globs",
+			library: `***.style.fill: red
+group: { a; b; a -> b }
+`,
+			source: `a: @library.group
+b: @library.group
+b.c
+`,
+		},
+		{
+			name: "retained board contexts",
+			library: `group: { a }
+layers: { x: { b } }
+`,
+			source: `a: @library.group
+b: @library.group
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full, fullErr := compilePrimedImport(t, tc.library, tc.source, false)
+			selected, selectedErr := compilePrimedImport(t, tc.library, tc.source, true)
+			if fullErr != selectedErr {
+				t.Fatalf("diagnostics differ:\nfull: %s\nselected: %s", fullErr, selectedErr)
+			}
+			if !bytes.Equal(full, selected) {
+				t.Fatal("selected import changed IR values, ordering, or source references")
+			}
+		})
+	}
+}
+
+// Prime both variants with the same compiled library, then use the old complete
+// library clone as an oracle. This compares the entire resulting IR, including
+// references and errors, without adding a production switch for the fast path.
+func compilePrimedImport(t *testing.T, library, source string, selective bool) ([]byte, string) {
+	t.Helper()
+	c := primedImportCompiler(t, library)
+	if template := c.importTemplates["library.d2"]; template == nil {
+		t.Fatal("library template was not cached")
+	} else if !selective {
+		template.selective = false
+		template.selectionChecked = true
+	}
+	c.globContextStack = nil
+	ast, err := d2parser.Parse("index.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := &Map{}
+	root.initRoot()
+	root.parent.(*Field).References[0].Context_.Scope = ast
+	root.parent.(*Field).References[0].Context_.ScopeAST = ast
+	c.compileMap(root, ast, ast)
+	c.compileSubstitutions(root, nil)
+	c.overlayClasses(root)
+	root.removeSuspendedFields()
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.err.Empty() {
+		// The existing missing-key diagnostic formats AST pointers. Ignore only
+		// those allocation addresses when comparing independent compilations.
+		return encoded, regexp.MustCompile(`0x[0-9a-f]+`).ReplaceAllString(c.err.Error(), "0xADDR")
+	}
+	return encoded, ""
+}
+
+func primedImportCompiler(t *testing.T, library string) *compiler {
+	t.Helper()
+	c := &compiler{
+		err:              &d2parser.ParseError{},
+		fs:               fstest.MapFS{"library.d2": &fstest.MapFile{Data: []byte(library)}},
+		importStack:      []string{"index.d2"},
+		seenImports:      make(map[string]struct{}),
+		parsedImports:    make(map[string]*d2ast.Map),
+		importTemplates:  make(map[string]*importTemplate),
+		globContextStack: [][]*globContext{{}},
+	}
+	key, err := d2parser.ParseMapKey("prime: @library")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.__import(key.Value.Import, true, true); !ok || !c.err.Empty() {
+		t.Fatalf("prime library: %v", c.err)
+	}
+	return c
+}
+
+func TestCloneImportFieldIsolatesMutableValuesAndReferences(t *testing.T) {
+	template := compileIndexTestSource(t, `component: {
+  first: { label: original }
+  second
+  first -> second: original
+  values: [1; two; { label: nested }]
+}
+`)
+	original := template.getFieldIndexed(d2ast.FlatUnquotedString("component"))
+	before, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := cloneImportField(original)
+	second := cloneImportField(original)
+	nilScopeMap(first)
+	first.Map().Fields[0].Map().Fields[0].Primary_.Value = d2ast.FlatUnquotedString("changed")
+	first.Map().Edges[0].ID.SrcPath[0] = d2ast.FlatUnquotedString("changed")
+	first.Map().Edges[0].Primary_.Value = d2ast.FlatUnquotedString("changed")
+	first.References[0].Context_.ScopeAST = nil
+	first.Map().Fields[2].Composite.(*Array).Values[0].(*Scalar).Value.(*d2ast.Number).Value.SetInt64(99)
+	for name, node := range map[string]Node{"template": original, "second copy": second} {
+		if got := node.Map().Edges[0].ID.SrcPath[0].ScalarString(); got != "first" {
+			t.Fatalf("%s edge source = %q", name, got)
+		}
+		if got := node.Map().Fields[2].Composite.(*Array).Values[0].Primary().Value.ScalarString(); got != "1" {
+			t.Fatalf("%s array value = %q", name, got)
+		}
+		if node.(*Field).References[0].Context_.ScopeMap == nil {
+			t.Fatalf("%s reference scope was cleared by another import", name)
+		}
+	}
+	after, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("mutating a selected import changed the template")
+	}
+}
+
+func TestSelectedImportStillValidatesUnselectedLibraryKeys(t *testing.T) {
+	ast, err := d2parser.Parse("index.d2", strings.NewReader("a: @library.good\nb: @library.good\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Compile(ast, &CompileOptions{FS: fstest.MapFS{
+		"library.d2": &fstest.MapFile{Data: []byte("good: okay\nbad: ${missing}\n")},
+	}})
+	// Unresolved substitutions on unrelated fields are deliberately not imported.
+	// Syntax and compile-time key errors in the full library still are validated.
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, invalid := range []string{"good: okay\nbad: {\n", "good: okay\n_.bad: invalid\n"} {
+		ast, err = d2parser.Parse("index.d2", strings.NewReader("a: @library.good\nb: @library.good\n"), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = Compile(ast, &CompileOptions{FS: fstest.MapFS{
+			"library.d2": &fstest.MapFile{Data: []byte(invalid)},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "library.d2") {
+			t.Fatalf("unselected library error for %q = %v", invalid, err)
+		}
+	}
+}
+
+func TestSelectiveImportFallbackPreservesArrayAncestry(t *testing.T) {
+	for _, tc := range []struct {
+		name, library, key string
+		arrayImporter      bool
+	}{
+		{"array importer", "vars: { item: { value: original } }", "@library.vars.item", true},
+		{"array map value", "vars: { item: [ { value: original } ] }", "@library.vars.item", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := primedImportCompiler(t, tc.library)
+			template := c.importTemplates["library.d2"].ir
+			key, err := d2parser.ParseMapKey("use: " + tc.key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destination := &Map{}
+			destination.initRoot()
+			field := &Field{parent: destination, Name: d2ast.FlatUnquotedString("use")}
+			var importer Node = field
+			if tc.arrayImporter {
+				importer = &Array{parent: field}
+			}
+			var imports []*Field
+			for i := 0; i < 2; i++ {
+				n, ok := c._import(key.Value.Import, importer)
+				if !ok {
+					t.Fatal(c.err)
+				}
+				selected := n.(*Field)
+				if selected.Parent() == nil || !IsVar(selected) {
+					t.Fatal("import lost its original vars ancestry")
+				}
+				root := RootMap(ParentMap(selected))
+				if root == template {
+					t.Fatal("import shares the cached template root")
+				}
+				if len(imports) > 0 && root == RootMap(ParentMap(imports[0])) {
+					t.Fatal("two imports share their source ancestry")
+				}
+				imports = append(imports, selected)
+			}
+			if !tc.arrayImporter {
+				firstMap := imports[0].Composite.(*Array).Values[0].(*Map)
+				secondMap := imports[1].Composite.(*Array).Values[0].(*Map)
+				ref := firstMap.Fields[0].References[0].Context_
+				if ref.ScopeMap != firstMap || secondMap.Fields[0].References[0].Context_.ScopeMap != secondMap {
+					t.Fatal("array map reference scope was not remapped to its private copy")
+				}
+				if !IsVar(ref.ScopeMap) {
+					t.Fatal("retained scope lost vars ancestry")
+				}
+				ref.ScopeMap.Fields[0].Primary_.Value = d2ast.FlatUnquotedString("changed")
+				if got := secondMap.Fields[0].Primary_.Value.ScalarString(); got != "original" {
+					t.Fatalf("another import changed through the retained scope: %s", got)
+				}
+				third, ok := c._import(key.Value.Import, importer)
+				if !ok {
+					t.Fatal(c.err)
+				}
+				thirdMap := third.(*Field).Composite.(*Array).Values[0].(*Map)
+				if got := thirdMap.Fields[0].Primary_.Value.ScalarString(); got != "original" {
+					t.Fatalf("a subsequent import changed through the cached template: %s", got)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectiveImportEligibilityKeepsScalarArrays(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   bool
+	}{
+		{"item: { class: [base; component] }", true},
+		{"item: [one; [two; 3]]", true},
+		{"item: [{ value: nested }]", false},
+		{"item: [[{ value: nested }]]", false},
+		{"**.style.fill: red\nitem", false},
+		{"item\nlayers: { other: { child } }", false},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			c := primedImportCompiler(t, tc.source)
+			if got := c.importTemplates["library.d2"].canSelect(); got != tc.want {
+				t.Fatalf("canSelect = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/d2ir/performance_test.go
+++ b/d2ir/performance_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/d2lang/util-go/mapfs"
 
@@ -98,5 +99,33 @@ func BenchmarkCompileDistinctEdges(b *testing.B) {
 			}
 			benchmarkCompileSource(b, source.String())
 		})
+	}
+}
+
+func BenchmarkCompileSelectedLibrary(b *testing.B) {
+	for _, size := range []int{100, 1000, 4000} {
+		for _, imports := range []int{10, 100} {
+			b.Run(fmt.Sprintf("library=%d/imports=%d", size, imports), func(b *testing.B) {
+				var library, source strings.Builder
+				for i := 0; i < size; i++ {
+					fmt.Fprintf(&library, "component%d: { a; b; a -> b; style.fill: red }\n", i)
+				}
+				for i := 0; i < imports; i++ {
+					fmt.Fprintf(&source, "use%d: @library.component%d\n", i, i%size)
+				}
+				filesystem := fstest.MapFS{"library.d2": &fstest.MapFile{Data: []byte(library.String())}}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					ast, err := d2parser.Parse("index.d2", strings.NewReader(source.String()), nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if _, _, err := d2ir.Compile(ast, &d2ir.CompileOptions{FS: filesystem}); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/d2layouts/d2grid/grid_search.go
+++ b/d2layouts/d2grid/grid_search.go
@@ -1,0 +1,74 @@
+package d2grid
+
+// Row measurements preserve the original left-to-right floating-point addition
+// order. Subtracting prefix sums could change ties between candidate layouts.
+type gridRowMeasurement struct {
+	start, end    int
+	size, withGap float64
+}
+
+type gridRowMeasurements struct {
+	sizes []float64
+	gap   float64
+	cache []gridRowMeasurement
+}
+
+func newGridRowMeasurements(sizes []float64, gap float64) *gridRowMeasurements {
+	// Bound the cache independently of diagram size; collisions only cause a
+	// measurement to be recomputed. Small diagrams fit without collisions.
+	const maxEntries = 32 * 1024
+	entries := 1
+	for len(sizes) > 0 && entries < maxEntries && entries/len(sizes) < len(sizes) {
+		entries *= 2
+	}
+	return &gridRowMeasurements{sizes: sizes, gap: gap, cache: make([]gridRowMeasurement, entries)}
+}
+
+func (m *gridRowMeasurements) get(start, end int) gridRowMeasurement {
+	slot := (uint(start)*uint(len(m.sizes)) + uint(end)) & uint(len(m.cache)-1)
+	cached := &m.cache[slot]
+	if cached.start == start && cached.end == end {
+		return *cached
+	}
+	size, withGap := 0., 0.
+	for _, v := range m.sizes[start:end] {
+		size += v
+		withGap += v + m.gap
+	}
+	if start < end {
+		withGap -= m.gap
+	}
+	*cached = gridRowMeasurement{start: start, end: end, size: size, withGap: withGap}
+	return *cached
+}
+
+// The division and row checks run in their original order, including repeated
+// checks: their attempt/skip counts affect when the bounded search terminates.
+// The callback borrows cuts only until it returns.
+type iterDivision func(division []int) (done bool)
+type checkCut func(start, end int, starting bool) (ok bool)
+
+func iterDivisions(nObjects, nCuts int, f iterDivision, check checkCut) {
+	if nObjects < 2 || nCuts == 0 {
+		return
+	}
+	cuts := make([]int, nCuts)
+	var visit func(end, remaining int) bool
+	visit = func(end, remaining int) bool {
+		for index := end - 1; index >= remaining; index-- {
+			if !check(index, end, false) {
+				continue
+			}
+			cuts[remaining-1] = index - 1
+			if remaining > 1 {
+				if visit(index, remaining-1) {
+					return true
+				}
+			} else if check(0, index, true) && f(cuts) {
+				return true
+			}
+		}
+		return false
+	}
+	visit(nObjects, nCuts)
+}

--- a/d2layouts/d2grid/grid_search.go
+++ b/d2layouts/d2grid/grid_search.go
@@ -14,22 +14,35 @@ type gridRowMeasurements struct {
 }
 
 func newGridRowMeasurements(sizes []float64, gap float64) *gridRowMeasurements {
-	// Bound the cache independently of diagram size; collisions only cause a
-	// measurement to be recomputed. Small diagrams fit without collisions.
-	const maxEntries = 32 * 1024
-	entries := 1
-	for len(sizes) > 0 && entries < maxEntries && entries/len(sizes) < len(sizes) {
-		entries *= 2
-	}
-	return &gridRowMeasurements{sizes: sizes, gap: gap, cache: make([]gridRowMeasurement, entries)}
+	return &gridRowMeasurements{sizes: sizes, gap: gap}
 }
 
 func (m *gridRowMeasurements) get(start, end int) gridRowMeasurement {
+	// Empty and singleton rows take constant time to measure. In particular,
+	// a grid with one row per object should not allocate a large row cache.
+	if end-start <= 1 {
+		return m.measure(start, end)
+	}
+	if m.cache == nil {
+		// Bound the cache independently of diagram size; collisions only cause
+		// recomputation. Small diagrams fit without collisions.
+		const maxEntries = 32 * 1024
+		entries := 1
+		for entries < maxEntries && entries/len(m.sizes) < len(m.sizes) {
+			entries *= 2
+		}
+		m.cache = make([]gridRowMeasurement, entries)
+	}
 	slot := (uint(start)*uint(len(m.sizes)) + uint(end)) & uint(len(m.cache)-1)
 	cached := &m.cache[slot]
 	if cached.start == start && cached.end == end {
 		return *cached
 	}
+	*cached = m.measure(start, end)
+	return *cached
+}
+
+func (m *gridRowMeasurements) measure(start, end int) gridRowMeasurement {
 	size, withGap := 0., 0.
 	for _, v := range m.sizes[start:end] {
 		size += v
@@ -38,8 +51,7 @@ func (m *gridRowMeasurements) get(start, end int) gridRowMeasurement {
 	if start < end {
 		withGap -= m.gap
 	}
-	*cached = gridRowMeasurement{start: start, end: end, size: size, withGap: withGap}
-	return *cached
+	return gridRowMeasurement{start: start, end: end, size: size, withGap: withGap}
 }
 
 // The division and row checks run in their original order, including repeated

--- a/d2layouts/d2grid/grid_search_test.go
+++ b/d2layouts/d2grid/grid_search_test.go
@@ -1,0 +1,160 @@
+package d2grid
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"reflect"
+	"testing"
+
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/lib/geo"
+)
+
+func TestGridSearchMatchesReference(t *testing.T) {
+	rng := rand.New(rand.NewPCG(17, 53))
+	for fixture := 0; fixture < 120; fixture++ {
+		n := 2 + rng.IntN(16)
+		gd := benchmarkGrid(n, 1+rng.IntN(n))
+		gd.columns = gd.rows
+		gd.horizontalGap = rng.IntN(80)
+		gd.verticalGap = rng.IntN(80)
+		for _, o := range gd.objects {
+			// Fractional sizes are common for nested shapes. Keep the original
+			// addition order, including when widths differ by several magnitudes.
+			o.Width = (float64(rng.IntN(1000)) + rng.Float64()) / 7
+			o.Height = (float64(rng.IntN(1000)) + rng.Float64()) / 3
+			if fixture%7 == 0 {
+				o.Width *= 1e12
+			}
+		}
+		for _, columns := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%d/columns=%v", fixture, columns), func(t *testing.T) {
+				assertSearchMatchesReference(t, gd, columns)
+			})
+		}
+	}
+	// The larger cases exercise the candidate and skipped-partition limits,
+	// where changing traversal order would change the chosen layout.
+	for _, tc := range []struct{ n, rows int }{{50, 8}, {100, 10}, {400, 20}} {
+		if testing.Short() && tc.n == 400 {
+			continue
+		}
+		t.Run(fmt.Sprintf("bounded_%d_%d", tc.n, tc.rows), func(t *testing.T) {
+			assertSearchMatchesReference(t, benchmarkGrid(tc.n, tc.rows), false)
+		})
+	}
+}
+
+func assertSearchMatchesReference(t *testing.T, gd *gridDiagram, columns bool) {
+	t.Helper()
+	target := gridTarget(gd, columns)
+	got := gd.getBestLayout(target, columns)
+	want := gd.referenceBestLayout(target, columns)
+	if !reflect.DeepEqual(got, want) {
+		ids := func(layout [][]*d2graph.Object) [][]string {
+			result := make([][]string, len(layout))
+			for i, row := range layout {
+				for _, o := range row {
+					result[i] = append(result[i], o.ID)
+				}
+			}
+			return result
+		}
+		t.Fatalf("layout = %v, want %v", ids(got), ids(want))
+	}
+}
+
+func gridTarget(gd *gridDiagram, columns bool) float64 {
+	var total float64
+	for _, o := range gd.objects {
+		if columns {
+			total += o.Height
+		} else {
+			total += o.Width
+		}
+	}
+	if columns {
+		return (total + float64(gd.verticalGap*(len(gd.objects)-gd.columns))) / float64(gd.columns)
+	}
+	return (total + float64(gd.horizontalGap*(len(gd.objects)-gd.rows))) / float64(gd.rows)
+}
+
+func TestGridDivisionTraversalMatchesReference(t *testing.T) {
+	type event struct {
+		start, end int
+		starting   bool
+		cuts       []int
+	}
+	for n := 2; n <= 12; n++ {
+		objects := make([]*d2graph.Object, n)
+		for i := range objects {
+			objects[i] = &d2graph.Object{Box: geo.NewBox(geo.NewPoint(0, 0), float64(i), 1)}
+		}
+		for cuts := 1; cuts < n; cuts++ {
+			for _, stop := range []int{1, 5, 1000} {
+				run := func(optimized bool) []event {
+					events := []event{}
+					attempts := 0
+					checked := 0
+					accept := func(start, end int, starting bool) bool {
+						events = append(events, event{start: start, end: end, starting: starting})
+						checked++
+						return checked%7 != 0 || checked > 100
+					}
+					callback := func(division []int) bool {
+						events = append(events, event{cuts: append([]int(nil), division...)})
+						attempts++
+						return attempts >= stop
+					}
+					if optimized {
+						iterDivisions(n, cuts, callback, accept)
+					} else {
+						referenceIterDivisions(objects, cuts, callback, func(row []*d2graph.Object, starting bool) bool {
+							start := int(row[0].Width)
+							return accept(start, start+len(row), starting)
+						})
+					}
+					return events
+				}
+				got, want := run(true), run(false)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("different traversal for objects=%d cuts=%d stop=%d", n, cuts, stop)
+				}
+			}
+		}
+	}
+}
+
+func TestGridRowMeasurementsPreserveAdditionOrder(t *testing.T) {
+	rng := rand.New(rand.NewPCG(39, 81))
+	sizes := make([]float64, 400)
+	for i := range sizes {
+		sizes[i] = rng.Float64() * 100
+		if i%31 == 0 {
+			sizes[i] *= 1e15
+		}
+	}
+	for _, gap := range []float64{0, 0.1, 40, 1000} {
+		measurements := newGridRowMeasurements(sizes, gap)
+		// Repeated and colliding entries must have exactly the same bits as a
+		// fresh left-to-right calculation, independent of previous accesses.
+		for iteration := 0; iteration < 10000; iteration++ {
+			start := rng.IntN(len(sizes))
+			end := start + 1 + rng.IntN(len(sizes)-start)
+			got := measurements.get(start, end)
+			var size, withGap float64
+			for _, v := range sizes[start:end] {
+				size += v
+				withGap += v + gap
+			}
+			withGap -= gap
+			if math.Float64bits(got.size) != math.Float64bits(size) || math.Float64bits(got.withGap) != math.Float64bits(withGap) {
+				t.Fatalf("row [%d:%d] differs: %+v, want %v/%v", start, end, got, size, withGap)
+			}
+		}
+	}
+	if got := len(newGridRowMeasurements(make([]float64, 100000), 40).cache); got != 32*1024 {
+		t.Fatalf("large grid cache has %d entries, want 32768", got)
+	}
+}

--- a/d2layouts/d2grid/grid_search_test.go
+++ b/d2layouts/d2grid/grid_search_test.go
@@ -154,7 +154,52 @@ func TestGridRowMeasurementsPreserveAdditionOrder(t *testing.T) {
 			}
 		}
 	}
-	if got := len(newGridRowMeasurements(make([]float64, 100000), 40).cache); got != 32*1024 {
+	large := newGridRowMeasurements(make([]float64, 100000), 40)
+	large.get(0, 2)
+	if got := len(large.cache); got != 32*1024 {
 		t.Fatalf("large grid cache has %d entries, want 32768", got)
+	}
+}
+
+func TestGridSingletonMeasurementsDoNotAllocateCache(t *testing.T) {
+	values := []float64{0, math.Copysign(0, -1), math.SmallestNonzeroFloat64, 0.1, 99.99, 1e20}
+	for _, gap := range []float64{0, 0.1, 40, 1e20} {
+		measurements := newGridRowMeasurements(values, gap)
+		for start := range values {
+			for _, end := range []int{start, start + 1} {
+				got := measurements.get(start, end)
+				var size, withGap float64
+				for _, value := range values[start:end] {
+					size += value
+					withGap += value + gap
+				}
+				if start < end {
+					withGap -= gap
+				}
+				if math.Float64bits(got.size) != math.Float64bits(size) || math.Float64bits(got.withGap) != math.Float64bits(withGap) {
+					t.Fatalf("row [%d:%d], gap %v differs: %+v, want %v/%v", start, end, gap, got, size, withGap)
+				}
+			}
+		}
+		if measurements.cache != nil {
+			t.Fatal("empty and singleton measurements allocated a cache")
+		}
+		if allocations := testing.AllocsPerRun(100, func() {
+			measurements.get(0, 0)
+			measurements.get(0, 1)
+		}); allocations != 0 {
+			t.Fatalf("empty and singleton measurements allocated %v times", allocations)
+		}
+		// The first longer row still enables the bounded cache.
+		measurements.get(0, 2)
+		if measurements.cache == nil {
+			t.Fatal("multi-object measurement did not allocate its cache")
+		}
+	}
+	for _, n := range []int{100, 400} {
+		gd := benchmarkGrid(n, n)
+		gd.columns = n
+		assertSearchMatchesReference(t, gd, false)
+		assertSearchMatchesReference(t, gd, true)
 	}
 }

--- a/d2layouts/d2grid/layout.go
+++ b/d2layouts/d2grid/layout.go
@@ -595,28 +595,27 @@ func (gd *gridDiagram) getBestLayout(targetSize float64, columns bool) [][]*d2gr
 	count := 0
 	// quickly eliminate bad row groupings
 	startingCache := make(map[int]bool)
+	measurements := newGridRowMeasurements(sizes, gap)
 	// Note: we want a low threshold to explore good options within attemptLimit,
 	// but the best option may require a few rows that are far from the target size.
 	okThreshold := STARTING_THRESHOLD
-	rowOk := func(row []*d2graph.Object, starting bool) (ok bool) {
+	rowOk := func(start, end int, starting bool) (ok bool) {
+		n := end - start
 		if starting {
 			// we can cache results from starting positions since they repeat and don't change
-			// with starting=true it will always be the 1st N objects based on len(row)
-			if ok, has := startingCache[len(row)]; has {
+			// with starting=true it will always be the first n objects
+			if ok, has := startingCache[n]; has {
 				return ok
 			}
 			defer func() {
 				// cache result before returning
-				startingCache[len(row)] = ok
+				startingCache[n] = ok
 			}()
 		}
 
-		rowSize := 0.
-		for _, obj := range row {
-			rowSize += getSize(obj)
-		}
-		if len(row) > 1 {
-			rowSize += gap * float64(len(row)-1)
+		rowSize := measurements.get(start, end).size
+		if n > 1 {
+			rowSize += gap * float64(n-1)
 			// if multiple nodes are too big, it isn't ok. but a single node can't shrink so only check here
 			if rowSize > okThreshold*targetSize {
 				skipCount++
@@ -642,15 +641,23 @@ func (gd *gridDiagram) getBestLayout(targetSize float64, columns bool) [][]*d2gr
 	// .       A │ B │ C   D   E                                  └────────────┘
 	// of these divisions, find the layout with rows closest to the targetSize
 	tryDivision := func(division []int) bool {
-		layout := GenLayout(gd.objects, division)
-		dist := getDistToTarget(layout, targetSize, float64(gd.horizontalGap), float64(gd.verticalGap), columns)
+		dist := 0.
+		start := 0
+		for i := 0; i <= len(division); i++ {
+			end := len(gd.objects)
+			if i < len(division) {
+				end = division[i] + 1
+			}
+			dist += math.Abs(measurements.get(start, end).withGap - targetSize)
+			start = end
+		}
 		if dist < bestDist {
-			bestLayout = layout
+			bestLayout = GenLayout(gd.objects, division)
 			bestDist = dist
 			fastIsBest = false
 		} else if fastIsBest && dist == bestDist {
 			// prefer ordered search solution to fast layout solution
-			bestLayout = layout
+			bestLayout = GenLayout(gd.objects, division)
 			fastIsBest = false
 		}
 		count++
@@ -668,7 +675,7 @@ func (gd *gridDiagram) getBestLayout(targetSize float64, columns bool) [][]*d2gr
 	for i := 0; i < thresholdAttempts || bestLayout == nil; i++ {
 		count = 0.
 		skipCount = 0.
-		iterDivisions(gd.objects, nCuts, tryDivision, rowOk)
+		iterDivisions(len(gd.objects), nCuts, tryDivision, rowOk)
 		okThreshold += THRESHOLD_STEP_SIZE
 		startingCache = make(map[int]bool)
 		if skipCount == 0 {
@@ -761,64 +768,6 @@ func (gd *gridDiagram) fastLayout(targetSize float64, nCuts int, columns bool) (
 	}
 
 	return layout
-}
-
-// process current division, return true to stop iterating
-type iterDivision func(division []int) (done bool)
-type checkCut func(objects []*d2graph.Object, starting bool) (ok bool)
-
-// get all possible divisions of objects by the number of cuts
-func iterDivisions(objects []*d2graph.Object, nCuts int, f iterDivision, check checkCut) {
-	if len(objects) < 2 || nCuts == 0 {
-		return
-	}
-	done := false
-	// we go in this order to prefer extra objects in starting rows rather than later ones
-	lastObj := len(objects) - 1
-	// with objects=[A, B, C, D, E]; nCuts=2
-	// d:depth; i:index; n:nCuts;
-	// ┌────┬───┬───┬─────────────────────┬────────────┐
-	// │ d  │ i │ n │ objects             │ cuts       │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ 0  │ 4 │ 2 │ [A   B   C   D | E] │            │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 3 │ 1 │ [A   B   C | D]     │ + | E]     │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 2 │ 1 │ [A   B | C   D]     │ + | E]     │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 1 │ 1 │ [A | B   C   D]     │ + | E]     │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ 0  │ 3 │ 2 │ [A   B   C | D   E] │            │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 2 │ 1 │ [A   B | C]         │ + | D E]   │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 1 │ 1 │ [A | B   C]         │ + | D E]   │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ 0  │ 2 │ 2 │ [A   B | C   D   E] │            │
-	// ├────┼───┼───┼─────────────────────┼────────────┤
-	// │ └1 │ 1 │ 1 │ [A | B]             │ + | C D E] │
-	// └────┴───┴───┴─────────────────────┴────────────┘
-	for index := lastObj; index >= nCuts; index-- {
-		if !check(objects[index:], false) {
-			// optimization: if current cut gives a bad grouping, don't recurse
-			continue
-		}
-		if nCuts > 1 {
-			iterDivisions(objects[:index], nCuts-1, func(inner []int) bool {
-				done = f(append(inner, index-1))
-				return done
-			}, check)
-		} else {
-			if !check(objects[:index], true) {
-				// e.g. [A   B   C | D] if [A,B,C] is bad, skip it
-				continue
-			}
-			done = f([]int{index - 1})
-		}
-		if done {
-			return
-		}
-	}
 }
 
 // generate a grid of objects from the given cut indices

--- a/d2layouts/d2grid/performance_test.go
+++ b/d2layouts/d2grid/performance_test.go
@@ -1,0 +1,35 @@
+package d2grid
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/lib/geo"
+)
+
+func benchmarkGrid(n, rows int) *gridDiagram {
+	gd := &gridDiagram{rows: rows, horizontalGap: 40, verticalGap: 40}
+	for i := 0; i < n; i++ {
+		gd.objects = append(gd.objects, &d2graph.Object{ID: fmt.Sprintf("n%d", i), Box: geo.NewBox(geo.NewPoint(0, 0), float64(50+(i*37)%200), float64(40+(i*53)%100))})
+	}
+	return gd
+}
+
+func BenchmarkDynamicGridSearch(b *testing.B) {
+	for _, tc := range []struct{ n, rows int }{{20, 4}, {50, 8}, {100, 10}, {400, 20}} {
+		b.Run(fmt.Sprintf("%d_objects_%d_rows", tc.n, tc.rows), func(b *testing.B) {
+			gd := benchmarkGrid(tc.n, tc.rows)
+			target := float64(gd.horizontalGap * (tc.n - tc.rows))
+			for _, o := range gd.objects {
+				target += o.Width
+			}
+			target /= float64(tc.rows)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				gd.getBestLayout(target, false)
+			}
+		})
+	}
+}

--- a/d2layouts/d2grid/search_reference_test.go
+++ b/d2layouts/d2grid/search_reference_test.go
@@ -1,0 +1,200 @@
+package d2grid
+
+import (
+	"math"
+
+	"github.com/d2lang/d2/d2graph"
+)
+
+// Frozen pre-optimization search, used as an exact compatibility oracle.
+func (gd *gridDiagram) referenceBestLayout(targetSize float64, columns bool) [][]*d2graph.Object {
+	var nCuts int
+	if columns {
+		nCuts = gd.columns - 1
+	} else {
+		nCuts = gd.rows - 1
+	}
+	if nCuts == 0 {
+		return GenLayout(gd.objects, nil)
+	}
+
+	var bestLayout [][]*d2graph.Object
+	bestDist := math.MaxFloat64
+	fastIsBest := false
+	// try fast layout algorithm as a baseline
+	if fastLayout := gd.fastLayout(targetSize, nCuts, columns); fastLayout != nil {
+		dist := getDistToTarget(fastLayout, targetSize, float64(gd.horizontalGap), float64(gd.verticalGap), columns)
+		if dist == 0 {
+			return fastLayout
+		}
+		bestDist = dist
+		bestLayout = fastLayout
+		fastIsBest = true
+	}
+
+	var gap float64
+	if columns {
+		gap = float64(gd.verticalGap)
+	} else {
+		gap = float64(gd.horizontalGap)
+	}
+	getSize := func(o *d2graph.Object) float64 {
+		if columns {
+			return o.Height
+		} else {
+			return o.Width
+		}
+	}
+
+	sizes := []float64{}
+	for _, obj := range gd.objects {
+		size := getSize(obj)
+		sizes = append(sizes, size)
+	}
+	sd := stddev(sizes)
+
+	skipCount := 0
+	count := 0
+	// quickly eliminate bad row groupings
+	startingCache := make(map[int]bool)
+	// Note: we want a low threshold to explore good options within attemptLimit,
+	// but the best option may require a few rows that are far from the target size.
+	okThreshold := STARTING_THRESHOLD
+	rowOk := func(row []*d2graph.Object, starting bool) (ok bool) {
+		if starting {
+			// we can cache results from starting positions since they repeat and don't change
+			// with starting=true it will always be the 1st N objects based on len(row)
+			if ok, has := startingCache[len(row)]; has {
+				return ok
+			}
+			defer func() {
+				// cache result before returning
+				startingCache[len(row)] = ok
+			}()
+		}
+
+		rowSize := 0.
+		for _, obj := range row {
+			rowSize += getSize(obj)
+		}
+		if len(row) > 1 {
+			rowSize += gap * float64(len(row)-1)
+			// if multiple nodes are too big, it isn't ok. but a single node can't shrink so only check here
+			if rowSize > okThreshold*targetSize {
+				skipCount++
+				// there may even be too many to skip
+				return skipCount >= SKIP_LIMIT
+			}
+		}
+		// row is too small to be good overall
+		if rowSize < targetSize/okThreshold {
+			skipCount++
+			return skipCount >= SKIP_LIMIT
+		}
+		return true
+	}
+
+	// get all options for where to place these cuts, preferring later cuts over earlier cuts
+	// with 5 objects and 2 cuts we have these options:
+	// .       A   B   C │ D │ E     <- these cuts would produce: ┌A─┐ ┌B─┐ ┌C─┐
+	// .       A   B │ C   D │ E                                  └──┘ └──┘ └──┘
+	// .       A │ B   C   D │ E                                  ┌D───────────┐
+	// .       A   B │ C │ D   E                                  └────────────┘
+	// .       A │ B   C │ D   E                                  ┌E───────────┐
+	// .       A │ B │ C   D   E                                  └────────────┘
+	// of these divisions, find the layout with rows closest to the targetSize
+	tryDivision := func(division []int) bool {
+		layout := GenLayout(gd.objects, division)
+		dist := getDistToTarget(layout, targetSize, float64(gd.horizontalGap), float64(gd.verticalGap), columns)
+		if dist < bestDist {
+			bestLayout = layout
+			bestDist = dist
+			fastIsBest = false
+		} else if fastIsBest && dist == bestDist {
+			// prefer ordered search solution to fast layout solution
+			bestLayout = layout
+			fastIsBest = false
+		}
+		count++
+		// with few objects we can try all options to get best result but this won't scale, so only try up to 100k options
+		return count >= ATTEMPT_LIMIT || skipCount >= SKIP_LIMIT
+	}
+
+	// try number of different okThresholds depending on std deviation of sizes
+	thresholdAttempts := int(math.Ceil(sd))
+	if thresholdAttempts < MIN_THRESHOLD_ATTEMPTS {
+		thresholdAttempts = MIN_THRESHOLD_ATTEMPTS
+	} else if thresholdAttempts > MAX_THRESHOLD_ATTEMPTS {
+		thresholdAttempts = MAX_THRESHOLD_ATTEMPTS
+	}
+	for i := 0; i < thresholdAttempts || bestLayout == nil; i++ {
+		count = 0.
+		skipCount = 0.
+		referenceIterDivisions(gd.objects, nCuts, tryDivision, rowOk)
+		okThreshold += THRESHOLD_STEP_SIZE
+		startingCache = make(map[int]bool)
+		if skipCount == 0 {
+			// threshold isn't skipping anything so increasing it won't help
+			break
+		}
+		// okThreshold isn't high enough yet, we skipped every option so don't count it
+		if count == 0 && thresholdAttempts < MAX_THRESHOLD_ATTEMPTS {
+			thresholdAttempts++
+		}
+	}
+
+	return bestLayout
+}
+
+func referenceIterDivisions(objects []*d2graph.Object, nCuts int, f iterDivision, check func([]*d2graph.Object, bool) bool) {
+	if len(objects) < 2 || nCuts == 0 {
+		return
+	}
+	done := false
+	// we go in this order to prefer extra objects in starting rows rather than later ones
+	lastObj := len(objects) - 1
+	// with objects=[A, B, C, D, E]; nCuts=2
+	// d:depth; i:index; n:nCuts;
+	// ┌────┬───┬───┬─────────────────────┬────────────┐
+	// │ d  │ i │ n │ objects             │ cuts       │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ 0  │ 4 │ 2 │ [A   B   C   D | E] │            │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 3 │ 1 │ [A   B   C | D]     │ + | E]     │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 2 │ 1 │ [A   B | C   D]     │ + | E]     │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 1 │ 1 │ [A | B   C   D]     │ + | E]     │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ 0  │ 3 │ 2 │ [A   B   C | D   E] │            │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 2 │ 1 │ [A   B | C]         │ + | D E]   │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 1 │ 1 │ [A | B   C]         │ + | D E]   │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ 0  │ 2 │ 2 │ [A   B | C   D   E] │            │
+	// ├────┼───┼───┼─────────────────────┼────────────┤
+	// │ └1 │ 1 │ 1 │ [A | B]             │ + | C D E] │
+	// └────┴───┴───┴─────────────────────┴────────────┘
+	for index := lastObj; index >= nCuts; index-- {
+		if !check(objects[index:], false) {
+			// optimization: if current cut gives a bad grouping, don't recurse
+			continue
+		}
+		if nCuts > 1 {
+			referenceIterDivisions(objects[:index], nCuts-1, func(inner []int) bool {
+				done = f(append(inner, index-1))
+				return done
+			}, check)
+		} else {
+			if !check(objects[:index], true) {
+				// e.g. [A   B   C | D] if [A,B,C] is bad, skip it
+				continue
+			}
+			done = f([]int{index - 1})
+		}
+		if done {
+			return
+		}
+	}
+}

--- a/d2renderers/d2raster/effects.go
+++ b/d2renderers/d2raster/effects.go
@@ -334,6 +334,16 @@ func planNodeResources(ctx context.Context, node *preparedNode, dst image.Rectan
 
 	usesFilters := len(node.filters) != 0
 	usesEffectLayer := node.isolated || node.opacity < 1 || node.blend != d2scene.BlendNormal || usesFilters || node.clip != nil || node.mask != nil
+	if planner.regionFilters && usesEffectLayer && !usesFilters {
+		var err error
+		visibleBounds, err = effectRenderBounds(ctx, node, dst)
+		if err != nil {
+			return resources, err
+		}
+		if visibleBounds.Empty() {
+			return resources, nil
+		}
+	}
 	baseBytes := int64(0)
 	finalLayerBytes := int64(0)
 	paintBounds := dst
@@ -440,11 +450,15 @@ func planNodeResources(ctx context.Context, node *preparedNode, dst image.Rectan
 	}
 
 	if node.mask != nil {
-		maskBytes, err := pixelStorageBytes(visibleBounds, 4)
+		maskBounds, err := maskRenderBounds(ctx, node.mask, visibleBounds, planner.regionFilters)
+		if err != nil {
+			return resources, err
+		}
+		maskBytes, err := pixelStorageBytes(maskBounds, 4)
 		if err != nil {
 			return resources, fmt.Errorf("d2raster: scene mask: %w", err)
 		}
-		maskResources, err := planNodeResources(ctx, node.mask.root, visibleBounds, planner)
+		maskResources, err := planNodeResources(ctx, node.mask.root, maskBounds, planner)
 		if err != nil {
 			return resources, err
 		}
@@ -663,6 +677,13 @@ func renderEffectNode(ctx context.Context, dst *image.RGBA, node *preparedNode, 
 		return renderFilteredEffectNode(ctx, dst, node, scratch)
 	}
 	bounds := node.bounds.Intersect(dst.Bounds())
+	if scratch.regionFilters {
+		var err error
+		bounds, err = effectRenderBounds(ctx, node, dst.Bounds())
+		if err != nil {
+			return err
+		}
+	}
 	if bounds.Empty() {
 		return nil
 	}
@@ -1069,7 +1090,17 @@ func multiplyLayerByAlpha(ctx context.Context, layer *image.RGBA, mask *image.Al
 }
 
 func applyMask(ctx context.Context, layer *image.RGBA, mask *preparedMask, scratch *rasterScratch) error {
-	maskLayer, maskBytes, err := scratch.offscreen.newRGBA(layer.Bounds(), "scene mask RGBA layer")
+	bounds, err := maskRenderBounds(ctx, mask, layer.Bounds(), scratch.regionFilters)
+	if err != nil {
+		return err
+	}
+	if bounds.Empty() {
+		return ctx.Err()
+	}
+	if bounds != layer.Bounds() {
+		layer = layer.SubImage(bounds).(*image.RGBA)
+	}
+	maskLayer, maskBytes, err := scratch.offscreen.newRGBA(bounds, "scene mask RGBA layer")
 	if err != nil {
 		return err
 	}

--- a/d2renderers/d2raster/geometry.go
+++ b/d2renderers/d2raster/geometry.go
@@ -482,6 +482,10 @@ func drawStroke(ctx context.Context, dst *image.RGBA, runs []strokeRun, transfor
 }
 
 func paintedStrokePixelBounds(runs []strokeRun, transform d2scene.Matrix, stroke *preparedStroke, canvas image.Rectangle) image.Rectangle {
+	return strokeRunPixelBounds(runs, transform, strokeExtent(stroke, transform), canvas)
+}
+
+func strokeExtent(stroke *preparedStroke, transform d2scene.Matrix) float64 {
 	expansion := stroke.width * transform.MaxScale() / 2
 	factor := 1.0
 	if stroke.cap == d2scene.CapSquare {
@@ -490,7 +494,7 @@ func paintedStrokePixelBounds(runs []strokeRun, transform d2scene.Matrix, stroke
 	if stroke.join == d2scene.JoinMiter && stroke.miterLimit > factor {
 		factor = stroke.miterLimit
 	}
-	return strokeRunPixelBounds(runs, transform, expansion*factor, canvas)
+	return expansion * factor
 }
 
 func strokeRunPixelBounds(runs []strokeRun, transform d2scene.Matrix, expansion float64, canvas image.Rectangle) image.Rectangle {

--- a/d2renderers/d2raster/mask_regions.go
+++ b/d2renderers/d2raster/mask_regions.go
@@ -1,0 +1,95 @@
+package d2raster
+
+import (
+	"context"
+	"image"
+	"math"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+// maskRenderBounds omits the unchanged white area of a luminance mask whose
+// first child is an opaque rectangular backdrop. D2's connection-label mask
+// uses exactly this representation: a diagram-wide white rectangle followed by
+// small label cutouts. Rendering that white area for every connection would
+// otherwise scale with the connections' bounding-box areas.
+//
+// Reference-coordinate rendering is required because a smaller destination
+// must not change the float32 rounding of antialiased mask geometry. Complete
+// frames retain their existing path; band rendering already supplies stable
+// reference origins for every node, including masks.
+func maskRenderBounds(ctx context.Context, mask *preparedMask, destination image.Rectangle, referenceCoordinates bool) (image.Rectangle, error) {
+	if err := ctx.Err(); err != nil {
+		return image.Rectangle{}, err
+	}
+	if !referenceCoordinates || mask == nil || mask.kind != d2scene.MaskLuminance || !plainMaskNode(mask.root) || mask.root.primitive != nil || len(mask.root.children) == 0 {
+		return destination, nil
+	}
+	base := mask.root.children[0]
+	if !plainMaskNode(base) || len(base.children) != 0 || base.primitive == nil {
+		return destination, nil
+	}
+	primitive := base.primitive
+	if primitive.fill == nil || primitive.fill.kind != preparedSolidPaint || primitive.fill.solid.R != 255 || primitive.fill.solid.G != 255 || primitive.fill.solid.B != 255 || primitive.fill.solid.A != 255 || primitive.stroke != nil || primitive.image != nil || primitive.vector != nil || len(primitive.subpaths) != 1 {
+		return destination, nil
+	}
+	if math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 {
+		return destination, nil
+	}
+	points := primitive.subpaths[0].points
+	if len(points) != 4 {
+		return destination, nil
+	}
+	var corners [4]d2scene.Point
+	minX, minY := math.Inf(1), math.Inf(1)
+	maxX, maxY := math.Inf(-1), math.Inf(-1)
+	for index, point := range points {
+		point = primitive.transform.Point(point)
+		// The one-pixel inset below is deliberately conservative. Within this
+		// coordinate range float32 endpoint rounding cannot consume the inset.
+		if !finitePoint(point) || math.Abs(point.X) > 1<<20 || math.Abs(point.Y) > 1<<20 {
+			return destination, nil
+		}
+		corners[index] = point
+		minX, minY = min(minX, point.X), min(minY, point.Y)
+		maxX, maxY = max(maxX, point.X), max(maxY, point.Y)
+	}
+	seenCorners := uint8(0)
+	for index, point := range corners {
+		next := corners[(index+1)%len(corners)]
+		if point.X != minX && point.X != maxX || point.Y != minY && point.Y != maxY || point == next || (point.X == next.X) == (point.Y == next.Y) {
+			return destination, nil
+		}
+		corner := uint8(0)
+		if point.X == maxX {
+			corner |= 1
+		}
+		if point.Y == maxY {
+			corner |= 2
+		}
+		seenCorners |= 1 << corner
+	}
+	if seenCorners != 0xf {
+		return destination, nil
+	}
+	interior := image.Rect(int(math.Ceil(minX))+1, int(math.Ceil(minY))+1, int(math.Floor(maxX))-1, int(math.Floor(maxY))-1)
+	if !destination.In(interior) {
+		return destination, nil
+	}
+	var changed image.Rectangle
+	for index, child := range mask.root.children[1:] {
+		if index&255 == 0 {
+			if err := ctx.Err(); err != nil {
+				return image.Rectangle{}, err
+			}
+		}
+		if child != nil && child.opacity != 0 {
+			changed = unionRect(changed, child.bounds.Intersect(destination))
+		}
+	}
+	return changed, nil
+}
+
+func plainMaskNode(node *preparedNode) bool {
+	return node != nil && node.opacity == 1 && node.blend == d2scene.BlendNormal && !node.isolated && len(node.filters) == 0 && node.clip == nil && node.mask == nil
+}

--- a/d2renderers/d2raster/mask_regions.go
+++ b/d2renderers/d2raster/mask_regions.go
@@ -33,7 +33,9 @@ func maskRenderBounds(ctx context.Context, mask *preparedMask, destination image
 	if primitive.fill == nil || primitive.fill.kind != preparedSolidPaint || primitive.fill.solid.R != 255 || primitive.fill.solid.G != 255 || primitive.fill.solid.B != 255 || primitive.fill.solid.A != 255 || primitive.stroke != nil || primitive.image != nil || primitive.vector != nil || len(primitive.subpaths) != 1 {
 		return destination, nil
 	}
-	if math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 {
+	// A large translation that cancels local coordinates can round differently
+	// when the renderer subtracts its reference origin before transformation.
+	if math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 || !boundedRegionPoint(d2scene.Point{X: primitive.transform.E, Y: primitive.transform.F}) {
 		return destination, nil
 	}
 	points := primitive.subpaths[0].points

--- a/d2renderers/d2raster/mask_regions_test.go
+++ b/d2renderers/d2raster/mask_regions_test.go
@@ -1,0 +1,142 @@
+package d2raster
+
+import (
+	"context"
+	"errors"
+	"image"
+	"image/color"
+	"image/draw"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+func regionMaskDocument() *d2scene.Document {
+	mask := d2scene.NewNode(nil)
+	mask.Children = []*d2scene.Node{
+		d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: -20, Y: -20, Width: 240, Height: 940}, Fill: d2scene.SolidPaint{Color: color.NRGBA{R: 255, G: 255, B: 255, A: 255}}}),
+		d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 50.13, Y: 57.71, Width: 39.47, Height: 21.39}, Fill: black}),
+	}
+	node := d2scene.NewNode(d2scene.Rect{Box: d2scene.Box{X: 10, Y: 10, Width: 180, Height: 880}, Fill: d2scene.SolidPaint{Color: color.NRGBA{R: 211, G: 103, B: 51, A: 173}}})
+	node.Mask = &d2scene.Mask{Root: mask, Type: d2scene.MaskLuminance, Transform: d2scene.Identity()}
+	return d2scene.NewDocument(d2scene.Box{Width: 200, Height: 900}, node)
+}
+
+func TestMaskRenderBoundsAdmission(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func(*d2scene.Document)
+		cropped bool
+	}{
+		{name: "white backdrop", cropped: true},
+		{name: "root translation", cropped: true, mutate: func(d *d2scene.Document) { d.Root.Mask.Root.Transform = d2scene.Translate(.125, .375) }},
+		{name: "root opacity", mutate: func(d *d2scene.Document) { d.Root.Mask.Root.Opacity = .9 }},
+		{name: "root blend", mutate: func(d *d2scene.Document) { d.Root.Mask.Root.Blend = d2scene.BlendMultiply }},
+		{name: "root filter", mutate: func(d *d2scene.Document) {
+			d.Root.Mask.Root.Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaY: 1}}
+		}},
+		{name: "base opacity", mutate: func(d *d2scene.Document) { d.Root.Mask.Root.Children[0].Opacity = .9 }},
+		{name: "base filter", mutate: func(d *d2scene.Document) {
+			d.Root.Mask.Root.Children[0].Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaY: 1}}
+		}},
+		{name: "base stroke", mutate: func(d *d2scene.Document) {
+			p := d.Root.Mask.Root.Children[0].Primitive.(d2scene.Rect)
+			p.Stroke = &d2scene.Stroke{Paint: black, Width: 1, MiterLimit: 4}
+			d.Root.Mask.Root.Children[0].Primitive = p
+		}},
+		{name: "base dark", mutate: func(d *d2scene.Document) {
+			p := d.Root.Mask.Root.Children[0].Primitive.(d2scene.Rect)
+			p.Fill = black
+			d.Root.Mask.Root.Children[0].Primitive = p
+		}},
+		{name: "base shear", mutate: func(d *d2scene.Document) { d.Root.Mask.Root.Children[0].Transform = d2scene.Matrix{A: 1, D: 1, C: .13} }},
+		{name: "base degenerate corners", mutate: func(d *d2scene.Document) {
+			d.Root.Mask.Root.Children[0].Primitive = d2scene.Path{Fill: d2scene.SolidPaint{Color: color.NRGBA{R: 255, G: 255, B: 255, A: 255}}, Commands: []d2scene.PathCommand{d2scene.MoveTo(-20, -20), d2scene.LineTo(220, -20), d2scene.LineTo(-20, -20), d2scene.LineTo(-20, 920), d2scene.ClosePath()}}
+		}},
+		{name: "alpha mask", mutate: func(d *d2scene.Document) { d.Root.Mask.Type = d2scene.MaskAlpha }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			document := regionMaskDocument()
+			if test.mutate != nil {
+				test.mutate(document)
+			}
+			prepared, err := prepareWithSessionBands(context.Background(), document, testOptions(), nil, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destination := image.Rect(10, 10, 190, 150)
+			got, err := maskRenderBounds(context.Background(), prepared.root.mask, destination, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.cropped && (got.Empty() || got == destination) || !test.cropped && got != destination {
+				t.Fatalf("mask bounds=%v cropped=%v", got, test.cropped)
+			}
+		})
+	}
+}
+
+func TestMaskRegionsMatchFullFrame(t *testing.T) {
+	for _, effect := range []string{"plain", "opacity", "blur", "shadow", "nested", "clip", "mask", "root-transform"} {
+		t.Run(effect, func(t *testing.T) {
+			document := regionMaskDocument()
+			hole := document.Root.Mask.Root.Children[1]
+			switch effect {
+			case "opacity":
+				hole.Opacity = .75
+			case "blur":
+				hole.Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaX: 2.37, SigmaY: 5.13}}
+			case "shadow":
+				hole.Filters = []d2scene.Filter{d2scene.DropShadow{OffsetX: -7.13, OffsetY: 23.71, SigmaX: 2.1, SigmaY: 3.7, Color: color.NRGBA{A: 197}}}
+			case "nested":
+				hole.Filters = []d2scene.Filter{d2scene.GaussianBlur{SigmaX: 3.1, SigmaY: 2.7}}
+				group := d2scene.NewNode(nil)
+				group.Opacity = .71
+				group.Children = []*d2scene.Node{hole}
+				document.Root.Mask.Root.Children[1] = group
+			case "clip":
+				hole.Clip = &d2scene.Clip{Transform: d2scene.Identity(), Path: d2scene.Path{Commands: []d2scene.PathCommand{d2scene.MoveTo(40, 40), d2scene.LineTo(90, 40), d2scene.LineTo(70, 100), d2scene.ClosePath()}}}
+			case "mask":
+				hole.Mask = &d2scene.Mask{Transform: d2scene.Identity(), Type: d2scene.MaskAlpha, Root: d2scene.NewNode(d2scene.Ellipse{Center: d2scene.Point{X: 70, Y: 70}, RadiusX: 12, RadiusY: 19, Fill: red})}
+			case "root-transform":
+				document.Root.Mask.Root.Transform = d2scene.Matrix{A: 1.1, D: .95, E: -.17, F: .71}
+			}
+			for _, scale := range []float64{.5, 1, 1.25} {
+				options := testOptions()
+				options.Scale = scale
+				options.MaxHeight = 1200
+				want, err := Render(context.Background(), document, options)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, height := range []int{1, 7, 64, 256} {
+					got := image.NewNRGBA(want.Bounds())
+					if err := RenderBands(context.Background(), document, options, height, func(b *image.NRGBA) error { draw.Draw(got, b.Bounds(), b, b.Bounds().Min, draw.Src); return nil }); err != nil {
+						t.Fatal(err)
+					}
+					assertBandPixels(t, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestMaskRegionsSkipUnchangedPixelsAndCancellation(t *testing.T) {
+	prepared, err := prepareWithSessionBands(context.Background(), regionMaskDocument(), testOptions(), nil, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bounds, err := maskRenderBounds(context.Background(), prepared.root.mask, image.Rect(10, 300, 190, 350), true)
+	if err != nil || !bounds.Empty() {
+		t.Fatalf("unchanged bounds=%v error=%v", bounds, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := maskRenderBounds(ctx, prepared.root.mask, image.Rect(10, 10, 190, 150), true); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation=%v", err)
+	}
+	bounds, err = maskRenderBounds(context.Background(), prepared.root.mask, image.Rect(-20, -20, 190, 150), true)
+	if err != nil || bounds != image.Rect(-20, -20, 190, 150) {
+		t.Fatalf("white backdrop edge bounds=%v error=%v", bounds, err)
+	}
+}

--- a/d2renderers/d2raster/region_numeric_test.go
+++ b/d2renderers/d2raster/region_numeric_test.go
@@ -1,0 +1,93 @@
+package d2raster
+
+import (
+	"context"
+	"image"
+	"image/draw"
+	"math"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+func TestStrokeRegionsIncludeLargeRotatedRoundCapsAndJoins(t *testing.T) {
+	for _, join := range []bool{false, true} {
+		commands := []d2scene.PathCommand{d2scene.MoveTo(0, 0), d2scene.LineTo(-100, 0)}
+		stroke := &d2scene.Stroke{Paint: red, Width: 20000, Cap: d2scene.CapRound, Join: d2scene.JoinBevel, MiterLimit: 4}
+		if join {
+			commands = []d2scene.PathCommand{d2scene.MoveTo(-100, -100), d2scene.LineTo(0, 0), d2scene.LineTo(-100, 0)}
+			stroke.Cap = d2scene.CapButt
+			stroke.Join = d2scene.JoinRound
+		}
+		// A distant run keeps the complete primitive's bounds broad enough that
+		// the rotated cubic's fringe is not clipped by the old full-frame bounds.
+		commands = append(commands, d2scene.MoveTo(100000, 0), d2scene.LineTo(100100, 0))
+		node := d2scene.NewNode(d2scene.Path{Commands: commands, Stroke: stroke})
+		node.Opacity = .73
+		angle := 20 * math.Pi / 180
+		node.Transform = d2scene.Matrix{A: math.Cos(angle), B: math.Sin(angle), C: -math.Sin(angle), D: math.Cos(angle)}
+		document := d2scene.NewDocument(d2scene.Box{X: -20, Y: 10000, Width: 40, Height: 8}, node)
+		options := testOptions()
+		want, err := Render(context.Background(), document, options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want.NRGBAAt(19, 2).A == 0 {
+			t.Fatalf("join=%v: missing reference cubic fringe", join)
+		}
+		got := image.NewNRGBA(want.Bounds())
+		if err := RenderBands(context.Background(), document, options, 1, func(b *image.NRGBA) error { draw.Draw(got, b.Bounds(), b, b.Bounds().Min, draw.Src); return nil }); err != nil {
+			t.Fatal(err)
+		}
+		assertBandPixels(t, got, want)
+	}
+}
+
+func TestStrokeRegionExtentEnclosesCircleControls(t *testing.T) {
+	const radius = 10000.0
+	const control = .5522847498307936
+	stroke := &preparedStroke{width: radius * 2, cap: d2scene.CapRound, join: d2scene.JoinBevel}
+	for _, matrix := range []d2scene.Matrix{d2scene.Identity(), {A: .9396926207859084, B: .3420201433256687, C: -.3420201433256687, D: .9396926207859084}, {A: 1.3, B: .2, C: -.7, D: .9}} {
+		extent := strokeRegionExtent(stroke, matrix)
+		for _, point := range []d2scene.Point{{X: radius, Y: radius * control}, {X: radius * control, Y: radius}, {X: -radius, Y: radius * control}, {X: -radius * control, Y: -radius}} {
+			transformed := matrix.Point(point)
+			if math.Abs(transformed.X) > extent || math.Abs(transformed.Y) > extent {
+				t.Fatalf("control%v exceeds extent%v", transformed, extent)
+			}
+		}
+	}
+	if got := strokeExtent(stroke, d2scene.Identity()); got != radius {
+		t.Fatalf("full-frame extent changed: %v", got)
+	}
+}
+
+func TestRegionBoundsRejectCancellingTransforms(t *testing.T) {
+	prepared, err := prepareWithSessionBands(context.Background(), regionMaskDocument(), testOptions(), nil, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mask := prepared.root.mask
+	base := mask.root.children[0].primitive
+	// Preserve finite, small transformed corners while introducing a huge
+	// intermediate translation. It must prevent the white-backdrop shortcut.
+	base.transform.E = 1e18
+	for i := range base.subpaths[0].points {
+		base.subpaths[0].points[i].X = -1e18 + base.subpaths[0].points[i].X
+	}
+	destination := image.Rect(20, 20, 180, 150)
+	got, err := maskRenderBounds(context.Background(), mask, destination, true)
+	if err != nil || got != destination {
+		t.Fatalf("mask fallback=%v error=%v", got, err)
+	}
+	primitive := &preparedPrimitive{bounds: destination, referenceBounds: destination, transform: d2scene.Translate(1e18, 0), stroke: &preparedStroke{width: 2, join: d2scene.JoinBevel}, strokeRuns: []strokeRun{{points: []d2scene.Point{{X: -1e18 + 512, Y: 30}, {X: -1e18 + 1024, Y: 30}}}}}
+	got, err = strokeRegionBounds(context.Background(), primitive, destination)
+	if err != nil || got != destination {
+		t.Fatalf("stroke fallback=%v error=%v", got, err)
+	}
+	if boundedStrokeLocalPoint(d2scene.Point{X: 1e18, Y: 1e18}, 2) {
+		t.Fatal("large cancelling local products admitted")
+	}
+	if !boundedStrokeLocalPoint(d2scene.Point{X: 100000, Y: -100000}, 4) {
+		t.Fatal("ordinary local coordinates rejected")
+	}
+}

--- a/d2renderers/d2raster/stroke_regions.go
+++ b/d2renderers/d2raster/stroke_regions.go
@@ -1,0 +1,115 @@
+package d2raster
+
+import (
+	"context"
+	"image"
+	"math"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+// effectRenderBounds tightens an effect layer around the actual stroke
+// segments crossing this destination. A long connection can have a wide full
+// frame bounding box while occupying only a narrow part of a horizontal band.
+// Fills and filtered nodes retain their established conservative bounds.
+func effectRenderBounds(ctx context.Context, node *preparedNode, destination image.Rectangle) (image.Rectangle, error) {
+	if err := ctx.Err(); err != nil {
+		return image.Rectangle{}, err
+	}
+	if node == nil || node.opacity == 0 {
+		return image.Rectangle{}, nil
+	}
+	visible := node.bounds.Intersect(destination)
+	if visible.Empty() || len(node.filters) != 0 {
+		return visible, nil
+	}
+	var bounds image.Rectangle
+	if primitive := node.primitive; primitive != nil {
+		if primitive.vector != nil {
+			var err error
+			bounds, err = effectRenderBounds(ctx, primitive.vector, visible)
+			if err != nil {
+				return image.Rectangle{}, err
+			}
+		} else if primitive.fill == nil && primitive.stroke != nil && primitive.image == nil {
+			var err error
+			bounds, err = strokeRegionBounds(ctx, primitive, visible)
+			if err != nil {
+				return image.Rectangle{}, err
+			}
+		} else {
+			bounds = primitive.bounds.Intersect(visible)
+		}
+	}
+	for _, child := range node.children {
+		childBounds, err := effectRenderBounds(ctx, child, visible)
+		if err != nil {
+			return image.Rectangle{}, err
+		}
+		bounds = unionRect(bounds, childBounds)
+	}
+	return bounds.Intersect(visible), nil
+}
+
+func strokeRegionBounds(ctx context.Context, primitive *preparedPrimitive, destination image.Rectangle) (image.Rectangle, error) {
+	fallback := primitive.bounds.Intersect(destination)
+	if fallback.Empty() || math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 {
+		return fallback, nil
+	}
+	expansion := strokeExtent(primitive.stroke, primitive.transform) + 1
+	if !finite(expansion) || expansion > 1<<20 {
+		return fallback, nil
+	}
+	minX, minY := math.Inf(1), math.Inf(1)
+	maxX, maxY := math.Inf(-1), math.Inf(-1)
+	lowerY := float64(destination.Min.Y) - expansion
+	upperY := float64(destination.Max.Y) + expansion
+	segments := 0
+	for _, run := range primitive.strokeRuns {
+		count := len(run.points) - 1
+		if run.closed {
+			count++
+		}
+		for index := 0; index < count; index++ {
+			if segments&255 == 0 {
+				if err := ctx.Err(); err != nil {
+					return image.Rectangle{}, err
+				}
+			}
+			segments++
+			from := primitive.transform.Point(run.points[index])
+			to := primitive.transform.Point(run.points[(index+1)%len(run.points)])
+			if !boundedRegionPoint(from) || !boundedRegionPoint(to) {
+				return fallback, nil
+			}
+			if max(from.Y, to.Y) < lowerY || min(from.Y, to.Y) > upperY {
+				continue
+			}
+			first, last := 0.0, 1.0
+			dx, dy := to.X-from.X, to.Y-from.Y
+			if dy != 0 {
+				t0, t1 := (lowerY-from.Y)/dy, (upperY-from.Y)/dy
+				first, last = max(0, min(t0, t1)), min(1, max(t0, t1))
+			}
+			x0, x1 := from.X+first*dx, from.X+last*dx
+			y0, y1 := from.Y+first*dy, from.Y+last*dy
+			minX, minY = min(minX, x0, x1), min(minY, y0, y1)
+			maxX, maxY = max(maxX, x0, x1), max(maxY, y0, y1)
+		}
+	}
+	if math.IsInf(minX, 1) {
+		return image.Rectangle{}, nil
+	}
+	minX = max(minX-expansion, float64(destination.Min.X))
+	minY = max(minY-expansion, float64(destination.Min.Y))
+	maxX = min(maxX+expansion, float64(destination.Max.X))
+	maxY = min(maxY+expansion, float64(destination.Max.Y))
+	if minX >= maxX || minY >= maxY {
+		return image.Rectangle{}, nil
+	}
+	return image.Rect(int(math.Floor(minX)), int(math.Floor(minY)), int(math.Ceil(maxX)), int(math.Ceil(maxY))).Intersect(destination), nil
+}
+
+func boundedRegionPoint(point d2scene.Point) bool {
+	return finitePoint(point) && math.Abs(point.X) <= 1<<20 && math.Abs(point.Y) <= 1<<20
+}

--- a/d2renderers/d2raster/stroke_regions.go
+++ b/d2renderers/d2raster/stroke_regions.go
@@ -53,10 +53,11 @@ func effectRenderBounds(ctx context.Context, node *preparedNode, destination ima
 
 func strokeRegionBounds(ctx context.Context, primitive *preparedPrimitive, destination image.Rectangle) (image.Rectangle, error) {
 	fallback := primitive.bounds.Intersect(destination)
-	if fallback.Empty() || math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 {
+	if fallback.Empty() || math.Abs(float64(primitive.referenceBounds.Min.X)) > 1<<20 || math.Abs(float64(primitive.referenceBounds.Min.Y)) > 1<<20 || !boundedRegionPoint(d2scene.Point{X: primitive.transform.E, Y: primitive.transform.F}) {
 		return fallback, nil
 	}
-	expansion := strokeExtent(primitive.stroke, primitive.transform) + 1
+	scale := primitive.transform.MaxScale()
+	expansion := strokeRegionExtent(primitive.stroke, primitive.transform) + 1
 	if !finite(expansion) || expansion > 1<<20 {
 		return fallback, nil
 	}
@@ -77,8 +78,13 @@ func strokeRegionBounds(ctx context.Context, primitive *preparedPrimitive, desti
 				}
 			}
 			segments++
-			from := primitive.transform.Point(run.points[index])
-			to := primitive.transform.Point(run.points[(index+1)%len(run.points)])
+			localFrom := run.points[index]
+			localTo := run.points[(index+1)%len(run.points)]
+			if !boundedStrokeLocalPoint(localFrom, scale) || !boundedStrokeLocalPoint(localTo, scale) {
+				return fallback, nil
+			}
+			from := primitive.transform.Point(localFrom)
+			to := primitive.transform.Point(localTo)
 			if !boundedRegionPoint(from) || !boundedRegionPoint(to) {
 				return fallback, nil
 			}
@@ -112,4 +118,23 @@ func strokeRegionBounds(ctx context.Context, primitive *preparedPrimitive, desti
 
 func boundedRegionPoint(point d2scene.Point) bool {
 	return finitePoint(point) && math.Abs(point.X) <= 1<<20 && math.Abs(point.Y) <= 1<<20
+}
+
+// addCircle uses cubic Beziers, whose control points lie outside the true
+// circle. Their convex hull remains a conservative envelope after any affine
+// transform; the true radius alone can miss rotated large caps and joins.
+func strokeRegionExtent(stroke *preparedStroke, transform d2scene.Matrix) float64 {
+	extent := strokeExtent(stroke, transform)
+	if stroke.cap == d2scene.CapRound || stroke.join == d2scene.JoinRound {
+		const circleControl = 0.5522847498307936 // Keep aligned with addCircle.
+		extent = max(extent, stroke.width/2*transform.MaxScale()*math.Hypot(1, circleControl))
+	}
+	return extent
+}
+
+func boundedStrokeLocalPoint(point d2scene.Point, scale float64) bool {
+	// Stroke outlines add offsets in local coordinates before transformation.
+	// Bound those intermediate magnitudes as well as final device coordinates:
+	// large cancelling products otherwise lose more than the one-pixel inset.
+	return finitePoint(point) && max(math.Abs(point.X), math.Abs(point.Y))*scale <= 1<<40
 }

--- a/d2renderers/d2raster/stroke_regions_test.go
+++ b/d2renderers/d2raster/stroke_regions_test.go
@@ -1,0 +1,97 @@
+package d2raster
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/draw"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2scene"
+)
+
+func TestStrokeRegionsMatchCompleteFrame(t *testing.T) {
+	state := uint32(0x2b317e99)
+	next := func() float64 { state = 1664525*state + 1013904223; return float64(state>>8) / float64(1<<24) }
+	for iteration := 0; iteration < 36; iteration++ {
+		group := d2scene.NewNode(nil)
+		group.Opacity = .73
+		for part := 0; part < 3; part++ {
+			commands := []d2scene.PathCommand{d2scene.MoveTo(next()*230-15, next()*980-40)}
+			for edge := 0; edge < 4; edge++ {
+				commands = append(commands, d2scene.LineTo(next()*230-15, next()*980-40))
+			}
+			if iteration%2 == 0 {
+				commands = append(commands, d2scene.ClosePath())
+			}
+			stroke := &d2scene.Stroke{Paint: d2scene.SolidPaint{Color: color.NRGBA{R: byte(iteration * 7), G: 31, B: byte(part * 83), A: 177}}, Width: 1 + next()*11, Cap: d2scene.LineCap(iteration % 3), Join: d2scene.LineJoin((iteration / 3) % 3), MiterLimit: 1 + next()*8}
+			if iteration%4 == 0 {
+				stroke.Dashes = []float64{11.37, 5.13, 3.71}
+				stroke.DashOffset = 7.19
+			}
+			node := d2scene.NewNode(d2scene.Path{Commands: commands, Stroke: stroke})
+			node.Transform = d2scene.Matrix{A: .93, B: .071, C: -.031, D: 1.013, E: 3.127, F: -2.571}
+			group.Children = append(group.Children, node)
+		}
+		document := d2scene.NewDocument(d2scene.Box{Width: 210, Height: 940}, group)
+		options := testOptions()
+		if iteration%2 == 0 {
+			options.Background = color.White
+		}
+		want, err := Render(context.Background(), document, options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, height := range []int{7, 37, 256} {
+			got := image.NewNRGBA(want.Bounds())
+			if err := RenderBands(context.Background(), document, options, height, func(b *image.NRGBA) error { draw.Draw(got, b.Bounds(), b, b.Bounds().Min, draw.Src); return nil }); err != nil {
+				t.Fatalf("iteration%d height%d: %v", iteration, height, err)
+			}
+			assertBandPixels(t, got, want)
+		}
+	}
+}
+
+func TestStrokeRegionsBoundLayerStorageAndPreflight(t *testing.T) {
+	root := d2scene.NewNode(d2scene.Path{Commands: []d2scene.PathCommand{d2scene.MoveTo(20.13, 20.71), d2scene.LineTo(1800.13, 20.71), d2scene.LineTo(1800.13, 900.71), d2scene.LineTo(20.13, 900.71)}, Stroke: &d2scene.Stroke{Paint: red, Width: 3.13, Cap: d2scene.CapRound, Join: d2scene.JoinRound, MiterLimit: 4}})
+	root.Opacity = .73
+	document := d2scene.NewDocument(d2scene.Box{Width: 1900, Height: 940}, root)
+	options := testOptions()
+	options.MaxWidth = 1900
+	options.MaxPixels = 2_000_000
+	prepared, err := prepareWithSessionBands(context.Background(), document, options, nil, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bounds, err := effectRenderBounds(context.Background(), prepared.root, image.Rect(0, 400, 1900, 464))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bounds.Dx() > 10 || bounds.Dy() != 64 {
+		t.Fatalf("middle of vertical stroke bounds=%v", bounds)
+	}
+	full, err := prepareWithSession(context.Background(), document, options, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.resources.peakOffscreenBytes*8 >= full.resources.peakOffscreenBytes {
+		t.Fatalf("band scratch%d not substantially below full%d", prepared.resources.peakOffscreenBytes, full.resources.peakOffscreenBytes)
+	}
+	options.MaxOffscreenBytes = prepared.resources.peakOffscreenBytes
+	calls := 0
+	if err := RenderBands(context.Background(), document, options, 64, func(*image.NRGBA) error { calls++; return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if calls == 0 {
+		t.Fatal("no bands rendered")
+	}
+	options.MaxOffscreenBytes--
+	calls = 0
+	if err := RenderBands(context.Background(), document, options, 64, func(*image.NRGBA) error { calls++; return nil }); err == nil || !strings.Contains(err.Error(), "offscreen") {
+		t.Fatalf("one-byte-short scratch error=%v", err)
+	}
+	if calls != 0 {
+		t.Fatal("resource rejection produced a partial frame")
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

Reduce repeated work in three paths: dynamic grid layout, repeated imports of individual fields from a D2 file, and PNG connection masks/effects. Rendering quality, layout decisions, import validation, and raster resource limits are preserved.

### Benchmarks

Fresh CLI process time, including startup, compilation, layout, rendering, and file output. Six alternating baseline/candidate pairs after one warmup per variant; Apple M4, Go 1.27.0, `CGO_ENABLED=0 go build -trimpath`, `GOMAXPROCS=1`, `--omit-version`.

| Workload | Before | After | Speedup |
|---|---:|---:|---:|
| Synthetic grid: 50 objects, 8 rows | 85.82 ms | 25.77 ms | 3.33× |
| Synthetic grid: 100 objects, 10 rows | 273.31 ms | 40.06 ms | 6.82× |
| Synthetic grid: 400 objects, 20 rows | 3,237.64 ms | 215.59 ms | 15.02× |
| Existing `grid_oom` regression fixture | 468.26 ms | 86.56 ms | 5.41× |
| Synthetic imports: 100 selections from 1,000 definitions | 395.79 ms | 133.42 ms | 2.97× |
| Synthetic imports: 100 selections from 4,000 definitions | 1,374.16 ms | 178.73 ms | 7.69× |
| TPMJS architecture PNG, ELK, effective 1× | 690.28 ms | 515.30 ms | 1.34× |
| TPMJS architecture PNG, Dagre, effective 1× | 1,096.05 ms | 914.72 ms | 1.20× |
| Queue workers PNG, Dagre, default 2× | 607.89 ms | 567.89 ms | 1.07× |

The import benchmark deliberately stresses repeated field imports such as `users: @shapes.database`. It is synthetic, not a demonstrated 7.7× gain on an existing real-world diagram. Each import fixture produces the same 300-node, 100-edge output; only library size changes. Peak RSS for the largest import case falls from 223 MiB to 112 MiB; TPMJS/Dagre PNG at effective 1× falls from 172 MiB to 125 MiB.

Across 20 real-world SVG cases, median per-case speedup is 1.00×. Across 20 real-world PNG cases using `--scale 0.5`, it is 1.01× (geometric mean 1.04×). The improvements are workload-dependent. Four appendix-bearing PNG cases retain existing 2× behavior despite that flag; the TPMJS 1× labels above were verified from output dimensions.

A separate three-pair check with Go's normal CPU setting measured 15.52× for the 400-object grid, 6.84× for the largest import case, and 1.20× for TPMJS/Dagre PNG at default 2×. These are single-machine/session results. Later full-corpus phase runs overlapped unrelated CPU-heavy work and are used for correctness only; their timings are inconclusive. Original unfavorable samples were retained, and two apparent small regressions reran approximately unchanged.

Measurements compare `a25ad90922962851a09d8970596483fd68ec09fe` with `1604525e305b9ae648256ecf2e261fa66249d5f1`. The initial PR head `699f8717a` has identical Go source/modules to the measured candidate after rebasing onto `e500d42d5`. Final head `1f6f80181` additionally delays grid-cache allocation until a multi-object row is measured; compiler and raster implementations are unchanged. Ten grid cases were rerun on that final head with identical outputs and retained search gains. The 400-object/400-row edge case now measures 27.31 → 27.42 ms and 37.77 → 37.73 MiB peak RSS, removing the earlier approximately 1 MiB overhead. Some search-case follow-up timings were noisy, so the original table is retained with its exact source attribution.

### Implementation and tradeoffs

- Grid search reuses a cut buffer and bounded row measurements, and allocates candidate layouts only when they become the best result. Traversal order, floating-point addition order, ties, and stopping rules are unchanged. The temporary cache is capped at 1 MiB on 64-bit platforms and is only allocated when a multi-object row needs measurement; empty/singleton rows do not allocate it.
- Eligible selective imports choose a field before cloning it, avoiding a whole-library copy per import. The whole library is still initially compiled and validated. Boards, globs, spreads, maps inside arrays, and imports into arrays retain conservative fallbacks. Eligibility is checked once per cached library.
- Regional PNG rendering bounds mask/effect work to pixels that can affect the current strip. It preserves reference origins and conservatively bounds cap/join control points. Unsupported effects and extreme coordinates retain the existing conservative bounds. Regional checks add some overhead when little can be cropped; this is not a claim that every possible input becomes faster.

### Validation

- All 62 CLI cases have byte-identical output between the original measured builds, across all measured runs and warmups. All ten final-head grid rechecks also match byte for byte.
- Twelve complete E2E corpus runs match all 672 output fingerprints and all 7,257 event keys/invocation counts; no golden files changed.
- Differential tests cover the original grid search, fractional geometry, import reference ownership and cache isolation, band sizes/scales, masks, and extreme raster coordinates.
- Full Go suite, targeted race tests, and `go vet --composites=false ./...` passed. After the final cache change, the full suite, grid race/vet checks, JS/WASM build, and Linux/386 grid test build were rerun successfully. JS/WASM builds and Linux/386 raster/grid test builds passed; cross-platform binaries were compiled, not executed locally.

The PR includes package benchmarks for the grid and import algorithms (these isolate the algorithms and are distinct from the end-to-end CLI numbers above):

```sh
go test ./d2layouts/d2grid -run '^$' -bench BenchmarkDynamicGridSearch -benchmem
go test ./d2ir -run '^$' -bench BenchmarkCompileSelectedLibrary -benchmem
```
