### PR TITLE
Prepare D2 0.9.0 and version its WASM release

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string
         default: nightly
+      d2_ref:
+        description: Exact D2 release tag to build, or empty for the dispatched master commit
+        required: false
+        type: string
+        default: ""
 permissions:
   contents: read
 
@@ -17,7 +22,7 @@ concurrency:
 
 jobs:
   pack:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && github.ref_protected
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -25,6 +30,22 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Select the exact D2 release source
+        if: inputs.d2_ref != ''
+        env:
+          D2_REF: ${{ inputs.d2_ref }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$D2_REF" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "d2_ref must be a v-prefixed semantic-version tag" >&2
+            exit 1
+          fi
+          source_commit=$(git rev-parse --verify "refs/tags/$D2_REF^{commit}")
+          git merge-base --is-ancestor "$source_commit" "$GITHUB_SHA"
+          git checkout --detach "$source_commit"
+          git submodule update --init --recursive
+          echo "Building D2 $D2_REF from $source_commit" >>"$GITHUB_STEP_SUMMARY"
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -18,6 +18,12 @@ must separately trust the `d2lang/d2` `npm-stage.yml` workflow for stage-only pu
 Each trusted publisher is restricted to the `npm-release` GitHub environment, whose
 deployment branch policy accepts only protected branches. The workflow itself also
 refuses to pack from any ref other than `refs/heads/master`.
+To package a specific D2 release, dispatch from `master` with `d2_ref` set to its
+exact tag, for example `v0.9.0`. The workflow verifies that the tag is an ancestor
+of the dispatched commit, then builds that tag's source. The npm version must be
+checked into that source before the D2 release is tagged. Without `d2_ref`, the
+workflow builds the dispatched master commit. The WASM reports its exact D2 tag
+or source commit independently of the npm version.
 The canonical package was bootstrapped once from the existing `@terrastruct/d2@0.1.33`
 built artifacts because npm does not allow a brand-new package to use staged publishing.
 

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,5 +1,7 @@
 #### Features 🚀
 
+- TALA is now open source and bundled with D2, including the JavaScript/WASM package. Select it with `d2 --layout=tala`, `D2_LAYOUT=tala`, or `vars.d2-config.layout-engine: tala`. No separate plugin installation or license key is required.
+- tala: configure layout attempts with `--tala-seeds`, `D2_TALA_SEEDS`, or `vars.d2-config.data.tala-seeds`.
 - exports: render PNG, GIF, PDF, and PPTX with the built-in renderer
 
 #### Improvements 🧹
@@ -7,73 +9,17 @@
 - performance: reduce repeated work in Dagre ranking, text measurement, SVG preparation, and PNG encoding
 - performance: reduce repeated work in selective imports, dynamic grid layout, and PNG connection rendering
 - exports: reduce PNG memory usage and support images above the previous 67-megapixel limit
-- tala: replace the Dagre-derived hierarchy ranker with an independently written deterministic network-simplex implementation based on the published algorithm, remove the fixed iteration cap, and remove TALA's Dagre license notice
-- tala: consume D2's canonical sequence-lifeline ID API and remove the private signed-ID compatibility path
-- tala: make D2 the only supported integration boundary: keep only options, layout, and routing public; remove the standalone SeedGraph transport and worker protocol, unreachable prearranged and fixed-size modes, the vestigial containment stage, and test-only topology transactions
-- tala: remove per-stage layout JSON goldens and their acceptance and inventory harness; retain input/final layout goldens and focused stage-invariant tests
-- tala: make internal graph fixtures current-only: reject unknown and trailing JSON, require unambiguous edge IDs, and remove obsolete arrowhead spellings and redundant adjacency, hierarchy, label-position, and vessel fields
-- tala: require explicit non-negative work limits: reject negative limits and treat zero as a zero-work budget instead of an unbounded compatibility mode
-- tala: enforce the shared placement work budget across disconnected-cluster discovery, overlap checks, and subtree movement, restoring exact geometry when the first over-limit unit follows an accepted move
-- tala: restore exact gap-normalization geometry, cell size, and placement-cost state when a work-limit error, cancellation, or panic interrupts the stage after an earlier accepted move
-- tala: restore exact cluster geometry, policy, cell size, and placement-cost state when an error, cancellation, or panic interrupts cluster optimization
-- tala: restore exact stage-entry geometry when a work-limit error, cancellation, or panic interrupts symmetry balancing after an earlier node move
-- tala: reuse bounded per-level scratch while counting graph edge crossings without changing crossing results or cancellation checks. On Apple M4, `big_many_subgraphs` uses 40.4 MB and 107,675 fewer allocations per layout, while `us_map` uses 12.5 MB and 46,236 fewer; four representative layout medians show no regression
-- tala: restore exact node geometry and edge routes when cancellation or a panic interrupts the Dejitter placement stage
-- tala: restore exact node geometry when cancellation or a panic interrupts disconnected-cluster joining during placement
-- tala: move a single-node edge-port-swap adapter used only by routing unit tests into the test file; the whole-graph production stage and guarded swap core are unchanged
-- tala: move an even-distribution helper used only by routing unit tests into the test file; guarded production balancing is unchanged
-- tala: move an OVG port-orientation helper used only by one routing unit test into the test file; guarded production port filtering is unchanged
-- tala: move two sizeless-optimizer work-guard adapters used only by their unit tests into the test file; guarded production paths are unchanged
-- tala: remove a stale unused routing box-overlap helper reintroduced after callers moved to the shared `geo.Box` implementation; live routing overlap checks are unchanged
-- tala: remove an unused node-level unrounded-bounding-box delegate orphaned by the mechanical bounding-box hot-path rewrite; live graph and node-list bounding-box paths are unchanged
-- tala: move a node-to-point distance convenience method used only by its layoutgraph unit test into the test file; production distance helpers are unchanged
-- tala: move a transaction constructor convenience method used only by layoutgraph resource tests into the test file; options-aware production paths are unchanged
-- tala: move two unguarded reachability methods used only by layoutgraph unit tests into the test file; context-aware production paths are unchanged
-- tala: move two unguarded label-placement convenience functions used only by their unit tests into the test file; checked production paths are unchanged
-- tala: move two unguarded OVG edge-set convenience methods used only by their unit tests into the test file; guarded production paths are unchanged
-- tala: remove three unused layoutgraph copies of placement math helpers left by engine domain modularization
-- tala: move two route-blocker convenience wrappers used only by the BinPack cancellation regression into its test file; the production delta-aware guarded route blocker is unchanged
-- tala: bypass node-order sorting for empty and singleton lists. In Apple M4 `Cleanup` microbenchmarks, zero- and one-group layouts use 48 fewer bytes and two fewer allocations per operation, while eight-cluster timing remains neutral
-- tala: remove test-only routing constructors from production and make explicit-limit port swapping private
-- tala: remove orphaned layoutgraph angle helpers and their self-test left behind by engine modularization
-- tala: remove two unused private edge-routing angle helpers
-- tala: move test-only edge-routing convenience wrappers out of the production routing implementation
-- tala: require caller-owned context-derived OVG build guards in the remaining private routing helpers, keeping cancellation and resource accounting explicit
-- tala: require live OVG build guards in contextless routing helpers instead of silently creating uncancelable fallback guards
-- tala: remove unused internal node-overlap, inclusive-containment, route-formatting, and Fibonacci-heap allocation helpers
-- tala: filter retired cluster vessels from graph and container lists once per reset instead of rescanning every list for every cluster. On Apple M4, `ResetClusters` is 2.54x faster for an 8-cluster relayout and 44.0x faster for a 512-cluster stress case, with unchanged allocations and no single-cluster regression
-- tala: remove the unused full transaction-clone API and its snapshot-cloning machinery, leaving geometry-only speculative cloning as the single supported path
-- tala: avoid allocating and sorting temporary slices when optimizer median scoring has one neighbor. On Apple M4, representative placement uses 8,414 fewer allocations per operation (3.99%) and 1.02% fewer bytes with neutral runtime
-- tala: reuse one shared read-only layout-stage plan, time stages only when benchmark instrumentation requests it, and avoid allocating route-snapshot observers when snapshots are disabled. On Apple M4, pipeline construction falls from 42 to 5 allocations (12,800 to 10,976 B/op)
-- tala: make raw graph serialization and deserialization consistently context-first and remove duplicate non-cancelable wrappers
-- tala: move sized-optimizer testing conveniences out of the production placement implementation
-- tala: remove the test-only contextless sequence-identification facade from the production grouping API
-- tala: make deliberately unmetered internal graph traversals use a shared no-op work stepper instead of allocating and polling an uncancelable guard
-- tala: adopt test-owned contexts across TALA facade and engine tests, and use Go 1.27 benchmark loops in engine and placement benchmarks
-- tala: replace reflection-based slice sorting and manual slice copies with typed standard-library helpers while preserving deterministic tie ordering and layout output. In an Apple M4 1,024-identity sort microbenchmark, median time falls 37.3% (40.5µs to 25.4µs) and reflection overhead falls from 104 B/3 allocations to zero
-- tala: restore exact node graph ownership when placement fails after temporarily splitting Near-connected subgraphs
-- tala: accelerate transaction validation, node placement, and orthogonal edge routing while preserving existing layout output and resource-limit behavior. Median Apple M4 benchmarks improve `label_positions` E2E by 7.2×, `nesting_power` resource rejection by 14.6×, and `tables_slow_edge_routing` by 5.5× while reducing allocated bytes by 95.5% and allocations by 96.1%
-- tala: reduce allocation overhead in placement scoring, table-column geometry, bounding boxes, topology validation, and empty-route checks while preserving existing layout output. Median Apple M4 single-CPU benchmarks improve `tables_slow_edge_routing`, `18tables`, and `big_connected` by 16.6%, 15.5%, and 10.1%; allocated bytes fall by 27.3–56.5% and allocations by 57.8–70.5%
 - performance: SVG rendering is approximately 10× faster across the E2E corpus. Real-world diagrams compile, lay out, and render approximately 3× faster at the median.
 - renders: SVG exports are approximately 24% smaller across the E2E corpus and 18% smaller across real-world fixtures, with unchanged appearance.
 - renders: render Markdown labels as native SVG instead of HTML `foreignObject` content
 
 #### Bugfixes ⛑️
 
-- tala: count actual routing index work instead of eliminated comparisons, allowing large diagrams such as TPMJS and `nesting_power` to render within the existing resource limits
-- tala: select the lowest-penalty seed independently of completion order, using area and then the later configured seed only for exact ties
-- tala: preserve SQL table row connections for reverse arrows between tables and ordinary shapes
 - install: reject the obsolete `--tala` installer flag with migration guidance before installing, instead of incorrectly claiming that older D2 releases bundle TALA
 - sequence diagrams: keep synthetic lifeline endpoint IDs stable across architectures
 - exports: honor `D2_TIMEOUT` during PNG and GIF rendering
 - compiler: keep recursive globs out of class and variable definitions and report class reference cycles instead of overflowing the stack
 - renders: decode gzip, Brotli, and deflate remote images before embedding them
-- tala: restore straight-edge fallback routes and routing-cost caches when cancellation or panic interrupts the stage
-- tala: restore duplicate-edge routes when duplicate reordering panics after a tentative swap
-- tala: propagate request cancellation while snapshotting subgraph positions during compaction
-- tala: restore exact external node ownership after hierarchy discovery and placement traverse temporary edge- or Near-connected subgraphs
-
-- tala: reconcile overlapping sibling placement groups before choosing their shared side, fixing the Lion Reader layout failure
 
 ---
 

--- a/ci/release/release-js.sh
+++ b/ci/release/release-js.sh
@@ -4,15 +4,17 @@ cd -- "$(dirname "$0")/../.."
 . "./ci/sub/lib.sh"
 
 VERSION=""
+D2_REF=""
 
 help() {
   cat <<EOF
-usage: $0 --version=<version>
+usage: $0 --version=<version> [--d2-ref=<tag>]
 
 Dispatches the protected npm staging workflow for both d2.js package identities.
 
 Flags:
-  --version     Version to stage (e.g., "0.1.2" or "nightly"). Note this is the js version, not related to the d2 version. A non-nightly version will use the latest tag after approval.
+  --version     npm version to stage (e.g., "0.1.2" or "nightly"), independent of the D2 version. Stable packages use npm's latest tag after approval.
+  --d2-ref      Exact D2 release tag to build (e.g., "v0.9.0"). It must be an ancestor of master. Omit to build the dispatched master commit.
 EOF
 }
 
@@ -24,6 +26,9 @@ for arg in "$@"; do
       ;;
     --version=*)
       VERSION="${arg#*=}"
