### PR TITLE
Reduce Dagre, text measurement, and rendering overhead

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,7 +4,7 @@
 
 #### Improvements 🧹
 
-- performance: reduce repeated work in text measurement, SVG preparation, and PNG encoding
+- performance: reduce repeated work in Dagre ranking, text measurement, SVG preparation, and PNG encoding
 - performance: reduce repeated work in selective imports, dynamic grid layout, and PNG connection rendering
 - exports: reduce PNG memory usage and support images above the previous 67-megapixel limit
 - performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 
 #### Improvements 🧹
 
+- performance: reduce repeated work in text measurement, SVG preparation, and PNG encoding
 - performance: reduce repeated work in selective imports, dynamic grid layout, and PNG connection rendering
 - exports: reduce PNG memory usage and support images above the previous 67-megapixel limit
 - performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.

--- a/d2cli/raster_png_encoder.go
+++ b/d2cli/raster_png_encoder.go
@@ -481,30 +481,16 @@ func rasterPNGUpFilter(destination, raw, prior []byte) int {
 	_ = prior[len(raw)-1]
 	destination[0] = 2
 	destination = destination[1:]
+	if bytes.Equal(raw, prior) {
+		clear(destination[:len(raw)])
+		return 0
+	}
 	cost := 0
-	for index := 0; index < len(raw); {
-		end := min(index+16, len(raw))
-		if end-index == 16 && rasterPNGEqual16(raw[index:], prior[index:]) {
-			clear(destination[index:end])
-			index = end
-			continue
-		}
-		// Avoid probing every block of a varied row that starts without an
-		// unchanged run, as happens for photos and gradients.
-		if index == 0 {
-			end = len(raw)
-		}
-		for ; index < end; index++ {
-			destination[index] = raw[index] - prior[index]
-			cost += rasterPNGAbs8(destination[index])
-		}
+	for index, value := range raw {
+		destination[index] = value - prior[index]
+		cost += rasterPNGAbs8(destination[index])
 	}
 	return cost
-}
-
-func rasterPNGEqual16(a, b []byte) bool {
-	return binary.LittleEndian.Uint64(a) == binary.LittleEndian.Uint64(b) &&
-		binary.LittleEndian.Uint64(a[8:]) == binary.LittleEndian.Uint64(b[8:])
 }
 
 func rasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
@@ -518,22 +504,11 @@ func rasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
 			return cost
 		}
 	}
-	for index := channels; index < len(raw); {
-		end := min(index+16, len(raw))
-		if end-index == 16 && rasterPNGEqual16(raw[index:], raw[index-channels:]) {
-			clear(destination[index:end])
-			index = end
-			continue
-		}
-		if index == channels {
-			end = len(raw)
-		}
-		for ; index < end; index++ {
-			destination[index] = raw[index] - raw[index-channels]
-			cost += rasterPNGAbs8(destination[index])
-			if cost >= stopAt {
-				return cost
-			}
+	for index := channels; index < len(raw); index++ {
+		destination[index] = raw[index] - raw[index-channels]
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			break
 		}
 	}
 	return cost
@@ -573,40 +548,26 @@ func rasterPNGPaethFilter(destination, raw, prior []byte, stopAt, channels int) 
 			return cost
 		}
 	}
