### PR TITLE
Reject dangerous ordinary link schemes

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -714,6 +714,10 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 		attrs.Left.Value = scalar.ScalarString()
 		attrs.Left.MapKey = f.LastPrimaryKey()
 	case "link":
+		if textmeasure.IsDangerousLink(scalar.ScalarString()) {
+			c.errorf(scalar, "link uses an unsafe URL scheme")
+			return
+		}
 		attrs.Link = &d2graph.Scalar{}
 		attrs.Link.Value = scalar.ScalarString()
 		attrs.Link.MapKey = f.LastPrimaryKey()

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -104,6 +104,52 @@ func TestEdgeLinkBecomesLabel(t *testing.T) {
 	}
 }
 
+func TestCompileRejectsDangerousOrdinaryLinks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		script string
+	}{
+		{name: "shape_javascript", script: `x.link: javascript:alert(1)`},
+		{name: "shape_encoded_javascript", script: `x.link: "j&#x61;va%73cript:alert(1)"`},
+		{name: "shape_unsafe_data", script: `x.link: "data:text/html,<script>alert(1)</script>"`},
+		{name: "connection_vbscript", script: `x -> y: {link: vbscript:msgbox(1)}`},
+		{name: "connection_obfuscated_javascript", script: "x -> y: {link: \"java\tscript:alert(1)\"}"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g, _, err := d2compiler.Compile("dangerous-link.d2", strings.NewReader(tc.script), nil)
+			tassert.Nil(t, g)
+			tassert.ErrorContains(t, err, "link uses an unsafe URL scheme")
+		})
+	}
+}
+
+func TestCompilePreservesSafeOrdinaryLinks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		script string
+	}{
+		{name: "https_shape", script: `x.link: https://example.com`},
+		{name: "mailto_connection", script: `x -> y: {link: mailto:security@example.com}`},
+		{name: "app_scheme", script: `x.link: vscode://file/example.go:10:2`},
+		{name: "safe_raster_data", script: `x.link: "data:image/png;base64,iVBORw0KGgo="`},
+		{name: "board", script: `x.link: layers.details; layers: {details: {y}}`},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g, _, err := d2compiler.Compile("safe-link.d2", strings.NewReader(tc.script), nil)
+			tassert.NoError(t, err)
+			tassert.NotNil(t, g)
+		})
+	}
+}
+
 func TestCompile(t *testing.T) {
 	t.Parallel()
 

--- a/d2renderers/d2scenebuild/metadata.go
+++ b/d2renderers/d2scenebuild/metadata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/d2lang/d2/d2parser"
 	"github.com/d2lang/d2/d2renderers/d2scene"
 	"github.com/d2lang/d2/d2target"
+	"github.com/d2lang/d2/lib/textmeasure"
 )
 
 func (b *builder) compileLinkRegions() error {
@@ -154,6 +155,9 @@ func (b *builder) connectionLinkRegion(object string, connection d2target.Connec
 }
 
 func validateLinkTooltipSecurity(object, link, tooltip string) error {
+	if textmeasure.IsDangerousLink(link) {
+		return invalidField(object, "link", link, "uses an unsafe URL scheme")
+	}
 	if link == "" || tooltip == "" {
 		return nil
 	}

--- a/d2renderers/d2scenebuild/metadata_test.go
+++ b/d2renderers/d2scenebuild/metadata_test.go
@@ -142,6 +142,14 @@ func TestBuildRejectsMalformedOrUnrepresentableLinkMetadata(t *testing.T) {
 		{name: "URL tooltip with link", mutate: func(d *d2target.Diagram) {
 			d.Shapes = []d2target.Shape{metadataShape("bad", 0, "https://example.com", "https://spoof.invalid")}
 		}, want: "must not be a URL when link is also set"},
+		{name: "dangerous shape link", mutate: func(d *d2target.Diagram) {
+			d.Shapes = []d2target.Shape{metadataShape("bad", 0, "java%0ascript:alert(1)", "")}
+		}, want: "uses an unsafe URL scheme"},
+		{name: "dangerous connection link", mutate: func(d *d2target.Diagram) {
+			connection := metadataConnection()
+			connection.Link = "v&#x62;script:msgbox(1)"
+			d.Connections = []d2target.Connection{connection}
+		}, want: "uses an unsafe URL scheme"},
 		{name: "orphan pretty link", mutate: func(d *d2target.Diagram) {
 			shape := metadataShape("bad", 0, "", "")
 			shape.PrettyLink = "derived label"

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -2834,6 +2834,17 @@ func appendOnTriggerLazy(buf *bytes.Buffer, source string, triggers []string, ne
 var DEFAULT_DARK_THEME *int64 = nil // no theme selected
 
 func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
+	for _, targetShape := range diagram.Shapes {
+		if textmeasure.IsDangerousLink(targetShape.Link) {
+			return nil, fmt.Errorf("shape %q uses an unsafe link URL scheme", targetShape.ID)
+		}
+	}
+	for _, connection := range diagram.Connections {
+		if textmeasure.IsDangerousLink(connection.Link) {
+			return nil, fmt.Errorf("connection %q uses an unsafe link URL scheme", connection.ID)
+		}
+	}
+
 	sketch := false
 	pad := DEFAULT_PADDING
 	tl, br := diagram.BoundingBox()

--- a/d2renderers/d2svg/padding_test.go
+++ b/d2renderers/d2svg/padding_test.go
@@ -90,3 +90,35 @@ func TestRenderValidatesPaddingDimensions(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderRejectsDangerousOrdinaryLinks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		link   string
+		shape  bool
+		object string
+	}{
+		{name: "shape", link: "java%0ascript:alert(1)", shape: true, object: `shape "unsafe-shape"`},
+		{name: "connection", link: "v&#x62;script:msgbox(1)", object: `connection "unsafe-connection"`},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := d2target.NewDiagram()
+			if tc.shape {
+				diagram.Shapes = []d2target.Shape{{ID: "unsafe-shape", Link: tc.link}}
+			} else {
+				diagram.Connections = []d2target.Connection{{ID: "unsafe-connection", Link: tc.link}}
+			}
+			out, err := d2svg.Render(diagram, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.object+" uses an unsafe link URL scheme") {
+				t.Fatalf("Render() output/error = %q/%v", out, err)
+			}
+			if out != nil {
+				t.Fatalf("Render() returned output on error: %q", out)
+			}
+		})
+	}
+}

--- a/lib/textmeasure/markdown_svg.go
+++ b/lib/textmeasure/markdown_svg.go
@@ -2,6 +2,7 @@ package textmeasure
 
 import (
 	"fmt"
+	stdhtml "html"
 	"math"
 	"sort"
 	"strconv"
@@ -318,22 +319,102 @@ func (l *MarkdownLayout) SVG(opts MarkdownSVGOptions) string {
 // annotations use the same policy.
 func SafeMarkdownLink(link string) string {
 	link = strings.TrimSpace(link)
-	if link == "" {
-		return ""
-	}
-	// Browsers ignore ASCII controls and whitespace in URI schemes. Normalize
-	// them before applying goldmark's dangerous-URL policy so variants such as
-	// "java\tscript:" cannot become active links in an embedded SVG.
-	normalized := strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) || unicode.IsSpace(r) {
-			return -1
-		}
-		return r
-	}, link)
-	if goldmarkHTML.IsDangerousURL([]byte(normalized)) {
+	if link == "" || IsDangerousLink(link) {
 		return ""
 	}
 	return link
+}
+
+// IsDangerousLink reports whether link uses a URL scheme that must not be
+// exposed as interactive metadata. It intentionally shares Goldmark's
+// dangerous-URL policy with Markdown links while preserving relative URLs,
+// board targets, and opaque application schemes.
+func IsDangerousLink(link string) bool {
+	normalized, complete := normalizeLinkForSafety(link)
+	if !complete {
+		// Do not fail open on an excessively nested encoding. Normal links settle
+		// in one pass, and a URL with an already-valid scheme settles immediately.
+		return true
+	}
+	return goldmarkHTML.IsDangerousURL([]byte(normalized))
+}
+
+const maxLinkNormalizationPasses = 8
+
+func normalizeLinkForSafety(link string) (string, bool) {
+	normalized := strings.TrimSpace(link)
+	for range maxLinkNormalizationPasses {
+		next := stdhtml.UnescapeString(normalized)
+		next = decodeLinkPercentEscapes(next)
+		// URI consumers ignore controls and whitespace in or around schemes.
+		// Normalize them for classification only; safe links retain their
+		// original spelling when emitted.
+		next = strings.Map(func(r rune) rune {
+			if unicode.IsControl(r) || unicode.IsSpace(r) {
+				return -1
+			}
+			return r
+		}, next)
+		if hasURLScheme(next) || next == normalized {
+			return next, true
+		}
+		normalized = next
+	}
+	return normalized, false
+}
+
+func hasURLScheme(value string) bool {
+	colon := strings.IndexByte(value, ':')
+	if colon <= 0 || !isASCIIAlpha(value[0]) {
+		return false
+	}
+	for i := 1; i < colon; i++ {
+		c := value[i]
+		if !isASCIIAlpha(c) && (c < '0' || c > '9') && c != '+' && c != '-' && c != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}
+
+func decodeLinkPercentEscapes(value string) string {
+	first := strings.IndexByte(value, '%')
+	if first < 0 {
+		return value
+	}
+	var out strings.Builder
+	out.Grow(len(value))
+	out.WriteString(value[:first])
+	for i := first; i < len(value); i++ {
+		if i+2 < len(value) {
+			hi, hiOK := hexValue(value[i+1])
+			lo, loOK := hexValue(value[i+2])
+			if value[i] == '%' && hiOK && loOK {
+				out.WriteByte(hi<<4 | lo)
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(value[i])
+	}
+	return out.String()
+}
+
+func hexValue(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	default:
+		return 0, false
+	}
 }
 
 func defaultMarkdownSVGRolePaint() map[MarkdownColorRole]MarkdownSVGPaint {

--- a/lib/textmeasure/markdown_svg_test.go
+++ b/lib/textmeasure/markdown_svg_test.go
@@ -1006,6 +1006,39 @@ func TestMarkdownSVGRejectsDangerousLinks(t *testing.T) {
 	assert.NotContains(t, manual, "<a ")
 }
 
+func TestDangerousLinkPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, link := range []string{
+		"javascript:alert(1)",
+		"JAVA\tSCRIPT:alert(1)",
+		"vBsCrIpT:msgbox(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"data:image/svg+xml,<svg onload=alert(1)>",
+		"file:///etc/passwd",
+		"j&#x61;vascript:alert(1)",
+		"java%0Ascript:alert(1)",
+		"java%250Ascript:alert(1)",
+	} {
+		assert.True(t, textmeasure.IsDangerousLink(link), link)
+		assert.Empty(t, textmeasure.SafeMarkdownLink(link), link)
+	}
+
+	for _, link := range []string{
+		"https://example.com/a?x=1&y=2",
+		"http://example.com",
+		"mailto:security@example.com",
+		"../docs/security",
+		"root.layers.details",
+		"vscode://file/example.go:10:2",
+		"obsidian://open?vault=notes",
+		"data:image/png;base64,iVBORw0KGgo=",
+	} {
+		assert.False(t, textmeasure.IsDangerousLink(link), link)
+		assert.Equal(t, link, textmeasure.SafeMarkdownLink(link), link)
+	}
+}
+
 func TestLayoutMarkdownOmitsImagesWithoutFetching(t *testing.T) {
 	t.Parallel()
 	ruler, err := textmeasure.NewRuler()


### PR DESCRIPTION
## Human

---

## AI

Applies one obfuscation-aware URL safety policy to ordinary D2 links across compilation and SVG, PDF, and PPTX rendering, while preserving supported web, board, and application links.

Tests:

- `go test ./...`
- `go vet --composites=false ./...`
