### PR TITLE
plugins: execute only the selected external plugin

### DIFF
--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -67,7 +67,7 @@ func themesCmd(_ context.Context, ms *xmain.State) {
 
 func shortLayoutHelp(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) error {
 	var pluginLines []string
-	pinfos, err := d2plugin.ListPluginInfos(ctx, ps)
+	pinfos, err := d2plugin.ListPluginSummaries(ctx, ps)
 	if err != nil {
 		return err
 	}
@@ -75,6 +75,8 @@ func shortLayoutHelp(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin)
 		var l string
 		if p.Type == "bundled" {
 			l = fmt.Sprintf("%s (bundled) - %s", p.Name, p.ShortHelp)
+		} else if p.ShortHelp == "" {
+			l = fmt.Sprintf("%s (%s)", p.Name, humanPath(p.Path))
 		} else {
 			l = fmt.Sprintf("%s (%s) - %s", p.Name, humanPath(p.Path), p.ShortHelp)
 		}
@@ -129,13 +131,9 @@ func longLayoutHelp(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) 
 }
 
 func layoutNotFound(ctx context.Context, ps []d2plugin.Plugin, layout string) error {
-	pinfos, err := d2plugin.ListPluginInfos(ctx, ps)
+	names, err := d2plugin.ListPluginNames(ctx, ps)
 	if err != nil {
 		return err
-	}
-	var names []string
-	for _, p := range pinfos {
-		names = append(names, p.Name)
 	}
 
 	return xmain.UsageErrorf(`D2_LAYOUT "%s" is not bundled and could not be found in your $PATH.

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -154,9 +155,11 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	selectedLayout := layoutFromArgs(ms.Opts.Args, *layoutFlag)
-	if err := populateLayoutOpts(ctx, ms, plugins, selectedLayout); err != nil {
-		return err
+	selectedLayout, selectionOK := layoutFromArgs(ms.Opts.Args, ms.Opts.Flags, *layoutFlag)
+	if selectionOK {
+		if err := populateLayoutOpts(ctx, ms, plugins, selectedLayout); err != nil {
+			return err
+		}
 	}
 
 	err = ms.Opts.Flags.Parse(ms.Opts.Args)
@@ -402,28 +405,82 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	return nil
 }
 
-func layoutFromArgs(args []string, fallback string) string {
-	layout := fallback
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			break
+func layoutFromArgs(args []string, baseFlags *pflag.FlagSet, fallback string) (string, bool) {
+	staged := pflag.NewFlagSet("layout selection", pflag.ContinueOnError)
+	staged.SetOutput(io.Discard)
+	staged.Usage = func() {}
+	staged.ParseErrorsAllowlist.UnknownFlags = true
+
+	valid := true
+	baseFlags.VisitAll(func(flag *pflag.Flag) {
+		if !valid {
+			return
 		}
-		switch {
-		case arg == "--layout" || arg == "-l":
-			if i+1 < len(args) {
-				i++
-				layout = args[i]
-			}
-		case strings.HasPrefix(arg, "--layout="):
-			layout = strings.TrimPrefix(arg, "--layout=")
-		case strings.HasPrefix(arg, "-l="):
-			layout = strings.TrimPrefix(arg, "-l=")
-		case strings.HasPrefix(arg, "-l") && len(arg) > len("-l"):
-			layout = strings.TrimPrefix(arg, "-l")
+		value, ok := newStagedFlagValue(flag.Value.Type(), flag.DefValue)
+		if !ok {
+			valid = false
+			return
 		}
+		copy := *flag
+		copy.Value = value
+		copy.Changed = false
+		staged.AddFlag(&copy)
+	})
+	if !valid {
+		return fallback, false
 	}
-	return layout
+	if err := staged.Parse(args); err != nil {
+		// The real parser below will return the authoritative help or usage
+		// result. Most importantly, do not execute a plugin named only in
+		// arguments that pflag would never reach.
+		return fallback, false
+	}
+	layout, err := staged.GetString("layout")
+	if err != nil {
+		return fallback, false
+	}
+	return layout, true
+}
+
+type stagedFlagValue struct {
+	typeName string
+	value    string
+}
+
+func newStagedFlagValue(typeName, value string) (*stagedFlagValue, bool) {
+	v := &stagedFlagValue{typeName: typeName, value: value}
+	if err := v.Set(value); err != nil {
+		return nil, false
+	}
+	return v, true
+}
+
+func (v *stagedFlagValue) Set(value string) error {
+	var err error
+	switch v.typeName {
+	case "string":
+	case "bool":
+		_, err = strconv.ParseBool(value)
+	case "int64":
+		_, err = strconv.ParseInt(value, 0, 64)
+	case "float64":
+		_, err = strconv.ParseFloat(value, 64)
+	default:
+		return fmt.Errorf("unsupported staged flag type %q", v.typeName)
+	}
+	if err != nil {
+		return err
+	}
+	v.value = value
+	return nil
+}
+
+func (v *stagedFlagValue) String() string {
+	return v.value
+}
+
+func (v *stagedFlagValue) Type() string {
+	return v.typeName
 }
 
 func LayoutResolver(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin) func(engine string) (d2graph.LayoutGraph, error) {

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -406,6 +406,10 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 }
 
 func layoutFromArgs(args []string, baseFlags *pflag.FlagSet, fallback string) (string, bool) {
+	if layoutSelectionIsAmbiguous(args, baseFlags) {
+		return fallback, false
+	}
+
 	staged := pflag.NewFlagSet("layout selection", pflag.ContinueOnError)
 	staged.SetOutput(io.Discard)
 	staged.Usage = func() {}
@@ -440,6 +444,89 @@ func layoutFromArgs(args []string, baseFlags *pflag.FlagSet, fallback string) (s
 		return fallback, false
 	}
 	return layout, true
+}
+
+// layoutSelectionIsAmbiguous applies a conservative ordering rule for plugin
+// flags that are not registered yet: a bare unknown flag must not precede a
+// layout selection or override. Such a flag might be boolean and leave the
+// layout token to be parsed, or it might require a value and consume that same
+// token. Attached values are unambiguous and remain supported.
+//
+// Known base flags are skipped using their real pflag arity so a layout-looking
+// value of --browser (or another known value flag) is not mistaken for a
+// selection. Once a bare unknown is found, the suffix check intentionally also
+// looks past --: a value-taking plugin flag could consume that terminator.
+func layoutSelectionIsAmbiguous(args []string, baseFlags *pflag.FlagSet) bool {
+	layoutFlag := baseFlags.Lookup("layout")
+	if layoutFlag == nil {
+		return true
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if len(arg) < 2 || arg[0] != '-' {
+			continue
+		}
+		if arg == "--" {
+			break
+		}
+		if strings.HasPrefix(arg, "--") {
+			name, _, hasAttachedValue := strings.Cut(arg[2:], "=")
+			flag := baseFlags.Lookup(name)
+			if flag == nil {
+				if !hasAttachedValue && argsContainLayoutSyntax(args[i+1:], layoutFlag) {
+					return true
+				}
+				continue
+			}
+			if !hasAttachedValue && flag.NoOptDefVal == "" && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+
+		shorthands := arg[1:]
+		for len(shorthands) > 0 {
+			flag := baseFlags.ShorthandLookup(shorthands[:1])
+			hasAttachedValue := len(shorthands) > 1 && shorthands[1] == '='
+			if flag == nil {
+				containsLayoutShorthand := layoutFlag.Shorthand != "" && strings.Contains(shorthands[1:], layoutFlag.Shorthand)
+				if !hasAttachedValue && (containsLayoutShorthand || argsContainLayoutSyntax(args[i+1:], layoutFlag)) {
+					return true
+				}
+				if hasAttachedValue {
+					break
+				}
+				shorthands = shorthands[1:]
+				continue
+			}
+			if hasAttachedValue || flag.NoOptDefVal == "" {
+				if !hasAttachedValue && len(shorthands) == 1 && i+1 < len(args) {
+					i++
+				}
+				break
+			}
+			shorthands = shorthands[1:]
+		}
+	}
+	return false
+}
+
+func argsContainLayoutSyntax(args []string, layoutFlag *pflag.Flag) bool {
+	long := "--" + layoutFlag.Name
+	for _, arg := range args {
+		if arg == long || strings.HasPrefix(arg, long+"=") || shortsContainLayoutSyntax(arg, layoutFlag) {
+			return true
+		}
+	}
+	return false
+}
+
+func shortsContainLayoutSyntax(arg string, layoutFlag *pflag.Flag) bool {
+	if layoutFlag.Shorthand == "" || len(arg) < 2 || arg[0] != '-' || arg[1] == '-' {
+		return false
+	}
+	return strings.Contains(arg[1:], layoutFlag.Shorthand)
 }
 
 type stagedFlagValue struct {

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -154,8 +154,8 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	err = populateLayoutOpts(ctx, ms, plugins)
-	if err != nil {
+	selectedLayout := layoutFromArgs(ms.Opts.Args, *layoutFlag)
+	if err := populateLayoutOpts(ctx, ms, plugins, selectedLayout); err != nil {
 		return err
 	}
 
@@ -400,6 +400,30 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return fmt.Errorf("failed to compile %s: %w", ms.HumanPath(inputPath), err)
 	}
 	return nil
+}
+
+func layoutFromArgs(args []string, fallback string) string {
+	layout := fallback
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		switch {
+		case arg == "--layout" || arg == "-l":
+			if i+1 < len(args) {
+				i++
+				layout = args[i]
+			}
+		case strings.HasPrefix(arg, "--layout="):
+			layout = strings.TrimPrefix(arg, "--layout=")
+		case strings.HasPrefix(arg, "-l="):
+			layout = strings.TrimPrefix(arg, "-l=")
+		case strings.HasPrefix(arg, "-l") && len(arg) > len("-l"):
+			layout = strings.TrimPrefix(arg, "-l")
+		}
+	}
+	return layout
 }
 
 func LayoutResolver(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin) func(engine string) (d2graph.LayoutGraph, error) {
@@ -1087,8 +1111,8 @@ func getFileName(path string) string {
 	return strings.TrimSuffix(filepath.Base(path), ext)
 }
 
-func populateLayoutOpts(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) error {
-	pluginFlags, err := d2plugin.ListPluginFlags(ctx, ps)
+func populateLayoutOpts(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin, selectedLayout string) error {
+	pluginFlags, err := d2plugin.ListPluginFlagsForSelection(ctx, ps, selectedLayout)
 	if err != nil {
 		return err
 	}

--- a/d2cli/plugin_discovery_test.go
+++ b/d2cli/plugin_discovery_test.go
@@ -1,30 +1,285 @@
 package d2cli
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/d2lang/d2/d2graph"
+	"github.com/d2lang/d2/d2layouts/d2dagrelayout"
+	"github.com/d2lang/util-go/xmain"
+)
+
+const (
+	pluginDiscoveryHelperEnv       = "D2_CLI_PLUGIN_DISCOVERY_HELPER_PROCESS"
+	pluginDiscoveryHelperMarkerEnv = "D2_CLI_PLUGIN_DISCOVERY_HELPER_MARKER"
+	pluginDiscoveryHelperNameEnv   = "D2_CLI_PLUGIN_DISCOVERY_HELPER_NAME"
+	pluginDiscoveryDefault         = "declared-default"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(pluginDiscoveryHelperEnv) == "1" {
+		runPluginDiscoveryHelper()
+	}
+	os.Exit(m.Run())
+}
+
+func runPluginDiscoveryHelper() {
+	if marker := os.Getenv(pluginDiscoveryHelperMarkerEnv); marker != "" {
+		f, err := os.OpenFile(marker, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		err = json.NewEncoder(f).Encode(os.Args[1:])
+		closeErr := f.Close()
+		if err != nil || closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+
+	if len(os.Args) == 2 && os.Args[1] == "info" {
+		name := os.Getenv(pluginDiscoveryHelperNameEnv)
+		if name == "" {
+			name = "external"
+		}
+		fmt.Fprintf(os.Stdout, `{"name":%q,"features":[]}`, name)
+		os.Exit(0)
+	}
+	if len(os.Args) == 2 && os.Args[1] == "flags" {
+		fmt.Fprintf(os.Stdout, `[{"Name":"external-option","Type":"string","Default":%q,"Usage":"test option","Tag":"external-option"}]`, pluginDiscoveryDefault)
+		os.Exit(0)
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "layout" {
+		in, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		var graph d2graph.Graph
+		if err := d2graph.DeserializeGraph(in, &graph); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		if err := d2dagrelayout.DefaultLayout(context.Background(), &graph); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		out, err := d2graph.SerializeGraph(&graph)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		if _, err := os.Stdout.Write(out); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+	if len(os.Args) == 2 && os.Args[1] == "postprocess" {
+		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+
+	fmt.Fprintf(os.Stderr, "unexpected helper arguments: %q", os.Args[1:])
+	os.Exit(2)
+}
 
 func TestLayoutFromArgs(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
-		name string
-		args []string
-		want string
+		name   string
+		args   []string
+		want   string
+		wantOK bool
 	}{
-		{name: "fallback", args: []string{"in.d2"}, want: "dagre"},
-		{name: "long separate", args: []string{"--layout", "elk", "in.d2"}, want: "elk"},
-		{name: "long equals", args: []string{"--layout=tala", "in.d2"}, want: "tala"},
-		{name: "short separate", args: []string{"-l", "elk", "in.d2"}, want: "elk"},
-		{name: "short equals", args: []string{"-l=tala", "in.d2"}, want: "tala"},
-		{name: "short attached", args: []string{"-lelk", "in.d2"}, want: "elk"},
-		{name: "last wins", args: []string{"-l", "elk", "--layout=tala", "in.d2"}, want: "tala"},
-		{name: "end of flags", args: []string{"--", "--layout=elk"}, want: "dagre"},
+		{name: "fallback", args: []string{"in.d2"}, want: "dagre", wantOK: true},
+		{name: "long separate", args: []string{"--layout", "elk", "in.d2"}, want: "elk", wantOK: true},
+		{name: "long equals", args: []string{"--layout=tala", "in.d2"}, want: "tala", wantOK: true},
+		{name: "short separate", args: []string{"-l", "elk", "in.d2"}, want: "elk", wantOK: true},
+		{name: "short equals", args: []string{"-l=tala", "in.d2"}, want: "tala", wantOK: true},
+		{name: "short attached", args: []string{"-lelk", "in.d2"}, want: "elk", wantOK: true},
+		{name: "combined shorthand", args: []string{"-sltala", "in.d2"}, want: "tala", wantOK: true},
+		{name: "last wins", args: []string{"-l", "elk", "--layout=tala", "in.d2"}, want: "tala", wantOK: true},
+		{name: "end of flags", args: []string{"--", "--layout=elk"}, want: "dagre", wantOK: true},
+		{name: "help terminates", args: []string{"--help", "--layout=external"}, want: "dagre", wantOK: false},
+		{name: "known flag consumes layout", args: []string{"--browser", "--layout=external", "--version"}, want: "dagre", wantOK: true},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := layoutFromArgs(tc.args, "dagre"); got != tc.want {
-				t.Fatalf("layoutFromArgs(%q) = %q, want %q", tc.args, got, tc.want)
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags.StringP("layout", "l", "dagre", "")
+			flags.BoolP("sketch", "s", false, "")
+			flags.String("browser", "", "")
+			flags.Bool("version", false, "")
+			got, gotOK := layoutFromArgs(tc.args, flags, "dagre")
+			if got != tc.want || gotOK != tc.wantOK {
+				t.Fatalf("layoutFromArgs(%q) = (%q, %t), want (%q, %t)", tc.args, got, gotOK, tc.want, tc.wantOK)
 			}
 		})
+	}
+}
+
+func TestRunExecutesOnlyParserSelectedExternalPlugin(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []string
+		wantCalls   [][]string
+		wantNoCalls bool
+	}{
+		{
+			name:        "help terminates before layout",
+			args:        []string{"--help", "--layout=external"},
+			wantNoCalls: true,
+		},
+		{
+			name:        "browser consumes layout-looking value",
+			args:        []string{"--browser", "--layout=external", "--version"},
+			wantNoCalls: true,
+		},
+		{
+			name:      "combined shorthand selects layout",
+			args:      []string{"-slexternal", "layout"},
+			wantCalls: [][]string{{"info"}, {"flags"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			directory := t.TempDir()
+			marker := filepath.Join(directory, "plugin-calls.jsonl")
+			installPluginDiscoveryHelper(t, directory, "external")
+			t.Setenv(pluginDiscoveryHelperEnv, "1")
+			t.Setenv(pluginDiscoveryHelperMarkerEnv, marker)
+			t.Setenv(pluginDiscoveryHelperNameEnv, "external")
+			t.Setenv("PATH", directory)
+
+			if err := runPluginDiscoveryCLI(t, directory, tc.args...); err != nil {
+				t.Fatal(err)
+			}
+			calls := readPluginDiscoveryCalls(t, marker)
+			if tc.wantNoCalls && len(calls) != 0 {
+				t.Fatalf("unselected external plugin calls = %q, want none", calls)
+			}
+			if tc.wantCalls != nil && !reflect.DeepEqual(calls, tc.wantCalls) {
+				t.Fatalf("selected external plugin calls = %q, want %q", calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRunSourceConfigExternalPluginUsesDeclaredFlagDefaults(t *testing.T) {
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "plugin-calls.jsonl")
+	installPluginDiscoveryHelper(t, directory, "external")
+	t.Setenv(pluginDiscoveryHelperEnv, "1")
+	t.Setenv(pluginDiscoveryHelperMarkerEnv, marker)
+	t.Setenv(pluginDiscoveryHelperNameEnv, "external")
+	t.Setenv("PATH", directory)
+
+	input := `vars: {d2-config: {layout-engine: external}}
+x
+`
+	if err := os.WriteFile(filepath.Join(directory, "input.d2"), []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runPluginDiscoveryCLI(t, directory, "input.d2", "output.svg"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "output.svg")); err != nil {
+		t.Fatalf("render output: %v", err)
+	}
+
+	wantLayout := []string{"layout", "--external-option", pluginDiscoveryDefault}
+	for _, call := range readPluginDiscoveryCalls(t, marker) {
+		if len(call) > 0 && call[0] == "layout" {
+			if !reflect.DeepEqual(call, wantLayout) {
+				t.Fatalf("external layout call = %q, want %q", call, wantLayout)
+			}
+			return
+		}
+	}
+	t.Fatal("external layout helper was not called")
+}
+
+func runPluginDiscoveryCLI(t *testing.T, directory string, args ...string) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	state := &xmain.TestState{
+		Run:  Run,
+		Args: append([]string{"d2"}, args...),
+		PWD:  directory,
+	}
+	state.Start(t, ctx)
+	defer state.Cleanup(t)
+	return state.Wait(ctx)
+}
+
+func installPluginDiscoveryHelper(t *testing.T, directory, name string) {
+	t.Helper()
+	source, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryName := "d2plugin-" + name
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(filepath.Join(directory, binaryName), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readPluginDiscoveryCalls(t *testing.T, marker string) [][]string {
+	t.Helper()
+	f, err := os.Open(marker)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var calls [][]string
+	decoder := json.NewDecoder(f)
+	for {
+		var call []string
+		if err := decoder.Decode(&call); errors.Is(err, io.EOF) {
+			return calls
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		calls = append(calls, call)
 	}
 }

--- a/d2cli/plugin_discovery_test.go
+++ b/d2cli/plugin_discovery_test.go
@@ -120,6 +120,16 @@ func TestLayoutFromArgs(t *testing.T) {
 		{name: "end of flags", args: []string{"--", "--layout=elk"}, want: "dagre", wantOK: true},
 		{name: "help terminates", args: []string{"--help", "--layout=external"}, want: "dagre", wantOK: false},
 		{name: "known flag consumes layout", args: []string{"--browser", "--layout=external", "--version"}, want: "dagre", wantOK: true},
+		{name: "known shorthand consumes layout", args: []string{"-h", "--layout=external", "--version"}, want: "dagre", wantOK: true},
+		{name: "unknown value may consume layout", args: []string{"--external-option", "--layout=external", "--version"}, want: "dagre", wantOK: false},
+		{name: "unknown flag may be boolean", args: []string{"--external-toggle", "--layout=external", "--version"}, want: "dagre", wantOK: false},
+		{name: "unknown shorthand before layout", args: []string{"-x", "--layout=external", "--version"}, want: "dagre", wantOK: false},
+		{name: "unknown before later override", args: []string{"--layout=external", "--external-option", "--layout=elk"}, want: "dagre", wantOK: false},
+		{name: "unknown may consume terminator", args: []string{"--external-option", "--", "--layout=external"}, want: "dagre", wantOK: false},
+		{name: "attached unknown is unambiguous", args: []string{"--external-option=value", "--layout=external"}, want: "external", wantOK: true},
+		{name: "attached unknown after layout", args: []string{"--layout=external", "--external-option=value"}, want: "external", wantOK: true},
+		{name: "bare unknown after final layout", args: []string{"--layout=external", "--external-option", "value"}, want: "external", wantOK: true},
+		{name: "known boolean before layout", args: []string{"--sketch", "--layout=external"}, want: "external", wantOK: true},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -127,6 +137,7 @@ func TestLayoutFromArgs(t *testing.T) {
 			flags.StringP("layout", "l", "dagre", "")
 			flags.BoolP("sketch", "s", false, "")
 			flags.String("browser", "", "")
+			flags.StringP("host", "h", "localhost", "")
 			flags.Bool("version", false, "")
 			got, gotOK := layoutFromArgs(tc.args, flags, "dagre")
 			if got != tc.want || gotOK != tc.wantOK {
@@ -142,6 +153,7 @@ func TestRunExecutesOnlyParserSelectedExternalPlugin(t *testing.T) {
 		args        []string
 		wantCalls   [][]string
 		wantNoCalls bool
+		wantErr     bool
 	}{
 		{
 			name:        "help terminates before layout",
@@ -158,6 +170,34 @@ func TestRunExecutesOnlyParserSelectedExternalPlugin(t *testing.T) {
 			args:      []string{"-slexternal", "layout"},
 			wantCalls: [][]string{{"info"}, {"flags"}},
 		},
+		{
+			name:        "unknown value flag may consume layout",
+			args:        []string{"--external-option", "--layout=external", "--version"},
+			wantNoCalls: true,
+			wantErr:     true,
+		},
+		{
+			name:        "unknown flag may instead be boolean",
+			args:        []string{"--external-toggle", "--layout=external", "--version"},
+			wantNoCalls: true,
+			wantErr:     true,
+		},
+		{
+			name:        "unknown flag before later layout override",
+			args:        []string{"--layout=dagre", "--external-option", "--layout=external", "--version"},
+			wantNoCalls: true,
+			wantErr:     true,
+		},
+		{
+			name:      "attached plugin option after layout is unambiguous",
+			args:      []string{"--layout=external", "--external-option=value", "layout"},
+			wantCalls: [][]string{{"info"}, {"flags"}},
+		},
+		{
+			name:      "bare plugin option after final layout is unambiguous",
+			args:      []string{"--layout=external", "--external-option", "value", "layout"},
+			wantCalls: [][]string{{"info"}, {"flags"}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -170,8 +210,9 @@ func TestRunExecutesOnlyParserSelectedExternalPlugin(t *testing.T) {
 			t.Setenv(pluginDiscoveryHelperNameEnv, "external")
 			t.Setenv("PATH", directory)
 
-			if err := runPluginDiscoveryCLI(t, directory, tc.args...); err != nil {
-				t.Fatal(err)
+			err := runPluginDiscoveryCLI(t, directory, tc.args...)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Run() error = %v, wantErr %t", err, tc.wantErr)
 			}
 			calls := readPluginDiscoveryCalls(t, marker)
 			if tc.wantNoCalls && len(calls) != 0 {

--- a/d2cli/plugin_discovery_test.go
+++ b/d2cli/plugin_discovery_test.go
@@ -1,0 +1,30 @@
+package d2cli
+
+import "testing"
+
+func TestLayoutFromArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "fallback", args: []string{"in.d2"}, want: "dagre"},
+		{name: "long separate", args: []string{"--layout", "elk", "in.d2"}, want: "elk"},
+		{name: "long equals", args: []string{"--layout=tala", "in.d2"}, want: "tala"},
+		{name: "short separate", args: []string{"-l", "elk", "in.d2"}, want: "elk"},
+		{name: "short equals", args: []string{"-l=tala", "in.d2"}, want: "tala"},
+		{name: "short attached", args: []string{"-lelk", "in.d2"}, want: "elk"},
+		{name: "last wins", args: []string{"-l", "elk", "--layout=tala", "in.d2"}, want: "tala"},
+		{name: "end of flags", args: []string{"--", "--layout=elk"}, want: "dagre"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := layoutFromArgs(tc.args, "dagre"); got != tc.want {
+				t.Fatalf("layoutFromArgs(%q) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -168,6 +168,11 @@ func externalPluginName(path string) string {
 	return basename
 }
 
+// ListPluginInfos returns metadata by executing Info on every plugin.
+//
+// Deprecated: Use ListPluginSummaries for execution-free discovery or
+// FindPlugin when selecting one plugin. ListPluginInfos executes every external
+// binary in ps.
 func ListPluginInfos(ctx context.Context, ps []Plugin) ([]*PluginInfo, error) {
 	var infoSlice []*PluginInfo
 	for _, p := range ps {
@@ -259,6 +264,10 @@ func FindPlugin(ctx context.Context, ps []Plugin, name string) (Plugin, error) {
 	return nil, exec.ErrNotFound
 }
 
+// ListPluginFlags returns flags by executing Flags on every plugin.
+//
+// Deprecated: Use ListPluginFlagsForSelection when ps may include discovered
+// external plugins. ListPluginFlags executes every external binary in ps.
 func ListPluginFlags(ctx context.Context, ps []Plugin) ([]PluginSpecificFlag, error) {
 	var out []PluginSpecificFlag
 	for _, p := range ps {
@@ -306,15 +315,29 @@ func HydratePluginOpts(ctx context.Context, ms *xmain.State, plugin Plugin) erro
 		return err
 	}
 	for _, f := range flags {
+		if ms.Opts.Flags.Lookup(f.Name) == nil {
+			opts[f.Tag] = f.Default
+			continue
+		}
+
 		switch f.Type {
 		case "string":
-			val, _ := ms.Opts.Flags.GetString(f.Name)
+			val, err := ms.Opts.Flags.GetString(f.Name)
+			if err != nil {
+				return err
+			}
 			opts[f.Tag] = val
 		case "int64":
-			val, _ := ms.Opts.Flags.GetInt64(f.Name)
+			val, err := ms.Opts.Flags.GetInt64(f.Name)
+			if err != nil {
+				return err
+			}
 			opts[f.Tag] = val
 		case "[]int64":
-			val, _ := ms.Opts.Flags.GetInt64Slice(f.Name)
+			val, err := ms.Opts.Flags.GetInt64Slice(f.Name)
+			if err != nil {
+				return err
+			}
 			opts[f.Tag] = val
 		}
 	}

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -8,6 +8,7 @@ package d2plugin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -128,50 +129,30 @@ type PluginInfo struct {
 const binaryPrefix = "d2plugin-"
 
 func ListPlugins(ctx context.Context) ([]Plugin, error) {
-	// 1. Run Info on all bundled plugins in the global plugins array.
-	//    - set Type for each bundled plugin to "bundled".
-	// 2. Iterate through directories in $PATH and look for executables within these
-	//    directories with the prefix d2plugin-*
-	// 3. Run each plugin binary with the argument info. e.g. d2plugin-dagre info
-
 	var ps []Plugin
 	ps = append(ps, plugins...)
+	seenNames := make(map[string]struct{}, len(plugins))
+	for _, bundled := range plugins {
+		info, err := bundled.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+		seenNames[strings.ToLower(info.Name)] = struct{}{}
+	}
 
 	matches, err := xexec.SearchPath(binaryPrefix)
 	if err != nil {
 		return nil, err
 	}
-BINARY_PLUGINS_LOOP:
 	for _, path := range matches {
-		// A bundled plugin owns its executable basename. Skip a shadowed
-		// external binary before even running its info command: a stale,
-		// malformed, or hanging legacy plugin must not make the bundled engine
-		// unavailable.
 		basename := externalPluginName(path)
-		for _, bundled := range plugins {
-			info, err := bundled.Info(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if strings.EqualFold(info.Name, basename) {
-				continue BINARY_PLUGINS_LOOP
-			}
+		key := strings.ToLower(basename)
+		if _, exists := seenNames[key]; exists {
+			continue
 		}
-		p := &execPlugin{path: path}
-		info, err := p.Info(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, p2 := range ps {
-			info2, err := p2.Info(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if strings.EqualFold(info.Name, info2.Name) {
-				continue BINARY_PLUGINS_LOOP
-			}
-		}
-		ps = append(ps, p)
+		seenNames[key] = struct{}{}
+		// External plugins are intentionally not executed during discovery.
+		ps = append(ps, &execPlugin{path: path})
 	}
 	return ps, nil
 }
@@ -200,6 +181,53 @@ func ListPluginInfos(ctx context.Context, ps []Plugin) ([]*PluginInfo, error) {
 	return infoSlice, nil
 }
 
+// ListPluginSummaries returns enough metadata to list discovered plugins
+// without executing external plugin binaries.
+func ListPluginSummaries(ctx context.Context, ps []Plugin) ([]*PluginInfo, error) {
+	infos := make([]*PluginInfo, 0, len(ps))
+	for _, p := range ps {
+		if external, ok := p.(*execPlugin); ok {
+			infos = append(infos, &PluginInfo{
+				Name: externalPluginName(external.path),
+				Type: "binary",
+				Path: external.path,
+			})
+			continue
+		}
+		info, err := p.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+// ListPluginNames returns discovered plugin names without executing external
+// plugin binaries.
+func ListPluginNames(ctx context.Context, ps []Plugin) ([]string, error) {
+	names := make([]string, 0, len(ps))
+	for _, p := range ps {
+		name, err := pluginName(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func pluginName(ctx context.Context, p Plugin) (string, error) {
+	if external, ok := p.(*execPlugin); ok {
+		return externalPluginName(external.path), nil
+	}
+	info, err := p.Info(ctx)
+	if err != nil {
+		return "", err
+	}
+	return info.Name, nil
+}
+
 // FindPlugin finds the plugin with the given name.
 //  1. It first searches the bundled plugins in the global plugins slice.
 //  2. If not found, it then searches each directory in $PATH for a binary with the name
@@ -208,11 +236,20 @@ func ListPluginInfos(ctx context.Context, ps []Plugin) ([]*PluginInfo, error) {
 //     to get a plugin implementation around the binary and returns it.
 func FindPlugin(ctx context.Context, ps []Plugin, name string) (Plugin, error) {
 	for _, p := range ps {
-		info, err := p.Info(ctx)
+		candidateName, err := pluginName(ctx, p)
 		if err != nil {
 			return nil, err
 		}
-		if strings.EqualFold(info.Name, name) {
+		if strings.EqualFold(candidateName, name) {
+			if external, ok := p.(*execPlugin); ok {
+				info, err := external.Info(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if !strings.EqualFold(info.Name, name) {
+					return nil, fmt.Errorf("plugin %q reported name %q", external.path, info.Name)
+				}
+			}
 			if instancer, ok := p.(pluginInstancer); ok {
 				return instancer.newInstance(), nil
 			}
@@ -233,6 +270,33 @@ func ListPluginFlags(ctx context.Context, ps []Plugin) ([]PluginSpecificFlag, er
 	}
 
 	return out, nil
+}
+
+// ListPluginFlagsForSelection returns flags for every bundled plugin and the
+// selected external plugin. Bundled plugins are safe to inspect in-process;
+// external plugins must not be executed merely because their binaries are on
+// PATH.
+func ListPluginFlagsForSelection(ctx context.Context, ps []Plugin, selectedName string) ([]PluginSpecificFlag, error) {
+	selected := make([]Plugin, 0, len(ps))
+	for _, p := range ps {
+		external, ok := p.(*execPlugin)
+		if !ok {
+			selected = append(selected, p)
+			continue
+		}
+		if !strings.EqualFold(externalPluginName(external.path), selectedName) {
+			continue
+		}
+		info, err := external.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.EqualFold(info.Name, selectedName) {
+			return nil, fmt.Errorf("plugin %q reported name %q", external.path, info.Name)
+		}
+		selected = append(selected, external)
+	}
+	return ListPluginFlags(ctx, selected)
 }
 
 func HydratePluginOpts(ctx context.Context, ms *xmain.State, plugin Plugin) error {

--- a/d2plugin/plugin_tala_test.go
+++ b/d2plugin/plugin_tala_test.go
@@ -2,8 +2,10 @@ package d2plugin
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -146,6 +148,64 @@ func TestBundledTALAWinsBeforeExecutingExternalDuplicate(t *testing.T) {
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("shadowed external TALA was executed before duplicate suppression: %v", err)
+	}
+}
+
+func TestExternalPluginsExecuteOnlyWhenSelected(t *testing.T) {
+	temp := t.TempDir()
+	marker := filepath.Join(temp, "executed")
+	name := binaryPrefix + "external"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	copyExecutable(t, filepath.Join(temp, name))
+
+	t.Setenv(pluginInfoHelperEnv, "1")
+	t.Setenv(pluginInfoMarkerEnv, marker)
+	t.Setenv(pluginInfoNameEnv, "external")
+	t.Setenv("PATH", temp)
+	listed, err := ListPlugins(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("plugin executed during discovery: %v", err)
+	}
+	if _, err := ListPluginNames(context.Background(), listed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("plugin executed while listing names: %v", err)
+	}
+	if _, err := ListPluginSummaries(context.Background(), listed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("plugin executed while listing summaries: %v", err)
+	}
+	if _, err := FindPlugin(context.Background(), listed, "missing"); !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("FindPlugin(missing) error = %v, want exec.ErrNotFound", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("unselected plugin executed: %v", err)
+	}
+	if _, err := ListPluginFlagsForSelection(context.Background(), listed, "missing"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("unselected plugin executed while listing flags: %v", err)
+	}
+	if _, err := ListPluginFlagsForSelection(context.Background(), listed, "external"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("selected plugin did not execute while listing flags: %v", err)
+	}
+	if _, err := FindPlugin(context.Background(), listed, "external"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("selected plugin did not execute: %v", err)
 	}
 }
 

--- a/d2plugin/postprocess_test.go
+++ b/d2plugin/postprocess_test.go
@@ -18,6 +18,7 @@ const postProcessHelperEnv = "D2_POSTPROCESS_HELPER_PROCESS"
 const (
 	pluginInfoHelperEnv = "D2_PLUGIN_INFO_HELPER_PROCESS"
 	pluginInfoMarkerEnv = "D2_PLUGIN_INFO_HELPER_MARKER"
+	pluginInfoNameEnv   = "D2_PLUGIN_INFO_HELPER_NAME"
 )
 
 func TestMain(m *testing.M) {
@@ -28,8 +29,20 @@ func TestMain(m *testing.M) {
 				os.Exit(2)
 			}
 		}
-		fmt.Fprint(os.Stdout, `{"name":"tala","features":[]}`)
-		os.Exit(0)
+		if len(os.Args) == 2 && os.Args[1] == "flags" {
+			fmt.Fprint(os.Stdout, `[]`)
+			os.Exit(0)
+		}
+		if len(os.Args) == 2 && os.Args[1] == "info" {
+			name := os.Getenv(pluginInfoNameEnv)
+			if name == "" {
+				name = "tala"
+			}
+			fmt.Fprintf(os.Stdout, `{"name":%q,"features":[]}`, name)
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "unexpected helper arguments: %q", os.Args[1:])
+		os.Exit(2)
 	}
 	if os.Getenv(postProcessHelperEnv) == "1" {
 		if len(os.Args) != 2 || os.Args[1] != "postprocess" {


### PR DESCRIPTION
## Human

---

## AI

Discovers external layout plugins from their executable names without running them, and executes only the external plugin unambiguously selected for use or detailed help. Ambiguous ordering between unregistered plugin flags and layout selection fails closed; bundled layout flags and source-configured defaults remain supported.

Tests:

- `go test ./...`
- `go vet ./...`
