### PR TITLE
Speed up exact integral grid row measurements

### DIFF
--- a/d2layouts/d2grid/grid_integral_test.go
+++ b/d2layouts/d2grid/grid_integral_test.go
@@ -1,0 +1,144 @@
+package d2grid
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+func assertRowMeasurement(t *testing.T, measurements *gridRowMeasurements, start, end int) {
+	t.Helper()
+	got := measurements.get(start, end)
+	var size, withGap float64
+	for _, value := range measurements.sizes[start:end] {
+		size += value
+		withGap += value + measurements.gap
+	}
+	if start < end {
+		withGap -= measurements.gap
+	}
+	if got.start != start || got.end != end || math.Float64bits(got.size) != math.Float64bits(size) || math.Float64bits(got.withGap) != math.Float64bits(withGap) {
+		t.Fatalf("row [%d:%d], gap %v: %+v, want %v/%v", start, end, measurements.gap, got, size, withGap)
+	}
+}
+
+func TestGridIntegralMeasurementsMatchAdditionOrder(t *testing.T) {
+	rng := rand.New(rand.NewPCG(85, 19))
+	for fixture := 0; fixture < 100; fixture++ {
+		sizes := make([]float64, 2+rng.IntN(80))
+		for i := range sizes {
+			sizes[i] = float64(rng.IntN(10000))
+		}
+		measurements := newGridRowMeasurements(sizes, float64(rng.IntN(1000)))
+		// Visit overlapping intervals in a changing order, then cover every
+		// interval including the empty and singleton paths.
+		for i := 0; i < 100; i++ {
+			start := rng.IntN(len(sizes))
+			assertRowMeasurement(t, measurements, start, start+rng.IntN(len(sizes)-start+1))
+		}
+		for start := range sizes {
+			for end := start; end <= len(sizes); end++ {
+				assertRowMeasurement(t, measurements, start, end)
+			}
+		}
+		if len(measurements.integralPrefix) != len(sizes)+1 || measurements.cache != nil {
+			t.Fatal("integral rows did not use the prefix sums exclusively")
+		}
+	}
+}
+
+func TestGridIntegralMeasurementBounds(t *testing.T) {
+	const limit = float64(1 << 53)
+	for _, tc := range []struct {
+		name   string
+		sizes  []float64
+		gap    float64
+		prefix bool
+	}{
+		{"zeros", []float64{0, math.Copysign(0, -1), 0}, 0, true},
+		{"exact_limit", []float64{limit - 2, 1, 1}, 0, true},
+		{"exact_limit_with_gaps", []float64{limit - 5, 1, 1}, 1, true},
+		{"sum_over_limit", []float64{limit, 1, 0}, 0, false},
+		{"gap_sum_over_limit", []float64{limit - 2, 0, 0}, 1, false},
+		{"size_over_limit", []float64{limit * 2, 1}, 0, false},
+		{"gap_over_limit", []float64{1, 1}, limit * 2, false},
+		{"fractional_size", []float64{0.5, 0.25, 100}, 40, false},
+		{"fractional_gap", []float64{10, 20, 30}, 0.1, false},
+		{"negative_size", []float64{-1, 2, 3}, 40, false},
+		{"negative_gap", []float64{10, 20, 30}, -1, false},
+		{"infinite_size", []float64{math.Inf(1), 0}, 0, false},
+		{"infinite_gap", []float64{10, 20}, math.Inf(1), false},
+		{"nan_size", []float64{math.NaN(), 0}, 0, false},
+		{"nan_gap", []float64{10, 20}, math.NaN(), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			measurements := newGridRowMeasurements(tc.sizes, tc.gap)
+			for start := range tc.sizes {
+				for end := start; end <= len(tc.sizes); end++ {
+					assertRowMeasurement(t, measurements, start, end)
+				}
+			}
+			if got := measurements.integralPrefix != nil; got != tc.prefix {
+				t.Fatalf("prefix enabled = %v, want %v", got, tc.prefix)
+			}
+		})
+	}
+}
+
+func TestGridIntegralSingletonMeasurementsStayLazy(t *testing.T) {
+	measurements := newGridRowMeasurements(make([]float64, 100000), 40)
+	for _, end := range []int{0, 1} {
+		assertRowMeasurement(t, measurements, 0, end)
+	}
+	if measurements.prefixChecked || measurements.integralPrefix != nil || measurements.cache != nil {
+		t.Fatal("empty and singleton rows initialized a measurement cache")
+	}
+	assertRowMeasurement(t, measurements, 0, 2)
+	if len(measurements.integralPrefix) != len(measurements.sizes)+1 || measurements.cache != nil {
+		t.Fatal("nontrivial integral rows did not allocate only a linear prefix array")
+	}
+}
+
+func TestGridIntegralSearchMatchesReference(t *testing.T) {
+	rng := rand.New(rand.NewPCG(23, 94))
+	for fixture := 0; fixture < 100; fixture++ {
+		n := 2 + rng.IntN(16)
+		gd := benchmarkGrid(n, 1+rng.IntN(n))
+		gd.columns = 1 + rng.IntN(n)
+		gd.horizontalGap = rng.IntN(80)
+		gd.verticalGap = rng.IntN(80)
+		for _, object := range gd.objects {
+			object.Width = float64(1 + rng.IntN(500))
+			object.Height = float64(1 + rng.IntN(500))
+		}
+		for _, columns := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%d/columns=%v", fixture, columns), func(t *testing.T) {
+				assertSearchMatchesReference(t, gd, columns)
+			})
+		}
+	}
+}
+
+func BenchmarkGridIntegralMeasurements(b *testing.B) {
+	sizes := make([]float64, 3001)
+	for i := range sizes {
+		sizes[i] = float64(80 + i%37)
+	}
+	for _, prefix := range []bool{false, true} {
+		b.Run(fmt.Sprintf("prefix=%v", prefix), func(b *testing.B) {
+			measurements := newGridRowMeasurements(sizes, 40)
+			if !prefix {
+				measurements.prefixChecked = true // Exercise the unchanged bounded-cache path.
+			}
+			measurements.get(0, len(sizes))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				start := (i * 977) % (len(sizes) - 1)
+				end := start + 2 + (i*1597)%(len(sizes)-start-1)
+				measurements.get(start, end)
+			}
+		})
+	}
+}

