### PR TITLE
Build npm releases without modifying the source checkout

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -84,9 +84,11 @@ jobs:
           NPM_PUBLISH_MODE: pack
           NPM_VERSION: ${{ inputs.version }}
         run: |
-          CI_FORCE=1 CI_MAKE_ROOT=0 COLOR=1 ./make.sh js
           cd d2js/js
-          bun test test/unit
+          bun install --frozen-lockfile
+          ./ci/build.sh
+          bun run test:all
+          git diff --exit-code
 
       - name: Upload immutable package tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Human

---

## AI

Build npm release packages without formatting or regenerating the selected D2 source. The previous workflow invoked the top-level development make target, which reformatted existing example files and failed its clean-source check before building the 0.9.0 WASM package.

Install the frozen JavaScript dependencies, run the package build directly, then run all JavaScript type, unit, and installed-package tests and require a clean tracked diff. The package still uses the exact selected release tag; this only changes workflow orchestration and does not change the published native release.
