### PR TITLE
fix: honor D2_STDOUT_FORMAT environment variable

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -103,7 +103,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	stdoutFormatFlag := ms.Opts.String("", "stdout-format", "", "", "output format when writing to stdout (svg, png, ascii, txt, pdf, pptx, gif). Usage: d2 input.d2 --stdout-format png - > output.png")
+	stdoutFormatFlag := ms.Opts.String("D2_STDOUT_FORMAT", "stdout-format", "", "", "output format when writing to stdout (svg, png, ascii, txt, pdf, pptx, gif). Usage: d2 input.d2 --stdout-format png - > output.png")
 	if err != nil {
 		return err
 	}

--- a/d2cli/stdout_format_env_test.go
+++ b/d2cli/stdout_format_env_test.go
@@ -1,0 +1,70 @@
+package d2cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/d2lang/util-go/xmain"
+	"github.com/d2lang/util-go/xos"
+)
+
+func TestRunStdoutFormatEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		env       string
+		flags     []string
+		wantPDF   bool
+		wantError string
+	}{
+		{name: "environment_selects_pdf", env: "pdf", wantPDF: true},
+		{name: "flag_overrides_environment", env: "pdf", flags: []string{"--stdout-format=svg"}},
+		{name: "flag_overrides_invalid_environment", env: "not-a-format", flags: []string{"--stdout-format=svg"}},
+		{name: "empty_environment_preserves_default"},
+		{name: "invalid_environment_is_reported", env: "not-a-format", wantError: "not-a-format is not a supported format"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			inputPath := filepath.Join(dir, "input.d2")
+			if err := os.WriteFile(inputPath, []byte("a -> b\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			env := xos.NewEnv(nil)
+			env.Setenv("D2_STDOUT_FORMAT", tc.env)
+			stdout := &bytes.Buffer{}
+			args := append([]string{"d2"}, tc.flags...)
+			state := &xmain.TestState{
+				Run: Run, Env: env, Args: append(args, inputPath, "-"),
+				PWD: dir, Stdout: stdout,
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			state.Start(t, ctx)
+			defer state.Cleanup(t)
+			err := state.Wait(ctx)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("Run() error = %v, want %q", err, tc.wantError)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("invalid format wrote %d bytes to stdout", stdout.Len())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantPDF {
+				if !bytes.HasPrefix(stdout.Bytes(), []byte("%PDF-")) {
+					t.Fatal("expected PDF output on stdout")
+				}
+			} else if !bytes.Contains(stdout.Bytes(), []byte("<svg")) {
+				t.Fatal("expected SVG output on stdout")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2763.

Register `D2_STDOUT_FORMAT` as the environment variable for `--stdout-format`, as already documented in the man page. For example, `D2_STDOUT_FORMAT=pdf d2 input.d2 -` now emits PDF instead of SVG. Explicit CLI flags retain precedence over the environment variable, including when the environment value is invalid.

Adds CLI regression coverage for environment selection, flag precedence, an empty value, and invalid values. The two cases that reproduce the bug fail before the one-line fix and pass afterward. This change uses the existing flag's format-selection behavior; it does not alter how that flag interacts with file output.

Validation: `./make.sh` passed (formatting, generation, Go vet/build/tests, Go WASM tests, JavaScript type/unit/integration tests). The representative Linux release archive and checksum/size checks passed. A built-binary smoke test confirmed PDF output, explicit SVG override, and invalid-format rejection. The race-detector run passed for `./d2cli` and `./d2layouts/d2talalayout/...`.

AI disclosure: Codex implemented, reviewed, and tested this change. The account owner does not perform technical code review; no human code-review claim is being made.