-	for index := channels; index < len(raw); {
-		end := min(index+16, len(raw))
-		// An unchanged run, including its preceding pixel, has zero Paeth
-		// residuals: left equals upper-left, so the predictor is upper.
-		if end-index == 16 && rasterPNGEqual16(raw[index:], prior[index:]) &&
-			bytes.Equal(raw[index-channels:index], prior[index-channels:index]) {
-			clear(destination[index:end])
-			index = end
-			continue
+	for index := channels; index < len(raw); index++ {
+		left := raw[index-channels]
+		upperLeft := prior[index-channels]
+		upper := prior[index]
+		leftDistance := rasterPNGByteDistance(upper, upperLeft)
+		upperDistance := rasterPNGByteDistance(left, upperLeft)
+		diagonalDistance := int(left) + int(upper) - 2*int(upperLeft)
+		if diagonalDistance < 0 {
+			diagonalDistance = -diagonalDistance
 		}
-		if index == channels {
-			end = len(raw)
+		predictor := upperLeft
+		if leftDistance <= upperDistance && leftDistance <= diagonalDistance {
+			predictor = left
+		} else if upperDistance <= diagonalDistance {
+			predictor = upper
 		}
-		for ; index < end; index++ {
-			left := raw[index-channels]
-			upperLeft := prior[index-channels]
-			upper := prior[index]
-			leftDistance := rasterPNGByteDistance(upper, upperLeft)
-			upperDistance := rasterPNGByteDistance(left, upperLeft)
-			diagonalDistance := int(left) + int(upper) - 2*int(upperLeft)
-			if diagonalDistance < 0 {
-				diagonalDistance = -diagonalDistance
-			}
-			predictor := upperLeft
-			if leftDistance <= upperDistance && leftDistance <= diagonalDistance {
-				predictor = left
-			} else if upperDistance <= diagonalDistance {
-				predictor = upper
-			}
-			destination[index] = raw[index] - predictor
-			cost += rasterPNGAbs8(destination[index])
-			if cost >= stopAt {
-				return cost
-			}
+		destination[index] = raw[index] - predictor
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			break
 		}
 	}
 	return cost

--- a/d2cli/raster_png_encoder.go
+++ b/d2cli/raster_png_encoder.go
@@ -482,11 +482,29 @@ func rasterPNGUpFilter(destination, raw, prior []byte) int {
 	destination[0] = 2
 	destination = destination[1:]
 	cost := 0
-	for index, value := range raw {
-		destination[index] = value - prior[index]
-		cost += rasterPNGAbs8(destination[index])
+	for index := 0; index < len(raw); {
+		end := min(index+16, len(raw))
+		if end-index == 16 && rasterPNGEqual16(raw[index:], prior[index:]) {
+			clear(destination[index:end])
+			index = end
+			continue
+		}
+		// Avoid probing every block of a varied row that starts without an
+		// unchanged run, as happens for photos and gradients.
+		if index == 0 {
+			end = len(raw)
+		}
+		for ; index < end; index++ {
+			destination[index] = raw[index] - prior[index]
+			cost += rasterPNGAbs8(destination[index])
+		}
 	}
 	return cost
+}
+
+func rasterPNGEqual16(a, b []byte) bool {
+	return binary.LittleEndian.Uint64(a) == binary.LittleEndian.Uint64(b) &&
+		binary.LittleEndian.Uint64(a[8:]) == binary.LittleEndian.Uint64(b[8:])
 }
 
 func rasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
@@ -500,11 +518,22 @@ func rasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
 			return cost
 		}
 	}
-	for index := channels; index < len(raw); index++ {
-		destination[index] = raw[index] - raw[index-channels]
-		cost += rasterPNGAbs8(destination[index])
-		if cost >= stopAt {
-			break
+	for index := channels; index < len(raw); {
+		end := min(index+16, len(raw))
+		if end-index == 16 && rasterPNGEqual16(raw[index:], raw[index-channels:]) {
+			clear(destination[index:end])
+			index = end
+			continue
+		}
+		if index == channels {
+			end = len(raw)
+		}
+		for ; index < end; index++ {
+			destination[index] = raw[index] - raw[index-channels]
+			cost += rasterPNGAbs8(destination[index])
+			if cost >= stopAt {
+				return cost
+			}
 		}
 	}
 	return cost
@@ -544,26 +573,40 @@ func rasterPNGPaethFilter(destination, raw, prior []byte, stopAt, channels int) 
 			return cost
 		}
 	}
-	for index := channels; index < len(raw); index++ {
-		left := raw[index-channels]
-		upperLeft := prior[index-channels]
-		upper := prior[index]
-		leftDistance := rasterPNGByteDistance(upper, upperLeft)
-		upperDistance := rasterPNGByteDistance(left, upperLeft)
-		diagonalDistance := int(left) + int(upper) - 2*int(upperLeft)
-		if diagonalDistance < 0 {
-			diagonalDistance = -diagonalDistance
+	for index := channels; index < len(raw); {
+		end := min(index+16, len(raw))
+		// An unchanged run, including its preceding pixel, has zero Paeth
+		// residuals: left equals upper-left, so the predictor is upper.
+		if end-index == 16 && rasterPNGEqual16(raw[index:], prior[index:]) &&
+			bytes.Equal(raw[index-channels:index], prior[index-channels:index]) {
+			clear(destination[index:end])
+			index = end
+			continue
 		}
-		predictor := upperLeft
-		if leftDistance <= upperDistance && leftDistance <= diagonalDistance {
-			predictor = left
-		} else if upperDistance <= diagonalDistance {
-			predictor = upper
+		if index == channels {
+			end = len(raw)
 		}
-		destination[index] = raw[index] - predictor
-		cost += rasterPNGAbs8(destination[index])
-		if cost >= stopAt {
-			break
+		for ; index < end; index++ {
+			left := raw[index-channels]
+			upperLeft := prior[index-channels]
+			upper := prior[index]
+			leftDistance := rasterPNGByteDistance(upper, upperLeft)
+			upperDistance := rasterPNGByteDistance(left, upperLeft)
+			diagonalDistance := int(left) + int(upper) - 2*int(upperLeft)
+			if diagonalDistance < 0 {
+				diagonalDistance = -diagonalDistance
+			}
+			predictor := upperLeft
+			if leftDistance <= upperDistance && leftDistance <= diagonalDistance {
+				predictor = left
+			} else if upperDistance <= diagonalDistance {
+				predictor = upper
+			}
+			destination[index] = raw[index] - predictor
+			cost += rasterPNGAbs8(destination[index])
+			if cost >= stopAt {
+				return cost
+			}
 		}
 	}
 	return cost

--- a/d2cli/raster_png_filter_runs_test.go
+++ b/d2cli/raster_png_filter_runs_test.go
@@ -1,0 +1,160 @@
+package d2cli
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Compare the actual scores and scratch writes against the pre-optimization
+// scalar filters, including early termination and runs crossing pixel boundaries.
+func TestRasterPNGFilterRunsMatchScalar(t *testing.T) {
+	random := rand.New(rand.NewSource(2879))
+	for _, channels := range []int{3, 4} {
+		for _, width := range []int{1, 2, 5, 6, 7, 8, 10, 15, 16, 17, 31, 32, 33, 63, 64, 65, 257} {
+			for pattern := 0; pattern < 9; pattern++ {
+				raw, prior := make([]byte, width*channels), make([]byte, width*channels)
+				random.Read(raw)
+				random.Read(prior)
+				switch pattern {
+				case 1:
+					copy(raw, prior)
+				case 2, 3:
+					for i := range raw {
+						raw[i] = byte(i%channels*53 + 1)
+						prior[i] = raw[i]
+						if pattern == 3 {
+							prior[i] += 19
+						}
+					}
+				case 4:
+					copy(raw, prior)
+					for i := channels - 1; i < len(raw); i += 16 {
+						raw[i] ^= 0x81
+					}
+				case 5:
+					for i := range raw {
+						raw[i] = 255
+						prior[i] = 255
+						if i%32 == 15 {
+							raw[i] = byte(i)
+						}
+					}
+				case 6:
+					for i := 0; i < min(64, len(raw)); i++ {
+						raw[i] = 255
+						prior[i] = 255
+					}
+				case 7:
+					for i := 16; i+16 <= len(raw); i += 32 {
+						copy(raw[i:i+16], prior[i:i+16])
+					}
+				case 8:
+					clear(raw)
+					clear(prior)
+				}
+				thresholds := []int{0, 1, 2, 7, 255, 65535, math.MaxInt}
+				scratch := make([]byte, len(raw)+1)
+				for _, fullCost := range []int{
+					referenceRasterPNGUpFilter(scratch, raw, prior),
+					referenceRasterPNGSubFilter(scratch, raw, math.MaxInt, channels),
+					referenceRasterPNGPaethFilter(scratch, raw, prior, math.MaxInt, channels),
+				} {
+					thresholds = append(thresholds, max(0, fullCost-1), fullCost, fullCost+1)
+				}
+				for _, stopAt := range thresholds {
+					for filter := 0; filter < 3; filter++ {
+						got, want := bytes.Repeat([]byte{0xa5}, len(raw)+1), bytes.Repeat([]byte{0xa5}, len(raw)+1)
+						var gotCost, wantCost int
+						switch filter {
+						case 0:
+							gotCost = rasterPNGUpFilter(got, raw, prior)
+							wantCost = referenceRasterPNGUpFilter(want, raw, prior)
+						case 1:
+							gotCost = rasterPNGSubFilter(got, raw, stopAt, channels)
+							wantCost = referenceRasterPNGSubFilter(want, raw, stopAt, channels)
+						case 2:
+							gotCost = rasterPNGPaethFilter(got, raw, prior, stopAt, channels)
+							wantCost = referenceRasterPNGPaethFilter(want, raw, prior, stopAt, channels)
+						}
+						if gotCost != wantCost || !bytes.Equal(got, want) {
+							t.Fatalf("channels=%d width=%d pattern=%d stop=%d filter=%d: cost %d != %d or scratch differs", channels, width, pattern, stopAt, filter, gotCost, wantCost)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// Frozen scalar implementations from 70affc0e.
+func referenceRasterPNGUpFilter(destination, raw, prior []byte) int {
+	_ = prior[len(raw)-1]
+	destination[0] = 2
+	destination = destination[1:]
+	cost := 0
+	for index, value := range raw {
+		destination[index] = value - prior[index]
+		cost += rasterPNGAbs8(destination[index])
+	}
+	return cost
+}
+
+func referenceRasterPNGSubFilter(destination, raw []byte, stopAt, channels int) int {
+	destination[0] = 1
+	destination = destination[1:]
+	cost := 0
+	for index := 0; index < channels; index++ {
+		destination[index] = raw[index]
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			return cost
+		}
+	}
+	for index := channels; index < len(raw); index++ {
+		destination[index] = raw[index] - raw[index-channels]
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			break
+		}
+	}
+	return cost
+}
+
+func referenceRasterPNGPaethFilter(destination, raw, prior []byte, stopAt, channels int) int {
+	_ = prior[len(raw)-1]
+	destination[0] = 4
+	destination = destination[1:]
+	cost := 0
+	for index := 0; index < channels; index++ {
+		destination[index] = raw[index] - prior[index]
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			return cost
+		}
+	}
+	for index := channels; index < len(raw); index++ {
+		left := raw[index-channels]
+		upperLeft := prior[index-channels]
+		upper := prior[index]
+		leftDistance := rasterPNGByteDistance(upper, upperLeft)
+		upperDistance := rasterPNGByteDistance(left, upperLeft)
+		diagonalDistance := int(left) + int(upper) - 2*int(upperLeft)
+		if diagonalDistance < 0 {
+			diagonalDistance = -diagonalDistance
+		}
+		predictor := upperLeft
+		if leftDistance <= upperDistance && leftDistance <= diagonalDistance {
+			predictor = left
+		} else if upperDistance <= diagonalDistance {
+			predictor = upper
+		}
+		destination[index] = raw[index] - predictor
+		cost += rasterPNGAbs8(destination[index])
+		if cost >= stopAt {
+			break
+		}
+	}
+	return cost
+}

--- a/d2cli/raster_png_mixed_content_test.go
+++ b/d2cli/raster_png_mixed_content_test.go
@@ -1,0 +1,104 @@
+package d2cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/png"
+	"math/rand"
+	"testing"
+)
+
+// These fixtures exercise unchanged prefixes followed by varied content.
+// Fixture generation is outside timed runs.
+func rasterPNGMixedContentImages() []struct {
+	name string
+	img  *image.NRGBA
+} {
+	var cases []struct {
+		name string
+		img  *image.NRGBA
+	}
+	for _, kind := range []string{"noise", "gradient"} {
+		for _, margin := range []int{8, 64} {
+			img := image.NewNRGBA(image.Rect(0, 0, 512, 512))
+			random := rand.New(rand.NewSource(0xD2))
+			for y := 0; y < 512; y++ {
+				for x := 0; x < 512; x++ {
+					offset := img.PixOffset(x, y)
+					// Consume one value for every pixel so both margin widths
+					// have the same underlying noise at matching coordinates.
+					value := random.Uint32()
+					red, green, blue := byte(value), byte(value>>8), byte(value>>16)
+					if kind == "gradient" {
+						// Match the existing encoder benchmark's diagonal
+						// gradient: colors vary both within and between rows.
+						red, green, blue = byte(x), byte(y), byte(x+y)
+					}
+					if x < margin {
+						red, green, blue = 0xff, 0xff, 0xff
+					}
+					img.Pix[offset], img.Pix[offset+1], img.Pix[offset+2], img.Pix[offset+3] = red, green, blue, 0xff
+				}
+			}
+			cases = append(cases, struct {
+				name string
+				img  *image.NRGBA
+			}{name: fmt.Sprintf("%s/margin-%d", kind, margin), img: img})
+		}
+	}
+	return cases
+}
+
+var benchmarkRasterPNGMixedBytes []byte
+
+// BenchmarkRasterPNGMixedContent uses the native subbenchmark lifecycle from
+// BenchmarkRasterPNGEncoder: one encoder per subbenchmark, retained across
+// iterations and closed afterward. Each encode allocates its output normally.
+func BenchmarkRasterPNGMixedContent(b *testing.B) {
+	for _, benchmark := range rasterPNGMixedContentImages() {
+		b.Run(benchmark.name+"/native", func(b *testing.B) {
+			var encoder rasterPNGEncoder
+			defer encoder.close()
+			b.ReportAllocs()
+			for range b.N {
+				encoded, err := encoder.encode(context.Background(), benchmark.img)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkRasterPNGMixedBytes = encoded
+			}
+		})
+	}
+}
+
+func TestRasterPNGMixedContentMatchesStdlib(t *testing.T) {
+	var encoder rasterPNGEncoder
+	defer encoder.close()
+	for _, test := range rasterPNGMixedContentImages() {
+		t.Run(test.name, func(t *testing.T) {
+			before := bytes.Clone(test.img.Pix)
+			var expected bytes.Buffer
+			stdlib := png.Encoder{CompressionLevel: png.BestSpeed}
+			if err := stdlib.Encode(&expected, test.img); err != nil {
+				t.Fatal(err)
+			}
+			// Both inputs are opaque NRGBA, so native encoding must emit
+			// the same truecolor PNG bytes and filter choices as image/png.
+			// Repeat to check retained encoder state as well as first use.
+			for pass := 0; pass < 2; pass++ {
+				got, err := encoder.encode(context.Background(), test.img)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, expected.Bytes()) {
+					t.Fatalf("pass %d: native PNG differs from image/png BestSpeed", pass)
+				}
+				if !bytes.Equal(test.img.Pix, before) {
+					t.Fatalf("pass %d: encoding mutated source pixels", pass)
+				}
+			}
+		})
+	}
+}

--- a/d2layouts/d2dagrelayout/real_world_benchmark_test.go
+++ b/d2layouts/d2dagrelayout/real_world_benchmark_test.go
@@ -1,0 +1,21 @@
+package d2dagrelayout
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Keep layout measurements separate from parsing and font measurement, using
+// the same real-world sources as the D2 end-to-end output compatibility suite.
+func BenchmarkDagreRealWorld(b *testing.B) {
+	for _, name := range []string{"tpmjs_architecture", "spyre_encoder", "mocha_soc", "fulcro_rad", "queue_workers"} {
+		b.Run(name, func(b *testing.B) {
+			source, err := os.ReadFile(filepath.Join("..", "..", "e2etests", "testdata", "files", name+".d2"))
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkDagreLayout(b, string(source))
+		})
+	}
+}

--- a/d2target/corpus_hash_test.go
+++ b/d2target/corpus_hash_test.go
@@ -1,0 +1,130 @@
+package d2target
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestHashJSONWithoutIconsMatchesNormalization(t *testing.T) {
+	labels := []string{
+		"", `quoted "icon":{"Scheme":"fake"}`, `escaped \\"icon":{`,
+		"<script>\u2028emoji: 🌐\x00", string([]byte{0xff, '\\', '"'}),
+	}
+	icons := []*url.URL{nil, {}, {Scheme: "https", Host: "example.com", Path: `/"icon":{`, RawQuery: "a=<b>&c=d"}}
+	for _, label := range labels {
+		for _, icon := range icons {
+			shape := Shape{Icon: icon, Text: Text{Label: label}, Class: Class{Fields: []ClassField{{Name: label}}}}
+			connection := Connection{Icon: icon, Text: Text{Label: label}, SrcLabel: &Text{Label: label}}
+			for _, value := range []any{shape, []Shape{shape, {}}, []Connection{connection, {}}, []Shape(nil), []Connection{}} {
+				raw, err := json.Marshal(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want, err := stabilizeHashURLs(raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := marshalHashJSON(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("hash JSON differs for %T, label %q, icon %v", value, label, icon)
+				}
+			}
+		}
+	}
+	if _, err := marshalHashJSON(Shape{Opacity: math.NaN()}); err == nil {
+		t.Fatal("hash JSON accepted non-finite geometry")
+	}
+}
+
+func TestCorpusOrderAndAppendixNumbering(t *testing.T) {
+	diagram := Diagram{
+		Shapes: []Shape{
+			{Text: Text{Label: "shape"}, Tooltip: "tip", Link: "link", PrettyLink: "pretty"},
+			{Type: ShapeClass, Text: Text{Label: "class"}, Class: Class{
+				Fields:  []ClassField{{Name: "field", Type: "type", Visibility: "private"}},
+				Methods: []ClassMethod{{Name: "method", Return: "return", Visibility: "protected"}},
+			}},
+			{Type: ShapeSQLTable, Text: Text{Label: "table"}, SQLTable: SQLTable{Columns: []SQLColumn{
+				{Name: Text{Label: "column"}, Type: Text{Label: "integer"}, Constraint: []string{"primary_key", "unique"}},
+			}}},
+			{Text: Text{Label: "unicode🌐"}, Tooltip: "last"},
+		},
+		Connections: []Connection{
+			{Text: Text{Label: "edge"}, SrcLabel: &Text{Label: "source"}, DstLabel: &Text{Label: "destination"}},
+		},
+		Legend: &Legend{Shapes: []Shape{{Text: Text{Label: "legend-shape"}}}, Connections: []Connection{{Text: Text{Label: "legend-edge"}}}},
+	}
+	// SQL constraints intentionally appear twice, matching the corpus used by
+	// existing font subsets, and appendix numbering counts only links/tooltips.
+	const want = "shapetip1link2prettyclassfieldtype-methodreturn#tablecolumnintegerPK, UNQPK, UNQunicode🌐last3edgesourcedestinationLegendlegend-shapelegend-edge"
+	if got := diagram.GetCorpus(); got != want {
+		t.Fatalf("corpus = %q, want %q", got, want)
+	}
+	diagram.Legend.Label = "named"
+	if got := diagram.GetCorpus(); got != strings.Replace(want, "Legend", "named", 1) {
+		t.Fatalf("named legend corpus = %q", got)
+	}
+}
+
+func TestNestedCorpusTraversal(t *testing.T) {
+	board := func(label string) *Diagram {
+		return &Diagram{Shapes: []Shape{{Text: Text{Label: label}, Tooltip: "tip"}}}
+	}
+	diagram := board("root")
+	diagram.Layers = []*Diagram{board("layer")}
+	diagram.Layers[0].Scenarios = []*Diagram{board("nested")}
+	diagram.Scenarios = []*Diagram{board("scenario")}
+	diagram.Steps = []*Diagram{board("step")}
+	const want = "roottip1layertip1nestedtip1scenariotip1steptip1"
+	if got := diagram.GetNestedCorpus(); got != want {
+		t.Fatalf("nested corpus = %q, want %q", got, want)
+	}
+	if got := (Diagram{}).GetNestedCorpus(); got != "" {
+		t.Fatalf("empty corpus = %q", got)
+	}
+}
+
+func BenchmarkDiagramCorpus(b *testing.B) {
+	for _, count := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			diagram := Diagram{Shapes: make([]Shape, count)}
+			for i := range diagram.Shapes {
+				diagram.Shapes[i].Label = fmt.Sprintf("service_%04d: process request", i)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = diagram.GetCorpus()
+			}
+		})
+	}
+}
+
+func BenchmarkDiagramHashJSON(b *testing.B) {
+	for _, icons := range []bool{false, true} {
+		b.Run(fmt.Sprintf("icons=%t", icons), func(b *testing.B) {
+			shapes := make([]Shape, 1000)
+			for i := range shapes {
+				shapes[i].Label = fmt.Sprintf("service_%04d: process request", i)
+			}
+			if icons {
+				shapes[0].Icon = &url.URL{Scheme: "https", Host: "example.com", Path: "/icon.svg"}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := marshalHashJSON(shapes); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"math"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/d2lang/util-go/go2"
@@ -220,6 +221,13 @@ func marshalHashJSON(v any) ([]byte, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
+	}
+	// The only URL values in these types are icon fields. json.Marshal emits
+	// compact field names and escapes quotation marks inside string values, so
+	// this marker cannot be hidden by whitespace or matched inside label text.
+	// Most diagrams have no icons; avoid decoding their entire JSON again.
+	if !bytes.Contains(b, []byte(`"icon":{`)) {
+		return b, nil
 	}
 	return stabilizeHashURLs(b)
 }
@@ -666,78 +674,87 @@ func calculateTooltipBounds(targetShape Shape, diagramFontFamily, diagramMonoFon
 }
 
 func (diagram Diagram) GetNestedCorpus() string {
-	corpus := diagram.GetCorpus()
+	var corpus strings.Builder
+	diagram.appendNestedCorpus(&corpus)
+	return corpus.String()
+}
+
+func (diagram Diagram) appendNestedCorpus(corpus *strings.Builder) {
+	diagram.appendCorpus(corpus)
 	for _, d := range diagram.Layers {
-		corpus += d.GetNestedCorpus()
+		d.appendNestedCorpus(corpus)
 	}
 	for _, d := range diagram.Scenarios {
-		corpus += d.GetNestedCorpus()
+		d.appendNestedCorpus(corpus)
 	}
 	for _, d := range diagram.Steps {
-		corpus += d.GetNestedCorpus()
+		d.appendNestedCorpus(corpus)
 	}
-
-	return corpus
 }
 
 func (diagram Diagram) GetCorpus() string {
-	var corpus string
+	var corpus strings.Builder
+	diagram.appendCorpus(&corpus)
+	return corpus.String()
+}
+
+func (diagram Diagram) appendCorpus(corpus *strings.Builder) {
 	appendixCount := 0
 	for _, s := range diagram.Shapes {
-		corpus += s.Label
+		corpus.WriteString(s.Label)
 		if s.Tooltip != "" {
-			corpus += s.Tooltip
+			corpus.WriteString(s.Tooltip)
 			appendixCount++
-			corpus += fmt.Sprint(appendixCount)
+			corpus.WriteString(strconv.Itoa(appendixCount))
 		}
 		if s.Link != "" {
-			corpus += s.Link
+			corpus.WriteString(s.Link)
 			appendixCount++
-			corpus += fmt.Sprint(appendixCount)
+			corpus.WriteString(strconv.Itoa(appendixCount))
 		}
-		corpus += s.PrettyLink
+		corpus.WriteString(s.PrettyLink)
 		if s.Type == ShapeClass {
 			for _, cf := range s.Fields {
-				corpus += cf.Text(0).Text + cf.VisibilityToken()
+				corpus.WriteString(cf.Text(0).Text)
+				corpus.WriteString(cf.VisibilityToken())
 			}
 			for _, cm := range s.Methods {
-				corpus += cm.Text(0).Text + cm.VisibilityToken()
+				corpus.WriteString(cm.Text(0).Text)
+				corpus.WriteString(cm.VisibilityToken())
 			}
 		}
 		if s.Type == ShapeSQLTable {
 			for _, c := range s.Columns {
 				for _, t := range c.Texts(0) {
-					corpus += t.Text
+					corpus.WriteString(t.Text)
 				}
-				corpus += c.ConstraintAbbr()
+				corpus.WriteString(c.ConstraintAbbr())
 			}
 		}
 	}
 	for _, c := range diagram.Connections {
-		corpus += c.Label
+		corpus.WriteString(c.Label)
 		if c.SrcLabel != nil {
-			corpus += c.SrcLabel.Label
+			corpus.WriteString(c.SrcLabel.Label)
 		}
 		if c.DstLabel != nil {
-			corpus += c.DstLabel.Label
+			corpus.WriteString(c.DstLabel.Label)
 		}
 	}
 
 	if diagram.Legend != nil {
 		if diagram.Legend.Label != "" {
-			corpus += diagram.Legend.Label
+			corpus.WriteString(diagram.Legend.Label)
 		} else {
-			corpus += "Legend"
+			corpus.WriteString("Legend")
 		}
 		for _, s := range diagram.Legend.Shapes {
-			corpus += s.Label
+			corpus.WriteString(s.Label)
 		}
 		for _, c := range diagram.Legend.Connections {
-			corpus += c.Label
+			corpus.WriteString(c.Label)
 		}
 	}
-
-	return corpus
 }
 
 func NewDiagram() *Diagram {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/andybalholm/brotli v1.2.2
 	github.com/coder/websocket v1.8.15
-	github.com/d2lang/dagro v0.2.0
+	github.com/d2lang/dagro v0.2.1
 	github.com/d2lang/elk-go v0.2.0
 	github.com/d2lang/mathjax-go v0.1.0
 	github.com/d2lang/rough-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6p
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/d2lang/dagro v0.2.0 h1:GxawYVyAm8MBJ8dyvjvS71gVlWmF1QbiaXpWPanpVnM=
-github.com/d2lang/dagro v0.2.0/go.mod h1:MPJvYGJla9b0ly0AZYUycLu/CP3z0dq8spR5Nl12OMM=
+github.com/d2lang/dagro v0.2.1 h1:0IGGByyyHXiyZqcYQ775H3Eha4vVYSNWC79osyVGt58=
+github.com/d2lang/dagro v0.2.1/go.mod h1:MPJvYGJla9b0ly0AZYUycLu/CP3z0dq8spR5Nl12OMM=
 github.com/d2lang/elk-go v0.2.0 h1:/NmqquuSleFTPVskM91UYOkwZe8+nRO3a8aaKB5Op+I=
 github.com/d2lang/elk-go v0.2.0/go.mod h1:tvu+zORoU3aAbBetbyvmwsF8Tjdvj/+fG9owqahZ+BQ=
 github.com/d2lang/mathjax-go v0.1.0 h1:wwEYeMNpjqZrKqoZYNA3ZvVxQuN0EzBwEPClUT/KcwE=

--- a/lib/textmeasure/atlas.go
+++ b/lib/textmeasure/atlas.go
@@ -118,55 +118,53 @@ func (a *atlas) Descent() float64 {
 // Rect is a rectangle where the glyph should be positioned. frame is the glyph frame inside the
 // atlas's Picture. NewDot is the new position of the dot.
 func (a *atlas) DrawRune(prevR, r rune, dot *geo.Point) (rect2, frame, bounds *rect, newDot *geo.Point) {
+	position, measured, frame := a.measureRune(prevR, r, dot)
+	if frame == nil {
+		return newRect(), newRect(), newRect(), dot
+	}
+	rect2 = position.rect()
+	bounds = rect2
+	if position.w()*position.h() != 0 {
+		bounds = measured.rect()
+	}
+	return rect2, frame, bounds, dot
+}
+
+// runeRect keeps temporary glyph bounds on the stack. Ruler needs the same
+// arithmetic as DrawRune, but does not need a heap rectangle for each glyph.
+type runeRect struct{ tl, br geo.Point }
+
+func (r runeRect) w() float64  { return r.br.X - r.tl.X }
+func (r runeRect) h() float64  { return r.br.Y - r.tl.Y }
+func (r runeRect) rect() *rect { return &rect{tl: r.tl.Copy(), br: r.br.Copy()} }
+
+func (a *atlas) measureRune(prevR, r rune, dot *geo.Point) (position, bounds runeRect, frame *rect) {
 	if !a.contains(r) {
 		r = unicode.ReplacementChar
 	}
 	if !a.contains(unicode.ReplacementChar) {
-		return newRect(), newRect(), newRect(), dot
+		return runeRect{}, runeRect{}, nil
 	}
 	if !a.contains(prevR) {
 		prevR = unicode.ReplacementChar
 	}
-
 	if prevR >= 0 {
 		dot.X += a.Kern(prevR, r)
 	}
-
 	glyph := a.glyph(r)
-
-	subbed := geo.NewPoint(
-		dot.X-glyph.dot.X,
-		dot.Y-glyph.dot.Y,
-	)
-
-	rect2 = &rect{
-		tl: geo.NewPoint(
-			glyph.frame.tl.X+subbed.X,
-			glyph.frame.tl.Y+subbed.Y,
-		),
-		br: geo.NewPoint(
-			glyph.frame.br.X+subbed.X,
-			glyph.frame.br.Y+subbed.Y,
-		),
+	// Preserve the packed operation order even for fractional or large dots.
+	x, y := dot.X-glyph.dot.X, dot.Y-glyph.dot.Y
+	position = runeRect{
+		tl: geo.Point{X: glyph.frame.tl.X + x, Y: glyph.frame.tl.Y + y},
+		br: geo.Point{X: glyph.frame.br.X + x, Y: glyph.frame.br.Y + y},
 	}
-	bounds = rect2
-
+	bounds = position
 	if bounds.w()*bounds.h() != 0 {
-		bounds = &rect{
-			tl: geo.NewPoint(
-				bounds.tl.X,
-				dot.Y-a.Descent(),
-			),
-			br: geo.NewPoint(
-				bounds.br.X,
-				dot.Y+a.Ascent(),
-			),
-		}
+		bounds.tl.Y = dot.Y - a.Descent()
+		bounds.br.Y = dot.Y + a.Ascent()
 	}
-
 	dot.X += glyph.advance
-
-	return rect2, glyph.frame, bounds, dot
+	return position, bounds, glyph.frame
 }
 
 type fixedGlyph struct {

--- a/lib/textmeasure/fontface_cache_test.go
+++ b/lib/textmeasure/fontface_cache_test.go
@@ -1,0 +1,112 @@
+package textmeasure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/sfnt"
+)
+
+func legacyFontWidth(t *Ruler, fontSpec d2fonts.Font, s string) (float64, bool) {
+	sizelessFont := fontSpec
+	sizelessFont.Size = SIZELESS_FONT_SIZE
+	ttf, ok := t.ttfs[sizelessFont]
+	if !ok {
+		return 0, false
+	}
+
+	var buffer sfnt.Buffer
+	for _, r := range s {
+		index, err := ttf.font.GlyphIndex(&buffer, r)
+		if err != nil || (index == 0 && r != 0) {
+			return 0, false
+		}
+	}
+
+	face := ttf.newFace(float64(fontSpec.Size))
+	bounds, advance := font.BoundString(face, s)
+	left := min(bounds.Min.X, 0)
+	right := max(bounds.Max.X, advance)
+	return float64(right-left) / 64, true
+}
+
+func legacyFontAdvance(t *Ruler, fontSpec d2fonts.Font, s string) (float64, bool) {
+	sizelessFont := fontSpec
+	sizelessFont.Size = SIZELESS_FONT_SIZE
+	ttf, ok := t.ttfs[sizelessFont]
+	if !ok {
+		return 0, false
+	}
+
+	var buffer sfnt.Buffer
+	for _, r := range s {
+		index, err := ttf.font.GlyphIndex(&buffer, r)
+		if err != nil || (index == 0 && r != 0) {
+			return 0, false
+		}
+	}
+	face := ttf.newFace(float64(fontSpec.Size))
+	return float64(font.MeasureString(face, s)) / 64, true
+}
+
+func TestRulerFontFaceReuseMatchesFreshFaces(t *testing.T) {
+	r, err := NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for spec := range r.ttfs {
+		for _, size := range []int{-1, 0, 1, 16, 72, 4097} {
+			spec.Size = size
+			for _, text := range []string{"", "AV To Wjgy", " é 	", "界🙂e\u0301", strings.Repeat("longer table text ", 40), "after long text", string([]byte{0xff, 'A'})} {
+				wantWidth, wantSupported := legacyFontWidth(r, spec, text)
+				gotWidth, gotSupported := r.measureFontWidth(spec, text)
+				if !sameFloat(gotWidth, wantWidth) || gotSupported != wantSupported {
+					t.Fatalf("width font=%v text=%q got=%v,%v want=%v,%v", spec, text, gotWidth, gotSupported, wantWidth, wantSupported)
+				}
+				wantAdvance, wantSupported := legacyFontAdvance(r, spec, text)
+				gotAdvance, gotSupported := r.measureFontAdvance(spec, text)
+				if !sameFloat(gotAdvance, wantAdvance) || gotSupported != wantSupported {
+					t.Fatalf("advance font=%v text=%q got=%v,%v want=%v,%v", spec, text, gotAdvance, gotSupported, wantAdvance, wantSupported)
+				}
+			}
+		}
+	}
+	missing := d2fonts.Font{Family: "not loaded", Size: 16}
+	if _, ok := r.measureFontWidth(missing, "text"); ok {
+		t.Fatal("missing width font accepted")
+	}
+	if _, ok := r.measureFontAdvance(missing, "text"); ok {
+		t.Fatal("missing advance font accepted")
+	}
+}
+
+func TestRulerFontFacesHavePrivateScratchBuffers(t *testing.T) {
+	first, err := NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := d2fonts.SourceSansPro.Font(16, d2fonts.FONT_STYLE_REGULAR)
+	first.measureFontAdvance(spec, "first")
+	cached := first.faces[spec]
+	first.measureFontWidth(spec, "second")
+	first.addFontSize(spec)
+	if cached == nil || first.faces[spec] != cached || first.atlases[spec].face != cached {
+		t.Fatal("font face not reused within ruler")
+	}
+	second.measureFontAdvance(spec, "other")
+	if second.faces[spec] == cached {
+		t.Fatal("mutable font face shared between rulers")
+	}
+	larger := spec
+	larger.Size++
+	first.measureFontAdvance(larger, "size")
+	if first.faces[larger] == cached {
+		t.Fatal("font face shared between sizes")
+	}
+}

--- a/lib/textmeasure/fontface_cache_test.go
+++ b/lib/textmeasure/fontface_cache_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/d2lang/d2/d2renderers/d2fonts"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/sfnt"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
 )
 
 func legacyFontWidth(t *Ruler, fontSpec d2fonts.Font, s string) (float64, bool) {

--- a/lib/textmeasure/perf_measure_test.go
+++ b/lib/textmeasure/perf_measure_test.go
@@ -1,8 +1,9 @@
 package textmeasure
 
 import (
-	"github.com/d2lang/d2/d2renderers/d2fonts"
 	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
 )
 
 func BenchmarkRulerLabelMetrics(b *testing.B) {

--- a/lib/textmeasure/perf_measure_test.go
+++ b/lib/textmeasure/perf_measure_test.go
@@ -1,0 +1,44 @@
+package textmeasure
+
+import (
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"testing"
+)
+
+func BenchmarkRulerLabelMetrics(b *testing.B) {
+	for _, name := range []string{"legacy", "current"} {
+		b.Run(name, func(b *testing.B) {
+			r, err := NewRuler()
+			if err != nil {
+				b.Fatal(err)
+			}
+			spec := d2fonts.SourceSansPro.Font(16, d2fonts.FONT_STYLE_REGULAR)
+			r.addFontSize(spec)
+			text := "Service API -> event queue -> worker: processing request"
+			b.ReportAllocs()
+			for b.Loop() {
+				if name == "legacy" {
+					r.clear()
+					r.buf = append(r.buf, text...)
+					legacyDrawBuf(r, spec)
+				} else {
+					r.MeasurePrecise(spec, text)
+				}
+			}
+		})
+	}
+}
+func BenchmarkMarkdownTableMetrics(b *testing.B) {
+	md := "| Header | Second | Third |\n|---|---|---|\n| plain | **bold** | `code` |\n| next row | *italic* | a [link](https://example.com) |"
+	r, err := NewRuler()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err := LayoutMarkdown(md, r, nil, nil, 16)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/lib/textmeasure/ruler_metrics_test.go
+++ b/lib/textmeasure/ruler_metrics_test.go
@@ -1,0 +1,166 @@
+package textmeasure
+
+import (
+	"math"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"github.com/d2lang/d2/lib/geo"
+)
+
+// Independent pre-optimization drawing oracle: retain its allocations and
+// operation order to detect changes in geometry, control handling, and state.
+func legacyDrawRune(a *atlas, prevR, r rune, dot *geo.Point) (rect2, frame, bounds *rect, newDot *geo.Point) {
+	if !a.contains(r) {
+		r = unicode.ReplacementChar
+	}
+	if !a.contains(unicode.ReplacementChar) {
+		return newRect(), newRect(), newRect(), dot
+	}
+	if !a.contains(prevR) {
+		prevR = unicode.ReplacementChar
+	}
+
+	if prevR >= 0 {
+		dot.X += a.Kern(prevR, r)
+	}
+
+	glyph := a.glyph(r)
+
+	subbed := geo.NewPoint(
+		dot.X-glyph.dot.X,
+		dot.Y-glyph.dot.Y,
+	)
+
+	rect2 = &rect{
+		tl: geo.NewPoint(
+			glyph.frame.tl.X+subbed.X,
+			glyph.frame.tl.Y+subbed.Y,
+		),
+		br: geo.NewPoint(
+			glyph.frame.br.X+subbed.X,
+			glyph.frame.br.Y+subbed.Y,
+		),
+	}
+	bounds = rect2
+
+	if bounds.w()*bounds.h() != 0 {
+		bounds = &rect{
+			tl: geo.NewPoint(
+				bounds.tl.X,
+				dot.Y-a.Descent(),
+			),
+			br: geo.NewPoint(
+				bounds.br.X,
+				dot.Y+a.Ascent(),
+			),
+		}
+	}
+
+	dot.X += glyph.advance
+
+	return rect2, glyph.frame, bounds, dot
+}
+
+func legacyDrawBuf(txt *Ruler, font d2fonts.Font) {
+	if !utf8.FullRune(txt.buf) {
+		return
+	}
+
+	for utf8.FullRune(txt.buf) {
+		r, l := utf8.DecodeRune(txt.buf)
+		txt.buf = txt.buf[l:]
+
+		var control bool
+		txt.Dot, control = txt.controlRune(r, txt.Dot, font)
+		if control {
+			continue
+		}
+
+		var bounds *rect
+		_, _, bounds, txt.Dot = legacyDrawRune(txt.atlases[font], txt.prevR, r, txt.Dot)
+
+		txt.prevR = r
+
+		if txt.boundsWithDot {
+			txt.bounds = txt.bounds.union(&rect{txt.Dot, txt.Dot})
+			txt.bounds = txt.bounds.union(bounds)
+		} else {
+			if txt.bounds.w()*txt.bounds.h() == 0 {
+				txt.bounds = bounds
+			} else {
+				txt.bounds = txt.bounds.union(bounds)
+			}
+		}
+	}
+}
+
+func sameFloat(a, b float64) bool    { return math.Float64bits(a) == math.Float64bits(b) }
+func samePoint(a, b *geo.Point) bool { return sameFloat(a.X, b.X) && sameFloat(a.Y, b.Y) }
+func sameRect(a, b *rect) bool       { return samePoint(a.tl, b.tl) && samePoint(a.br, b.br) }
+
+func TestRulerMetricsMatchLegacy(t *testing.T) {
+	r, err := NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for spec := range r.ttfs {
+		for _, size := range []int{0, 1, 16, 72, 4097} {
+			spec.Size = size
+			r.addFontSize(spec)
+			for _, origin := range []geo.Point{{}, {X: .1, Y: -.3}, {X: -.5, Y: 13.25}, {X: 1 << 50, Y: -(1 << 50)}, {X: math.Copysign(0, -1), Y: math.Copysign(0, -1)}} {
+				for _, lineHeight := range []float64{1, 1.3, math.Sqrt2} {
+					for _, withDot := range []bool{false, true} {
+						r.Orig = origin.Copy()
+						r.LineHeightFactor = lineHeight
+						r.boundsWithDot = withDot
+						old := *r
+						old.buf = append([]byte(nil), r.buf...)
+						for _, text := range []string{"", "AVATAR To. Wjgy", " \t  ", "first\nsecond\n\nthird", "reset\rtext\tend", "aé界🙂e\u0301", string([]byte{0xff, 'A', 0xc3})} {
+							gotW, gotH := r.MeasurePrecise(spec, text)
+							old.clear()
+							old.buf = append(old.buf, text...)
+							legacyDrawBuf(&old, spec)
+							if !sameFloat(gotW, old.bounds.w()) || !sameFloat(gotH, old.bounds.h()) || !samePoint(r.Dot, old.Dot) || !sameRect(r.bounds, old.bounds) || r.prevR != old.prevR || string(r.buf) != string(old.buf) {
+								t.Fatalf("font=%v origin=%v lineHeight=%v withDot=%v text=%q got=(%v,%v,%v) want=(%v,%v,%v)", spec, origin, lineHeight, withDot, text, gotW, gotH, r.Dot, old.bounds.w(), old.bounds.h(), old.Dot)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestDrawRuneMetricsMatchLegacy(t *testing.T) {
+	parsed, err := parseFont(d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, size := range []float64{0, 16.25, 65536} {
+		a := NewAtlas(parsed.newFace(size), Runes)
+		for _, dot := range []geo.Point{{}, {X: .1, Y: -.3}, {X: 1 << 53, Y: -(1 << 53)}, {X: math.Inf(1), Y: math.Inf(-1)}, {X: math.NaN(), Y: math.NaN()}} {
+			for _, r := range []rune{'A', ' ', 'g', '界', unicode.ReplacementChar} {
+				for _, previous := range []rune{-1, 'A', '界'} {
+					actualDot, wantDot := dot.Copy(), dot.Copy()
+					gotPosition, gotFrame, gotBounds, gotDot := a.DrawRune(previous, r, actualDot)
+					wantPosition, wantFrame, wantBounds, wantDot := legacyDrawRune(a, previous, r, wantDot)
+					if !sameRect(gotPosition, wantPosition) || !sameRect(gotFrame, wantFrame) || !sameRect(gotBounds, wantBounds) || !samePoint(gotDot, wantDot) {
+						t.Fatalf("size=%v dot=%v previous=%q rune=%q", size, dot, previous, r)
+					}
+					if (gotPosition == gotBounds) != (wantPosition == wantBounds) || gotDot != actualDot {
+						t.Fatal("DrawRune aliasing changed")
+					}
+				}
+			}
+		}
+	}
+	a := &atlas{mapping: map[rune]glyph{}}
+	dot := geo.NewPoint(1, 2)
+	_, _, bounds, returned := a.DrawRune('A', 'B', dot)
+	if !sameRect(bounds, newRect()) || returned != dot || *dot != (geo.Point{X: 1, Y: 2}) {
+		t.Fatal("missing replacement glyph changed")
+	}
+}

--- a/lib/textmeasure/textmeasure.go
+++ b/lib/textmeasure/textmeasure.go
@@ -96,7 +96,8 @@ type Ruler struct {
 
 	atlases map[d2fonts.Font]*atlas
 
-	ttfs map[d2fonts.Font]*parsedFont
+	ttfs  map[d2fonts.Font]*parsedFont
+	faces map[d2fonts.Font]font.Face
 
 	buf    []byte
 	prevR  rune
@@ -127,6 +128,7 @@ func NewRuler() (*Ruler, error) {
 		tabWidths:        make(map[d2fonts.Font]float64),
 		atlases:          make(map[d2fonts.Font]*atlas),
 		ttfs:             make(map[d2fonts.Font]*parsedFont),
+		faces:            make(map[d2fonts.Font]font.Face),
 	}
 
 	for _, fontFamily := range d2fonts.FontFamilies {
@@ -174,11 +176,22 @@ func (r *Ruler) HasFontFamilyLoaded(fontFamily *d2fonts.FontFamily) bool {
 func (r *Ruler) addFontSize(font d2fonts.Font) {
 	sizeless := font
 	sizeless.Size = SIZELESS_FONT_SIZE
-	face := r.ttfs[sizeless].newFace(float64(font.Size))
+	face := r.fontFace(font, r.ttfs[sizeless])
 	atlas := NewAtlas(face, Runes)
 	r.atlases[font] = atlas
 	r.lineHeights[font] = atlas.lineHeight
 	r.tabWidths[font] = atlas.glyph(' ').advance * TAB_SIZE
+}
+
+// fontFace retains the per-size scratch buffers used by immutable font metrics.
+// A Ruler already owns mutable drawing state and must not be used concurrently.
+func (r *Ruler) fontFace(spec d2fonts.Font, parsed *parsedFont) font.Face {
+	if face := r.faces[spec]; face != nil {
+		return face
+	}
+	face := parsed.newFace(float64(spec.Size))
+	r.faces[spec] = face
+	return face
 }
 
 func (t *Ruler) measureFontWidth(fontSpec d2fonts.Font, s string) (float64, bool) {
@@ -197,7 +210,7 @@ func (t *Ruler) measureFontWidth(fontSpec d2fonts.Font, s string) (float64, bool
 		}
 	}
 
-	face := ttf.newFace(float64(fontSpec.Size))
+	face := t.fontFace(fontSpec, ttf)
 	bounds, advance := font.BoundString(face, s)
 	left := min(bounds.Min.X, 0)
 	right := max(bounds.Max.X, advance)
@@ -223,7 +236,7 @@ func (t *Ruler) measureFontAdvance(fontSpec d2fonts.Font, s string) (float64, bo
 			return 0, false
 		}
 	}
-	face := ttf.newFace(float64(fontSpec.Size))
+	face := t.fontFace(fontSpec, ttf)
 	return float64(font.MeasureString(face, s)) / 64, true
 }
 
@@ -618,21 +631,22 @@ func (txt *Ruler) drawBuf(font d2fonts.Font) {
 			continue
 		}
 
-		var bounds *rect
-		_, _, bounds, txt.Dot = txt.atlases[font].DrawRune(txt.prevR, r, txt.Dot)
-
+		_, bounds, _ := txt.atlases[font].measureRune(txt.prevR, r, txt.Dot)
 		txt.prevR = r
 
 		if txt.boundsWithDot {
-			txt.bounds = txt.bounds.union(&rect{txt.Dot, txt.Dot})
-			txt.bounds = txt.bounds.union(bounds)
-		} else {
-			if txt.bounds.w()*txt.bounds.h() == 0 {
-				txt.bounds = bounds
-			} else {
-				txt.bounds = txt.bounds.union(bounds)
-			}
+			txt.bounds.tl.X = math.Min(txt.bounds.tl.X, txt.Dot.X)
+			txt.bounds.tl.Y = math.Min(txt.bounds.tl.Y, txt.Dot.Y)
+			txt.bounds.br.X = math.Max(txt.bounds.br.X, txt.Dot.X)
+			txt.bounds.br.Y = math.Max(txt.bounds.br.Y, txt.Dot.Y)
+		} else if txt.bounds.w()*txt.bounds.h() == 0 {
+			*txt.bounds.tl, *txt.bounds.br = bounds.tl, bounds.br
+			continue
 		}
+		txt.bounds.tl.X = math.Min(txt.bounds.tl.X, bounds.tl.X)
+		txt.bounds.tl.Y = math.Min(txt.bounds.tl.Y, bounds.tl.Y)
+		txt.bounds.br.X = math.Max(txt.bounds.br.X, bounds.br.X)
+		txt.bounds.br.Y = math.Max(txt.bounds.br.Y, bounds.br.Y)
 	}
 }
 


### PR DESCRIPTION
## Human

---

## AI

Reduce repeated work during layout, text measurement, SVG preparation and PNG encoding:

- Update Dagro to v0.2.1, incorporating the ranking/traversal improvements in https://github.com/d2lang/dagro/pull/4.
- Measure glyph bounds without per-character heap rectangles and reuse font faces within a Ruler.
- Build the font text corpus with one string builder and skip JSON decoding when no icon URL needs normalization.
- Skip Up-filter arithmetic for a PNG row identical to its predecessor. This is a four-line shortcut; more aggressive block variants were rejected after mixed-image regressions.

Geometry, SVG and PNG output bytes are unchanged. Font and layout scratch remains local to the owning Ruler/layout.

### Benchmarks

Full CLI exports, including startup, compilation, layout, rendering and file output:

| Diagram/export | Before | After | Speedup |
|---|---:|---:|---:|
| TPMJS Dagre SVG | 163.57 ms | 109.40 ms | 1.50× |
| Spyre Dagre SVG | 40.79 ms | 36.78 ms | 1.11× |
| Lion Reader Dagre SVG | 33.17 ms | 31.44 ms | 1.06× |
| TPMJS Dagre PNG, 1× | 934.28 ms | 855.54 ms | 1.09× |
| TPMJS Dagre PNG, default 2× | 3150.94 ms | 2986.98 ms | 1.05× |

Apple M4, Go 1.27.0, GOMAXPROCS=1, one warmup and six alternating baseline/candidate process pairs per case. Ratios divide variant medians. Baseline D2 is `70affc0e`; measured candidate D2 is `8f5bd501d` with Dagro `1b61d9e`. The release dependency has the same Dagro source tree. With normal Go CPU settings, TPMJS SVG improves 1.33×. Across 13 inputs (10 real-world diagrams and three basics), geometric means are 1.07× Dagre SVG, 1.01× ELK SVG, 1.04× Dagre PNG and 1.03× ELK PNG. Small exports remain near their startup floor.

Component benchmarks:

| Operation | Before | After |
|---|---:|---:|
| TPMJS Dagre layout | 135.92 ms; 100.86 MB allocated | 81.76 ms; 52.20 MB allocated |
| Mixed Markdown table measurement | 1.412 ms; 34,982 allocations | 0.714 ms; 5,647 allocations |
| Ordinary label measurement | 7,760 bytes; 482 allocations | 128 bytes; 5 allocations |
| Font text corpus, synthetic 10,000 labels | 1.49 GB allocated | 1.54 MB allocated |

These time the named operation, not the whole diagram. Allocation bytes are cumulative traffic, not peak live memory. The flat PNG microbenchmark improves 1.58×; gradient, noise and mixed-margin cases remain effectively unchanged. Local timings contain system noise; unfavorable samples were retained and small differences should not be treated as guaranteed improvements.

### Validation

- Full Go tests, targeted race checks, vet, WASM build and Linux 386 test compilation.
- All 672 E2E output hashes and 7,257 per-case phase invocation counts match the baseline; no golden changes.
- All measured output bytes match across 62 CLI cases, plus normal-CPU and D2-only controls, using `--omit-version` to exclude version metadata.
- Added frozen glyph/font-face oracles, corpus/hash normalization cases, scalar PNG-filter comparisons, mixed-image byte equality and retained-state checks.
- Upstream Dagro additionally preserves 1,320 frozen layouts and 241 separately checked weighted ranking exchanges.

Reproduce the component benchmarks with `GOMAXPROCS=1 go test -p 1 ./d2layouts/d2dagrelayout ./lib/textmeasure ./d2target ./d2cli -run '^$' -bench 'Benchmark(DagreRealWorld|MarkdownTableMetrics|RulerLabelMetrics|DiagramCorpus|DiagramHashJSON|RasterPNGEncoder|RasterPNGMixedContent)$' -benchmem`. The PNG CLI cases use `--scale 0.5` for effective 1×, except existing Lion Reader/Ross appendix behavior at 2×; the three default-density controls use 2×.