--- a/d2layouts/d2grid/grid_search.go
+++ b/d2layouts/d2grid/grid_search.go
@@ -1,16 +1,20 @@
 package d2grid
 
-// Row measurements preserve the original left-to-right floating-point addition
-// order. Subtracting prefix sums could change ties between candidate layouts.
+import "math"
+
+// Row measurements preserve the original left-to-right floating-point results.
+// Prefix sums are used only when every intermediate value is an exact integer.
 type gridRowMeasurement struct {
 	start, end    int
 	size, withGap float64
 }
 
 type gridRowMeasurements struct {
-	sizes []float64
-	gap   float64
-	cache []gridRowMeasurement
+	sizes          []float64
+	gap            float64
+	cache          []gridRowMeasurement
+	prefixChecked  bool
+	integralPrefix []float64
 }
 
 func newGridRowMeasurements(sizes []float64, gap float64) *gridRowMeasurements {
@@ -22,6 +26,13 @@ func (m *gridRowMeasurements) get(start, end int) gridRowMeasurement {
 	// a grid with one row per object should not allocate a large row cache.
 	if end-start <= 1 {
 		return m.measure(start, end)
+	}
+	if !m.prefixChecked {
+		m.initIntegralPrefix()
+	}
+	if m.integralPrefix != nil {
+		size := m.integralPrefix[end] - m.integralPrefix[start]
+		return gridRowMeasurement{start: start, end: end, size: size, withGap: size + m.gap*float64(end-start-1)}
 	}
 	if m.cache == nil {
 		// Bound the cache independently of diagram size; collisions only cause
@@ -40,6 +51,38 @@ func (m *gridRowMeasurements) get(start, end int) gridRowMeasurement {
 	}
 	*cached = m.measure(start, end)
 	return *cached
+}
+
+func (m *gridRowMeasurements) initIntegralPrefix() {
+	m.prefixChecked = true
+	// All integers through 2^53 are represented exactly by float64. Requiring
+	// nonnegative integral sizes and gaps, and bounding their complete sum,
+	// also bounds every intermediate in the original row sums (including the
+	// trailing gap before it is subtracted). Prefix subtraction and adding the
+	// internal gaps therefore reproduce the original results exactly.
+	const maxExactInteger = uint64(1 << 53)
+	exact := func(value float64) bool {
+		return value >= 0 && value <= float64(maxExactInteger) && math.Trunc(value) == value
+	}
+	if !exact(m.gap) {
+		return
+	}
+	gap := uint64(m.gap)
+	var total uint64
+	for _, value := range m.sizes {
+		if !exact(value) {
+			return
+		}
+		size := uint64(value)
+		if size > maxExactInteger-total || gap > maxExactInteger-total-size {
+			return
+		}
+		total += size + gap
+	}
+	m.integralPrefix = make([]float64, len(m.sizes)+1)
+	for i, value := range m.sizes {
+		m.integralPrefix[i+1] = m.integralPrefix[i] + value
+	}
 }
 
 func (m *gridRowMeasurements) measure(start, end int) gridRowMeasurement {

--- a/d2layouts/d2grid/grid_search_test.go
+++ b/d2layouts/d2grid/grid_search_test.go
@@ -154,7 +154,9 @@ func TestGridRowMeasurementsPreserveAdditionOrder(t *testing.T) {
 			}
 		}
 	}
-	large := newGridRowMeasurements(make([]float64, 100000), 40)
+	largeSizes := make([]float64, 100000)
+	largeSizes[0] = 0.5 // Fractional measurements retain the bounded cache.
+	large := newGridRowMeasurements(largeSizes, 40)
 	large.get(0, 2)
 	if got := len(large.cache); got != 32*1024 {
 		t.Fatalf("large grid cache has %d entries, want 32768", got)
@@ -181,7 +183,7 @@ func TestGridSingletonMeasurementsDoNotAllocateCache(t *testing.T) {
 				}
 			}
 		}