+      ;;
+    --d2-ref=*)
+      D2_REF="${arg#*=}"
       ;;
   esac
 done
@@ -46,6 +51,7 @@ FGCOLOR=6 header "Staging JavaScript packages for npm review (version: $VERSION)
 gh workflow run npm-stage.yml \
   --repo d2lang/d2 \
   --ref master \
-  --field "version=$VERSION"
+  --field "version=$VERSION" \
+  --field "d2_ref=$D2_REF"
 
 FGCOLOR=2 header 'npm staging workflow dispatched; approve both package stages after every job succeeds'

--- a/d2js/js/CHANGELOG.md
+++ b/d2js/js/CHANGELOG.md
@@ -5,6 +5,10 @@ include changes to the main d2 project.**
 
 ## Next
 
+## [0.1.34]
+### September 7, 2026
+
+- Support D2 0.9.0, including the bundled open-source TALA layout engine (`layout: "tala"`) and configurable TALA seeds.
 - Add `D2.dispose()` for terminating the backing worker
 - Fix concurrent calls sharing a D2 instance
 - Fix completions after Unicode characters
@@ -13,7 +17,6 @@ include changes to the main d2 project.**
 - Fix theme-overrides not applying
 - Fix grids in ELK layouts
 - Significantly reduce bundle size
