### PR TITLE
fix(svg): sanitize bundled image media types

### DIFF
--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/andybalholm/brotli"
 
 	"github.com/d2lang/d2/lib/simplelog"
+	"github.com/d2lang/d2/lib/svg"
 	"github.com/d2lang/util-go/xdefer"
 )
 
@@ -182,20 +183,21 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 		return nil, err
 	}
 
-	if mimeType == "" {
-		mimeType = sniffMimeType(href, buf, isRemote)
-		l.Debug(fmt.Sprintf("no mimetype provided - sniffed MIME type for %s: %s", string(href), mimeType))
+	declaredMIMEType := mimeType
+	mimeType, ok := canonicalImageMIMEType(declaredMIMEType)
+	if !ok {
+		mimeType, ok = sniffImageMIMEType(href, buf, isRemote)
+		if !ok {
+			mimeType = "application/octet-stream"
+		}
+		l.Debug(fmt.Sprintf("invalid or unsupported mimetype %q - sniffed MIME type for %s: %s", declaredMIMEType, string(href), mimeType))
 	} else {
 		l.Debug(fmt.Sprintf("mimetype provided for %s: %s", string(href), mimeType))
 	}
-	mimeType = strings.Replace(mimeType, "text/xml", "image/svg+xml", 1)
-	if mimeType == "application/octet-stream" && bytes.Contains(buf, []byte("<svg")) {
-		l.Debug(fmt.Sprintf("octet-stream mimetype replaced with svg for %s", string(href)))
-		mimeType = "image/svg+xml"
-	}
 	b64 := base64.StdEncoding.EncodeToString(buf)
+	dataURI := fmt.Sprintf("data:%s;base64,%s", mimeType, b64)
 
-	out := []byte(fmt.Sprintf(`<image href="data:%s;base64,%s"`, mimeType, b64))
+	out := []byte(fmt.Sprintf(`<image href="%s"`, svg.EscapeText(dataURI)))
 	if cacheImages {
 		imgCache.Store(string(href), out)
 	}
@@ -306,8 +308,31 @@ func readDecoded(r io.Reader) ([]byte, error) {
 	return buf, nil
 }
 
-// sniffMimeType sniffs the mime type of href based on its file extension and contents.
-func sniffMimeType(href, buf []byte, isRemote bool) string {
+// canonicalImageMIMEType strictly parses a declared media type and returns a
+// parameter-free image media type suitable for a data URI. Preserve arbitrary
+// valid image subtypes for browser compatibility while normalizing aliases D2
+// has historically supported.
+func canonicalImageMIMEType(value string) (string, bool) {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", false
+	}
+	mediaType = strings.ToLower(mediaType)
+	switch mediaType {
+	case "image/jpg", "image/pjpeg":
+		return "image/jpeg", true
+	case "image/x-png":
+		return "image/png", true
+	case "text/xml", "application/xml", "application/svg+xml":
+		return "image/svg+xml", true
+	default:
+		return mediaType, mediaType != "image/*" && strings.HasPrefix(mediaType, "image/")
+	}
+}
+
+// sniffImageMIMEType sniffs the MIME type of href based on its file extension
+// and contents, accepting only values canonicalImageMIMEType can make safe.
+func sniffImageMIMEType(href, buf []byte, isRemote bool) (string, bool) {
 	p := string(href)
 	if isRemote {
 		u, err := url.Parse(html.UnescapeString(p))
@@ -317,9 +342,16 @@ func sniffMimeType(href, buf []byte, isRemote bool) string {
 			p = u.Path
 		}
 	}
-	mimeType := mime.TypeByExtension(path.Ext(p))
-	if mimeType == "" {
-		mimeType = http.DetectContentType(buf)
+	for _, candidate := range []string{
+		mime.TypeByExtension(path.Ext(p)),
+		http.DetectContentType(buf),
+	} {
+		if mimeType, ok := canonicalImageMIMEType(candidate); ok {
+			return mimeType, true
+		}
 	}
-	return mimeType
+	if bytes.Contains(buf, []byte("<svg")) {
+		return "image/svg+xml", true
+	}
+	return "", false
 }

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -8,7 +8,9 @@ import (
 	"crypto/rand"
 	_ "embed"
 	"encoding/base64"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -404,6 +406,96 @@ func TestInlineRemoteCompressedSVG(t *testing.T) {
 			}
 			tassert.Equal(t, rawSVG, decoded)
 		})
+	}
+}
+
+func TestInlineRemoteContentTypeIsSafeAndCanonical(t *testing.T) {
+	ctx := log.With(context.Background(), testlog.New(t))
+	originalTransport := httpClient.Transport
+	t.Cleanup(func() {
+		httpClient.Transport = originalTransport
+	})
+	imageURL := "https://example.com/asset"
+	sampleSVG := []byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg"><image href="%s" /></svg>`, imageURL))
+	rawSVG := []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`)
+
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        []byte
+		wantType    string
+	}{
+		{
+			name:        "malicious quoted header",
+			contentType: `image/svg+xml" onerror="alert(1)" data-x="`,
+			body:        rawSVG,
+			wantType:    "image/svg+xml",
+		},
+		{
+			name:        "parameterized SVG",
+			contentType: "image/svg+xml; charset=utf-8",
+			body:        rawSVG,
+			wantType:    "image/svg+xml",
+		},
+		{
+			name:        "parameterized PNG alias",
+			contentType: "image/x-png; charset=binary",
+			body:        testPNGFile,
+			wantType:    "image/png",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imgCache = sync.Map{}
+			httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
+				if req.URL.String() != imageURL {
+					t.Fatalf("unexpected URL %s", req.URL)
+				}
+				respRecorder := httptest.NewRecorder()
+				respRecorder.Header().Set("Content-Type", tc.contentType)
+				respRecorder.WriteHeader(http.StatusOK)
+				_, _ = respRecorder.Write(tc.body)
+				return respRecorder.Result()
+			})
+
+			out, err := BundleRemote(ctx, simplelog.FromLibLog(ctx), sampleSVG, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantHref := "data:" + tc.wantType + ";base64," + base64.StdEncoding.EncodeToString(tc.body)
+			assertBundledImageHref(t, out, wantHref)
+		})
+	}
+}
+
+func assertBundledImageHref(t *testing.T, source []byte, wantHref string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(bytes.NewReader(source))
+	decoder.Strict = true
+	found := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("bundled SVG is not valid XML: %v\n%s", err, source)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Local != "image" {
+			continue
+		}
+		for _, attr := range start.Attr {
+			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+				t.Fatalf("bundled image contains event handler %q: %s", attr.Name.Local, source)
+			}
+			if attr.Name.Local == "href" && attr.Value == wantHref {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("bundled SVG does not contain href %q: %s", wantHref, source)
 	}
 }
 


### PR DESCRIPTION
## Human

---

## AI

Parses and canonicalizes remote image media types before constructing bundled SVG data URIs, and escapes the complete URI as XML attribute data.

Tests:

- `go test ./...`