-		if measurements.cache != nil {
+		if measurements.cache != nil || measurements.integralPrefix != nil {
 			t.Fatal("empty and singleton measurements allocated a cache")
 		}
 		if allocations := testing.AllocsPerRun(100, func() {


### PR DESCRIPTION
## Human

---

## AI

Large dynamic grids repeatedly rescan row sizes when the bounded measurement cache misses. A native Studio compile profile for 3,001 grid objects spent 87% of sampled CPU time in those row sums.

Use lazy prefix sums when all sizes and the gap are nonnegative integers and their complete total, including the trailing gap used by the existing calculation, fits within float64's exact integer range of 2^53. Every intermediate remains exact, so interval subtraction and gap addition preserve the existing results. Fractional, negative, nonfinite, or oversized inputs retain the existing bounded cache and addition order. Empty and singleton intervals still avoid allocating a cache. Division traversal, search limits, and tie-breaking are unchanged.

Validation:

- `go test ./d2layouts/d2grid -count=1`
- `go test ./d2layouts ./d2lib -count=1`
- New randomized tests compare interval results bit-for-bit and grid partitions against the existing reference implementation, including exact-range boundaries and fallback cases.
- An additional local Studio comparison of v0.9.0 against v0.9.0 plus this patch produced byte-identical D2 layout JSON, SVG, and Studio board JSON for all 14 fixtures: 42 matching artifacts. Cases include variable dimensions, all four directions, rows/columns, asymmetric and zero gaps, nested grids, labels, Markdown/tables/classes, source configuration, Dagre/ELK, and 1,000/3,000-node grids.
- In one native Apple M4/Go 1.27 profile pair, the 3,001-object Studio compile fell from 6,834 ms to 215.5 ms; JSON serialization remained approximately 13 ms and returned the same 2,288,627 bytes. These are native measurements for this workload, not browser timings or a general speed claim.