-- Support D2 0.7.1
 
 ## [0.1.22]
 ### March 20, 2025

--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -17,7 +17,10 @@ if [ -n "${NPM_VERSION:-}" ]; then
 else
   JS_VERSION=$(awk -F'"' '/"version"/ {print $4}' ./d2js/js/package.json)
 fi
-sh_c "GOOS=js GOARCH=wasm go build -ldflags='-s -w -X github.com/d2lang/d2/d2js/d2wasm.jsVersion=${JS_VERSION}' -trimpath -o main.wasm ./d2js"
+# Match native builds: identify the exact release tag, or the source commit for
+# an untagged development build. The npm package has its own independent version.
+D2_VERSION=$(git_describe_ref)
+sh_c "GOOS=js GOARCH=wasm go build -ldflags='-s -w -X github.com/d2lang/d2/lib/version.Version=${D2_VERSION} -X github.com/d2lang/d2/d2js/d2wasm.jsVersion=${JS_VERSION}' -trimpath -o main.wasm ./d2js"
 
 if [ -n "${NPM_VERSION:-}" ]; then
   # Optimize with wasm-opt if available

--- a/d2js/js/package-lock.json
+++ b/d2js/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d2lang/d2",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@d2lang/d2",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "MPL-2.0",
       "devDependencies": {
         "bun": "1.3.14",

--- a/d2js/js/package.json
+++ b/d2js/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@d2lang/d2",
   "description": "D2.js is a wrapper around the WASM build of D2, the modern text-to-diagram language.",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/d2lang/d2.git",

--- a/d2js/js/test/unit/basic.test.js
+++ b/d2js/js/test/unit/basic.test.js
@@ -399,7 +399,7 @@ vars: {
     const version = await d2.version();
     expect(version).toBeDefined();
     expect(typeof version).toBe("string");
-    expect(version).toContain("v");
+    expect(version).toMatch(/^(v\d+\.\d+\.\d+(?:-[\w.-]+)?|[0-9a-f]{7,40})$/);
     await d2.dispose();
   }, 20000);
 

