### PR TITLE
Preserve TALA seed configuration in nested layouts

### DIFF
--- a/d2layouts/d2layouts.go
+++ b/d2layouts/d2layouts.go
@@ -475,6 +475,7 @@ func extractSubgraphs(g *d2graph.Graph, specs []subgraphExtractionSpec) *subgrap
 			}
 		}
 		nestedGraph := d2graph.NewGraph()
+		nestedGraph.Data = cloneGraphData(g.Data)
 		nestedGraph.RootLevel = int(spec.container.Level())
 		if spec.includeSelf {
 			nestedGraph.RootLevel--
@@ -605,10 +606,39 @@ func (b *subgraphExtractionBatch) rollbackAfter(index int) {
 	}
 }
 
+// Clone JSON-shaped source configuration for nested layout calls so a plugin
+// cannot change the configuration of the parent or another nested diagram.
+func cloneGraphData(data map[string]interface{}) map[string]interface{} {
+	if data == nil {
+		return nil
+	}
+	clone := make(map[string]interface{}, len(data))
+	for key, value := range data {
+		clone[key] = cloneGraphDataValue(value)
+	}
+	return clone
+}
+
+func cloneGraphDataValue(value interface{}) interface{} {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		return cloneGraphData(value)
+	case []interface{}:
+		clone := make([]interface{}, len(value))
+		for i, entry := range value {
+			clone[i] = cloneGraphDataValue(entry)
+		}
+		return clone
+	default:
+		return value
+	}
+}
+
 func ExtractSubgraph(container *d2graph.Object, includeSelf bool) (nestedGraph *d2graph.Graph, externalEdges []*d2graph.Edge, externalEdgeIDs []edgeIDs) {
 	// includeSelf: when we have a constant near or a grid cell that is a container,
 	// we want to include itself in the nested graph, not just its descendants,
 	nestedGraph = d2graph.NewGraph()
+	nestedGraph.Data = cloneGraphData(container.Graph.Data)
 	nestedGraph.RootLevel = int(container.Level())
 	if includeSelf {
 		nestedGraph.RootLevel--

--- a/d2layouts/d2layouts_test.go
+++ b/d2layouts/d2layouts_test.go
@@ -313,3 +313,43 @@ func BenchmarkLayoutNestedPartitions(b *testing.B) {
 		})
 	}
 }
+
+func TestExtractSubgraphsPreservesIndependentConfigData(t *testing.T) {
+	for _, batched := range []bool{false, true} {
+		t.Run(fmt.Sprintf("batched=%t", batched), func(t *testing.T) {
+			g := compileLayoutTestGraph(t, `grid: {grid-columns: 1; a -> b}
+note: {near: top-left; c -> d}`)
+			data := map[string]interface{}{
+				"tala-seeds": []interface{}{"7", "11"},
+				"metadata":   map[string]interface{}{"name": "original"},
+			}
+			g.Data = map[string]interface{}{
+				"tala-seeds": []interface{}{"7", "11"},
+				"metadata":   map[string]interface{}{"name": "original"},
+			}
+			specs := collectNestedExtractions(g)
+			var graphs []*d2graph.Graph
+			if batched {
+				batch := extractSubgraphs(g, specs)
+				for _, spec := range specs {
+					graphs = append(graphs, batch.extractions[spec.container].nestedGraph)
+				}
+			} else {
+				for _, spec := range specs {
+					nested, _, _ := ExtractSubgraph(spec.container, spec.includeSelf)
+					graphs = append(graphs, nested)
+				}
+			}
+			for _, graph := range graphs {
+				if !reflect.DeepEqual(graph.Data, data) {
+					t.Fatalf("nested data = %#v, want %#v", graph.Data, data)
+				}
+				graph.Data["tala-seeds"].([]interface{})[0] = "changed"
+				graph.Data["metadata"].(map[string]interface{})["name"] = "changed"
+			}
+			if !reflect.DeepEqual(g.Data, data) {
+				t.Fatalf("nested layout changed parent data: %#v", g.Data)
+			}
+		})
+	}
+}

--- a/d2lib/d2_test.go
+++ b/d2lib/d2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2layouts/d2talalayout"
 	"github.com/d2lang/d2/lib/geo"
 	d2log "github.com/d2lang/d2/lib/log"
 	"github.com/d2lang/d2/lib/textmeasure"
@@ -91,5 +92,59 @@ steps: {
 		if !reflect.DeepEqual(seeds, want) {
 			t.Fatalf("board %d tala-seeds = %#v, want %#v", i, seeds, want)
 		}
+	}
+}
+
+func TestCompileTALAConfigSeedsInNestedLayouts(t *testing.T) {
+	const nodes = `a -> b -> c
+a -> d -> e
+b -> e
+d -> c
+f -> e
+g -> b
+`
+	const config = `vars: {d2-config: {layout-engine: tala; data: {tala-seeds: [7]}}}
+`
+	for _, tc := range []struct{ name, source string }{
+		{"plain", nodes},
+		{"grid-cell", "grid: {grid-columns: 1\ncell: {\n" + nodes + "}\n}\n"},
+		{"batched-grids", "grid1: {grid-columns: 1\ncell: {\n" + nodes + "}\n}\ngrid2: {grid-columns: 1\ncell: {\n" + nodes + "}\n}\n"},
+		{"constant-near", "main\nlegend: {near: top-left\n" + nodes + "}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ruler, err := textmeasure.NewRuler()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := d2log.WithDefault(t.Context())
+			opts := &CompileOptions{
+				Ruler: ruler,
+				RouterResolver: func(string) (d2graph.RouteEdges, error) {
+					return d2talalayout.RouteEdges, nil
+				},
+			}
+			setSeeds := func(seed int64) {
+				opts.LayoutResolver = func(string) (d2graph.LayoutGraph, error) {
+					return func(ctx context.Context, g *d2graph.Graph) error {
+						return d2talalayout.Layout(ctx, g, &d2talalayout.Options{Seeds: []int64{seed}, MaxConcurrency: 1})
+					}, nil
+				}
+			}
+			setSeeds(7)
+			want, _, err := Compile(ctx, config+tc.source, opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Source seeds must override the supplied options in every core
+			// layout call, including graphs extracted for nested diagrams.
+			setSeeds(1)
+			got, _, err := Compile(ctx, config+tc.source, opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatal("layout changed when source seeds override the supplied options")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Human

---

## AI

A diagram with source configuration `data: {tala-seeds: [7]}` could produce different grid-cell or constant-near layouts when `--tala-seeds` changed. Both subgraph extraction paths discarded graph data before invoking the nested layout engine, so source seeds no longer took precedence over supplied options there.

Preserve an independent copy of JSON-shaped source configuration in each extracted graph. This covers both sequential and batched extraction while preventing a nested layout from modifying its parent's or sibling's configuration.

Regression tests cover single grids, batched grids, constant-near containers, a plain-diagram control, and configuration ownership. The tests fail on the merged source and pass with this fix. Existing layout goldens are unchanged.

Validation: full repository Go suite passes (78 tested packages), affected-package race tests and vet pass, and actual CLI renders with source seed 7 now produce identical output with command-line seeds 1 and 7.