--- a/d2js/js/test/unit/concurrency.test.js
+++ b/d2js/js/test/unit/concurrency.test.js
@@ -181,7 +181,7 @@ test("correlates every operation through the real worker", async () => {
   expect(rendered).toContain("base");
   expect(await d2.decode(encoded)).toBe("encoded result");
   expect(decoded).toBe("decoded result");
-  expect(version).toMatch(/^v?\d+\.\d+\.\d+/);
+  expect(version).toMatch(/^(v\d+\.\d+\.\d+(?:-[\w.-]+)?|[0-9a-f]{7,40})$/);
   expect(jsVersion).toBe(packageJson.version);
   await d2.dispose();
 }, 20000);


### PR DESCRIPTION
## Human

---

## AI

Prepare D2 0.9.0 and the matching d2.js 0.1.34 package. The release notes introduce bundled open-source TALA and its configuration, summarize the new exports and rendering improvements, and replace the private TALA development history with user-facing release information.

The WASM build now reports the exact D2 tag or source commit independently of the npm version. npm staging can select an exact release tag already merged into the protected master branch, so the playground can consume the same D2 source as the native release.

Validation: build and exercise the actual WASM package, run the JavaScript unit and type checks, and run the 37 release preparation/upload regression tests. Release publication follows the exact-tag native archive, MSI, and npm artifact checks.
