### PR TITLE
security: restrict remote asset network access

### DIFF
--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -138,6 +138,9 @@ Set the diagram layout engine to the passed string. For a list of available opti
 .It Fl b , -bundle Ar true
 Bundle all assets and layers into the output svg
 .Ns .
+.It Fl -allow-private-network Ar false
+Allow remote image assets to access private, loopback, and link-local networks. Only enable this for trusted diagrams
+.Ns .
 .It Fl -force-appendix Ar false
 An appendix for tooltips and links is added to PNG exports since they are not interactive. Setting this to true adds an appendix to SVG exports as well
 .Ns .
@@ -217,6 +220,8 @@ See --center flag.
 See -s[ketch] flag.
 .It Ev Sy D2_BUNDLE
 See -b[undle] flag.
+.It Ev Sy D2_ALLOW_PRIVATE_NETWORK
+See --allow-private-network flag.
 .It Ev Sy D2_FORCE_APPENDIX
 See --force-appendix flag.
 .It Ev Sy D2_FONT_REGULAR

--- a/d2cli/help_test.go
+++ b/d2cli/help_test.go
@@ -1,13 +1,45 @@
 package d2cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/d2lang/util-go/xmain"
 	"github.com/d2lang/util-go/xos"
 )
+
+func TestHelpWithPrivateNetworkEnvironment(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	var stdout bytes.Buffer
+	state := &xmain.TestState{
+		Run:    Run,
+		Env:    xos.NewEnv([]string{"D2_ALLOW_PRIVATE_NETWORK=1"}),
+		Args:   []string{"d2", "--help"},
+		Stdout: &stdout,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	state.Start(t, ctx)
+	defer state.Cleanup(t)
+	if err := state.Wait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if output := stdout.String(); !strings.Contains(output, "--allow-private-network") || !strings.Contains(output, "$D2_ALLOW_PRIVATE_NETWORK") {
+		t.Fatalf("help does not document private-network opt-in:\n%s", output)
+	}
+}
+
+func TestPrivateNetworkEnvDefaultRejectsInvalidValue(t *testing.T) {
+	_, err := privateNetworkEnvDefault(&xmain.State{Env: xos.NewEnv([]string{"D2_ALLOW_PRIVATE_NETWORK=yes"})})
+	var usageErr xmain.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("privateNetworkEnvDefault() error = %v, want xmain.UsageError", err)
+	}
+}
 
 func TestLayoutCmdRejectsExtraArguments(t *testing.T) {
 	opts := xmain.NewOpts(xos.NewEnv(nil), []string{"layout", "dagre", "info"})

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -48,6 +48,18 @@ import (
 	"github.com/d2lang/d2/lib/version"
 )
 
+func privateNetworkEnvDefault(ms *xmain.State) (bool, error) {
+	const key = "D2_ALLOW_PRIVATE_NETWORK"
+	switch value := ms.Env.Getenv(key); value {
+	case "", "0", "false":
+		return false, nil
+	case "1", "true":
+		return true, nil
+	default:
+		return false, xmain.UsageErrorf(`invalid environment variable %s. Expected bool. Found "%s".`, key, value)
+	}
+}
+
 func Run(ctx context.Context, ms *xmain.State) (err error) {
 	ctx = log.WithDefault(ctx)
 	// These should be kept up-to-date with the d2 man page
@@ -61,7 +73,11 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	allowPrivateNetworkFlag, err := ms.Opts.Bool("D2_ALLOW_PRIVATE_NETWORK", "allow-private-network", "", false, "allow remote image assets to access private, loopback, and link-local networks. Only enable this for trusted diagrams")
+	allowPrivateNetworkDefault, err := privateNetworkEnvDefault(ms)
+	if err != nil {
+		return err
+	}
+	allowPrivateNetworkFlag, err := ms.Opts.Bool("", "allow-private-network", "", allowPrivateNetworkDefault, "allow remote image assets to access private, loopback, and link-local networks. Only enable this for trusted diagrams. Can also be set with $D2_ALLOW_PRIVATE_NETWORK")
 	if err != nil {
 		return err
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/d2lang/d2/lib/background"
 	"github.com/d2lang/d2/lib/imgbundler"
 	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/pdf"
 	"github.com/d2lang/d2/lib/pptx"
 	"github.com/d2lang/d2/lib/simplelog"
@@ -57,6 +58,10 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	hostFlag := ms.Opts.String("HOST", "host", "h", "localhost", "host listening address when used with watch")
 	portFlag := ms.Opts.String("PORT", "port", "p", "0", "port listening address when used with watch")
 	bundleFlag, err := ms.Opts.Bool("D2_BUNDLE", "bundle", "b", true, "when outputting SVG, bundle all assets and layers into the output file")
+	if err != nil {
+		return err
+	}
+	allowPrivateNetworkFlag, err := ms.Opts.Bool("D2_ALLOW_PRIVATE_NETWORK", "allow-private-network", "", false, "allow remote image assets to access private, loopback, and link-local networks. Only enable this for trusted diagrams")
 	if err != nil {
 		return err
 	}
@@ -168,6 +173,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		help(ms)
 		return nil
 	}
+	ctx = netpolicy.WithPolicy(ctx, netpolicy.Policy{AllowPrivateNetworks: *allowPrivateNetworkFlag})
 
 	fontFamily, monoFontFamily, err := loadFonts(ms, *fontRegularFlag, *fontItalicFlag, *fontBoldFlag, *fontSemiboldFlag, *fontMonoFlag, *fontMonoBoldFlag, *fontMonoItalicFlag, *fontMonoSemiboldFlag)
 	if err != nil {
@@ -1043,7 +1049,7 @@ func _renderWithPNGEncoder(ctx context.Context, ms *xmain.State, plugin d2plugin
 	svg, bundleErr := imgbundler.BundleLocal(ctx, l, inputPath, svg, cacheImages)
 	if bundle {
 		var bundleErr2 error
-		svg, bundleErr2 = imgbundler.BundleRemote(ctx, l, svg, cacheImages)
+		svg, bundleErr2 = imgbundler.BundleRemoteWithPolicy(ctx, l, svg, cacheImages, netpolicy.FromContext(ctx))
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 	}
 	if forceAppendix {

--- a/d2cli/paged.go
+++ b/d2cli/paged.go
@@ -78,7 +78,7 @@ func newPagedRenderer(ctx context.Context, plugin d2plugin.Plugin, inputPath str
 	if err != nil {
 		return nil, err
 	}
-	assets, err := pagedSceneAssetOptions(inputPath, cacheImages, boardCount)
+	assets, err := pagedSceneAssetOptions(ctx, inputPath, cacheImages, boardCount)
 	if err != nil {
 		return nil, err
 	}
@@ -226,12 +226,12 @@ func pagedFrameOptions(totalBoards int, remainingPixels int64) (d2raster.FrameOp
 	return options, nil
 }
 
-func pagedSceneAssetOptions(inputPath string, cacheImages bool, boardCount int) (*d2scenebuild.AssetOptions, error) {
+func pagedSceneAssetOptions(ctx context.Context, inputPath string, cacheImages bool, boardCount int) (*d2scenebuild.AssetOptions, error) {
 	budget, err := divideSVGImportBudget(svgImportBudget(), boardCount)
 	if err != nil {
 		return nil, err
 	}
-	return newSceneAssetOptions(inputPath, cacheImages, assetSessionLimits{
+	return newSceneAssetOptions(ctx, inputPath, cacheImages, assetSessionLimits{
 		maxDecodedPixels:          rasterMaxPixels,
 		maxAssets:                 imageAssetMaxCount,
 		maxCumulativeEncodedBytes: imageAssetMaxCumulativeEncodedBytes,

--- a/d2cli/raster.go
+++ b/d2cli/raster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/d2lang/d2/d2renderers/d2svgimport"
 	"github.com/d2lang/d2/d2target"
 	"github.com/d2lang/d2/lib/imageasset"
+	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/xgif"
 )
 
@@ -265,7 +266,7 @@ func buildScene(ctx context.Context, inputPath string, cacheImages bool, diagram
 	if diagram == nil {
 		return nil, fmt.Errorf("raster export: nil diagram")
 	}
-	assetOptions, err := sceneAssetOptions(inputPath, cacheImages)
+	assetOptions, err := sceneAssetOptions(ctx, inputPath, cacheImages)
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +616,7 @@ func renderGIFWithSession(
 	if len(boards) == 0 {
 		return summary, fmt.Errorf("GIF animation requires at least one renderable board")
 	}
-	assetOptions, err := gifSceneAssetOptions(inputPath, cacheImages, len(boards))
+	assetOptions, err := gifSceneAssetOptions(ctx, inputPath, cacheImages, len(boards))
 	if err != nil {
 		return summary, err
 	}
@@ -985,8 +986,8 @@ type assetSessionLimits struct {
 	svgImportBudget           d2scenebuild.SVGImportBudget
 }
 
-func sceneAssetOptions(inputPath string, cacheImages bool) (*d2scenebuild.AssetOptions, error) {
-	return newSceneAssetOptions(inputPath, cacheImages, assetSessionLimits{
+func sceneAssetOptions(ctx context.Context, inputPath string, cacheImages bool) (*d2scenebuild.AssetOptions, error) {
+	return newSceneAssetOptions(ctx, inputPath, cacheImages, assetSessionLimits{
 		maxDecodedPixels:          rasterMaxPixels,
 		maxAssets:                 imageAssetMaxCount,
 		maxCumulativeEncodedBytes: imageAssetMaxCumulativeEncodedBytes,
@@ -995,12 +996,12 @@ func sceneAssetOptions(inputPath string, cacheImages bool) (*d2scenebuild.AssetO
 	})
 }
 
-func gifSceneAssetOptions(inputPath string, cacheImages bool, boardCount int) (*d2scenebuild.AssetOptions, error) {
+func gifSceneAssetOptions(ctx context.Context, inputPath string, cacheImages bool, boardCount int) (*d2scenebuild.AssetOptions, error) {
 	budget, err := divideSVGImportBudget(svgImportBudget(), boardCount)
 	if err != nil {
 		return nil, err
 	}
-	return newSceneAssetOptions(inputPath, cacheImages, assetSessionLimits{
+	return newSceneAssetOptions(ctx, inputPath, cacheImages, assetSessionLimits{
 		maxDecodedPixels:          gifMaxFramePixels,
 		maxAssets:                 gifImageAssetMaxCount,
 		maxCumulativeEncodedBytes: gifImageEncodedBytes,
@@ -1009,7 +1010,7 @@ func gifSceneAssetOptions(inputPath string, cacheImages bool, boardCount int) (*
 	})
 }
 
-func newSceneAssetOptions(inputPath string, cacheImages bool, limits assetSessionLimits) (*d2scenebuild.AssetOptions, error) {
+func newSceneAssetOptions(ctx context.Context, inputPath string, cacheImages bool, limits assetSessionLimits) (*d2scenebuild.AssetOptions, error) {
 	baseDir := ""
 	if inputPath != "" && inputPath != "-" {
 		baseDir = filepath.Dir(inputPath)
@@ -1031,6 +1032,7 @@ func newSceneAssetOptions(inputPath string, cacheImages bool, limits assetSessio
 	resolver, err := imageasset.New(imageasset.Options{
 		BaseDir:        baseDir,
 		HTTPClient:     assetHTTPClient,
+		NetworkPolicy:  netpolicy.FromContext(ctx),
 		Cache:          cache,
 		CacheNamespace: cacheNamespace,
 		Limits: imageasset.Limits{

--- a/d2cli/raster_test.go
+++ b/d2cli/raster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/d2lang/d2/d2renderers/d2svg"
 	"github.com/d2lang/d2/d2target"
 	"github.com/d2lang/d2/lib/geo"
+	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/pptx"
 	"github.com/d2lang/d2/lib/xgif"
 )
@@ -682,7 +683,7 @@ func TestBundleGIFPreviewUsesResolvedSnapshotAndUnescapesHref(t *testing.T) {
 	if err := os.WriteFile(assetPath, first, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	assetOptions, err := gifSceneAssetOptions(inputPath, false, 1)
+	assetOptions, err := gifSceneAssetOptions(context.Background(), inputPath, false, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,7 +707,7 @@ func TestBundleGIFPreviewUsesResolvedSnapshotAndUnescapesHref(t *testing.T) {
 }
 
 func TestBundleGIFPreviewBoundsReferencesAndExpandedOutput(t *testing.T) {
-	assetOptions, err := gifSceneAssetOptions("-", false, 1)
+	assetOptions, err := gifSceneAssetOptions(context.Background(), "-", false, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,7 +722,7 @@ func TestBundleGIFPreviewBoundsReferencesAndExpandedOutput(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(directory, "asset.svg"), []byte(largeSVG), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	assetOptions, err = gifSceneAssetOptions(inputPath, false, 1)
+	assetOptions, err = gifSceneAssetOptions(context.Background(), inputPath, false, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -871,7 +872,7 @@ func TestGIFSharesOperationAssetResolverAcrossBoards(t *testing.T) {
 	root := rasterImageDiagram(assetURL)
 	root.Layers = []*d2target.Diagram{rasterImageDiagram(assetURL)}
 	frames, _, err := renderGIFFramesForTest(
-		context.Background(),
+		trustedAssetContext(),
 		nil,
 		"-",
 		false,
@@ -886,6 +887,10 @@ func TestGIFSharesOperationAssetResolverAcrossBoards(t *testing.T) {
 	if len(frames) != 2 || requests.Load() != 1 {
 		t.Fatalf("shared GIF frames/asset requests = %d/%d, want 2/1", len(frames), requests.Load())
 	}
+}
+
+func trustedAssetContext() context.Context {
+	return netpolicy.WithPolicy(context.Background(), netpolicy.Policy{AllowPrivateNetworks: true})
 }
 
 func TestGIFDividesOperationWorkBudgets(t *testing.T) {
@@ -1109,14 +1114,14 @@ func TestRenderPNGUsesPlaceholderForUnavailableImage(t *testing.T) {
 	diagram := rasterImageDiagram(assetURL)
 	diagram.Shapes[0].Width = 64
 	diagram.Shapes[0].Height = 64
-	encoded, err := renderPNGWithEncoder(context.Background(), "-", true, diagram, d2svg.RenderOpts{
+	encoded, err := renderPNGWithEncoder(trustedAssetContext(), "-", true, diagram, d2svg.RenderOpts{
 		Pad: go2.Pointer(int64(0)), Scale: go2.Pointer(1.0),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertPNGPixel(t, encoded, 32, 56, color.NRGBA{R: 0xb8, G: 0xd7, B: 0xf2, A: 0xff})
-	second, err := renderPNGWithEncoder(context.Background(), "-", true, diagram, d2svg.RenderOpts{
+	second, err := renderPNGWithEncoder(trustedAssetContext(), "-", true, diagram, d2svg.RenderOpts{
 		Pad: go2.Pointer(int64(0)), Scale: go2.Pointer(1.0),
 	}, nil)
 	if err != nil {
@@ -1143,13 +1148,13 @@ func TestRenderPNGPreservesRemoteImageCacheBehavior(t *testing.T) {
 	}
 	diagram := rasterImageDiagram(assetURL)
 	options := d2svg.RenderOpts{Pad: go2.Pointer(int64(0)), Scale: go2.Pointer(1.0)}
-	first, err := renderPNGWithEncoder(context.Background(), "-", true, diagram, options, nil)
+	first, err := renderPNGWithEncoder(trustedAssetContext(), "-", true, diagram, options, nil)
 	if err != nil {
 		server.Close()
 		t.Fatal(err)
 	}
 	server.Close()
-	second, err := renderPNGWithEncoder(context.Background(), "-", true, diagram, options, nil)
+	second, err := renderPNGWithEncoder(trustedAssetContext(), "-", true, diagram, options, nil)
 	if err != nil {
 		t.Fatalf("cached render after origin shutdown: %v", err)
 	}
@@ -1185,7 +1190,7 @@ func TestRenderPNGReusesRemoteConnectionsWithoutImageCache(t *testing.T) {
 	diagram := rasterImageDiagram(assetURL)
 	options := d2svg.RenderOpts{Pad: go2.Pointer(int64(0)), Scale: go2.Pointer(1.0)}
 	for render := 0; render < 3; render++ {
-		if _, err := renderPNGWithEncoder(context.Background(), "-", false, diagram, options, nil); err != nil {
+		if _, err := renderPNGWithEncoder(trustedAssetContext(), "-", false, diagram, options, nil); err != nil {
 			t.Fatalf("uncached render %d: %v", render+1, err)
 		}
 	}
@@ -1216,7 +1221,7 @@ func TestAssetBudgetsReserveFontsAndBoundEverySVGDimension(t *testing.T) {
 	if pagedRenderCacheBytes <= rasterMaxDecodedBytes+fontAssetByteReserve+imageAssetMaxBytes {
 		t.Fatalf("paged cache budget %d does not exceed decoded %d + fonts %d + image key %d", pagedRenderCacheBytes, rasterMaxDecodedBytes, fontAssetByteReserve, imageAssetMaxBytes)
 	}
-	options, err := sceneAssetOptions("-", false)
+	options, err := sceneAssetOptions(context.Background(), "-", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/d2renderers/d2scenebuild/assets_test.go
+++ b/d2renderers/d2scenebuild/assets_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/d2lang/d2/d2target"
 	"github.com/d2lang/d2/lib/geo"
 	"github.com/d2lang/d2/lib/imageasset"
+	"github.com/d2lang/d2/lib/netpolicy"
 )
 
 func TestResolvedJPEGEXIFOrientationRenders(t *testing.T) {
@@ -654,7 +655,7 @@ func newCountingAssetResolver(t *testing.T, failure error) (*imageasset.Resolver
 
 func newTestAssetResolver(t *testing.T, client *http.Client) *imageasset.Resolver {
 	t.Helper()
-	resolver, err := imageasset.New(imageasset.Options{HTTPClient: client, Limits: imageasset.Limits{
+	resolver, err := imageasset.New(imageasset.Options{HTTPClient: client, NetworkPolicy: netpolicy.Policy{AllowPrivateNetworks: true}, Limits: imageasset.Limits{
 		MaxFetchedBytes: 1 << 20, MaxEncodedBytes: 1 << 20, MaxDecompressedBytes: 1 << 20, MaxSVGBytes: 1 << 20,
 		MaxDecodedWidth: 1024, MaxDecodedHeight: 1024, MaxDecodedPixels: 1 << 20,
 		MaxAssets: 64, MaxCumulativeEncodedBytes: 8 << 20, MaxCumulativeDecodedBytes: 16 << 20,

--- a/lib/imageasset/imageasset.go
+++ b/lib/imageasset/imageasset.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/d2lang/d2/lib/netpolicy"
 )
 
 // Preserve imgbundler's worker ceiling so per-resource byte limits also bound
@@ -250,10 +252,14 @@ type Options struct {
 	// value freezes the current working directory at construction time.
 	BaseDir    string
 	HTTPClient *http.Client
-	Cache      Cache
+	// NetworkPolicy defaults to public addresses only. Trusted callers can
+	// explicitly allow private-network assets.
+	NetworkPolicy netpolicy.Policy
+	Cache         Cache
 	// CacheNamespace is required when Cache is set. Reusing a namespace asserts
 	// identical tenant, credentials, CookieJar, redirect policy, transport, and
-	// fetch semantics for every Resolver sharing that cache.
+	// fetch semantics for every Resolver sharing that cache. NetworkPolicy is
+	// automatically included in the effective namespace.
 	CacheNamespace string
 	Limits         Limits
 }
@@ -305,9 +311,17 @@ func New(options Options) (*Resolver, error) {
 		}
 		client = &clone
 	}
+	client, err = netpolicy.NewHTTPClient(client, options.NetworkPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("imageasset: configure HTTP network policy: %w", err)
+	}
 	cachePrefix := ""
 	if options.Cache != nil {
-		namespaceHash := sha256.Sum256([]byte(options.CacheNamespace))
+		networkNamespace := "public-only"
+		if options.NetworkPolicy.AllowPrivateNetworks {
+			networkNamespace = "private-network"
+		}
+		namespaceHash := sha256.Sum256([]byte(options.CacheNamespace + "\x00network-policy:" + networkNamespace))
 		cachePrefix = fmt.Sprintf("namespace:%x:", namespaceHash)
 	}
 	return &Resolver{

--- a/lib/imageasset/imageasset_test.go
+++ b/lib/imageasset/imageasset_test.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+
+	"github.com/d2lang/d2/lib/netpolicy"
 )
 
 func TestResolveLocalRelativeAbsoluteAndOwnedBytes(t *testing.T) {
@@ -827,6 +829,10 @@ func TestLimitsMustBeCallerSupplied(t *testing.T) {
 
 func newTestResolver(t *testing.T, options Options) *Resolver {
 	t.Helper()
+	// Existing fixtures intentionally use loopback servers and custom in-memory
+	// transports. Tests of the default public-only policy construct a Resolver
+	// directly instead.
+	options.NetworkPolicy = netpolicy.Policy{AllowPrivateNetworks: true}
 	if options.Limits == (Limits{}) {
 		options.Limits = generousLimits()
 	}

--- a/lib/imageasset/network_policy_test.go
+++ b/lib/imageasset/network_policy_test.go
@@ -1,0 +1,171 @@
+package imageasset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d2lang/d2/lib/netpolicy"
+)
+
+func TestHTTPNetworkPolicy(t *testing.T) {
+	image := encodePNG(t, 2, 3)
+	var imageHits atomic.Int32
+	var firstRedirectHits atomic.Int32
+	var secondRedirectHits atomic.Int32
+	var privateHits atomic.Int32
+
+	var port string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/image":
+			imageHits.Add(1)
+			response.Header().Set("Content-Type", "image/png")
+			_, _ = response.Write(image)
+		case "/redirect-one":
+			firstRedirectHits.Add(1)
+			http.Redirect(response, request, "http://1.1.1.1:"+port+"/redirect-two", http.StatusFound)
+		case "/redirect-two":
+			secondRedirectHits.Add(1)
+			http.Redirect(response, request, "http://127.0.0.1:"+port+"/private", http.StatusFound)
+		case "/private":
+			privateHits.Add(1)
+			response.Header().Set("Content-Type", "image/png")
+			_, _ = response.Write(image)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	parsedServer, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err = net.SplitHostPort(parsedServer.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := mappedPublicClient(parsedServer.Host, map[string]bool{"8.8.8.8": true, "1.1.1.1": true})
+
+	newResolver := func(t *testing.T) *Resolver {
+		t.Helper()
+		resolver, err := New(Options{HTTPClient: client, Limits: generousLimits()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resolver
+	}
+
+	t.Run("allows public target", func(t *testing.T) {
+		resource, err := newResolver(t).Resolve(context.Background(), "http://8.8.8.8:"+port+"/image")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertResource(t, resource, KindRaster, "image/png", 2, 3)
+		if imageHits.Load() != 1 {
+			t.Fatalf("image endpoint received %d requests", imageHits.Load())
+		}
+	})
+
+	t.Run("blocks direct private target", func(t *testing.T) {
+		_, err := newResolver(t).Resolve(context.Background(), server.URL+"/private")
+		if !errors.Is(err, netpolicy.ErrBlockedAddress) {
+			t.Fatalf("Resolve error = %v, want ErrBlockedAddress", err)
+		}
+		if privateHits.Load() != 0 {
+			t.Fatalf("private endpoint received %d requests", privateHits.Load())
+		}
+	})
+
+	t.Run("checks every redirect", func(t *testing.T) {
+		_, err := newResolver(t).Resolve(context.Background(), "http://8.8.8.8:"+port+"/redirect-one")
+		if !errors.Is(err, netpolicy.ErrBlockedAddress) {
+			t.Fatalf("Resolve error = %v, want ErrBlockedAddress", err)
+		}
+		if firstRedirectHits.Load() != 1 || secondRedirectHits.Load() != 1 {
+			t.Fatalf("redirect hits = %d/%d, want 1/1", firstRedirectHits.Load(), secondRedirectHits.Load())
+		}
+		if privateHits.Load() != 0 {
+			t.Fatalf("private redirect endpoint received %d requests", privateHits.Load())
+		}
+	})
+
+	t.Run("explicit opt-in allows trusted private target", func(t *testing.T) {
+		resolver, err := New(Options{
+			HTTPClient:    server.Client(),
+			NetworkPolicy: netpolicy.Policy{AllowPrivateNetworks: true},
+			Limits:        generousLimits(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := privateHits.Load()
+		resource, err := resolver.Resolve(context.Background(), server.URL+"/private")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertResource(t, resource, KindRaster, "image/png", 2, 3)
+		if privateHits.Load() != before+1 {
+			t.Fatalf("private endpoint received %d requests", privateHits.Load())
+		}
+	})
+
+	t.Run("cache is separated by policy", func(t *testing.T) {
+		cache, err := NewMemoryCache(4, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trusted, err := New(Options{
+			HTTPClient:     server.Client(),
+			NetworkPolicy:  netpolicy.Policy{AllowPrivateNetworks: true},
+			Cache:          cache,
+			CacheNamespace: "shared-network-test",
+			Limits:         generousLimits(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := privateHits.Load()
+		if _, err := trusted.Resolve(context.Background(), server.URL+"/private"); err != nil {
+			t.Fatal(err)
+		}
+		publicOnly, err := New(Options{
+			HTTPClient:     server.Client(),
+			Cache:          cache,
+			CacheNamespace: "shared-network-test",
+			Limits:         generousLimits(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = publicOnly.Resolve(context.Background(), server.URL+"/private")
+		if !errors.Is(err, netpolicy.ErrBlockedAddress) {
+			t.Fatalf("Resolve error = %v, want ErrBlockedAddress", err)
+		}
+		if privateHits.Load() != before+1 {
+			t.Fatalf("private endpoint received %d new requests, want one trusted request", privateHits.Load()-before)
+		}
+	})
+}
+
+func mappedPublicClient(localAddress string, allowed map[string]bool) *http.Client {
+	transport := &http.Transport{}
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed[host] {
+			return nil, fmt.Errorf("test dialer received unexpected address %s", address)
+		}
+		return dialer.DialContext(ctx, network, localAddress)
+	}
+	return &http.Client{Transport: transport}
+}

--- a/lib/imageasset/network_policy_test.go
+++ b/lib/imageasset/network_policy_test.go
@@ -3,11 +3,8 @@ package imageasset
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"sync/atomic"
 	"testing"
 
@@ -16,24 +13,10 @@ import (
 
 func TestHTTPNetworkPolicy(t *testing.T) {
 	image := encodePNG(t, 2, 3)
-	var imageHits atomic.Int32
-	var firstRedirectHits atomic.Int32
-	var secondRedirectHits atomic.Int32
 	var privateHits atomic.Int32
 
-	var port string
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
-		case "/image":
-			imageHits.Add(1)
-			response.Header().Set("Content-Type", "image/png")
-			_, _ = response.Write(image)
-		case "/redirect-one":
-			firstRedirectHits.Add(1)
-			http.Redirect(response, request, "http://1.1.1.1:"+port+"/redirect-two", http.StatusFound)
-		case "/redirect-two":
-			secondRedirectHits.Add(1)
-			http.Redirect(response, request, "http://127.0.0.1:"+port+"/private", http.StatusFound)
 		case "/private":
 			privateHits.Add(1)
 			response.Header().Set("Content-Type", "image/png")
@@ -43,35 +26,15 @@ func TestHTTPNetworkPolicy(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	parsedServer, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, port, err = net.SplitHostPort(parsedServer.Host)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := mappedPublicClient(parsedServer.Host, map[string]bool{"8.8.8.8": true, "1.1.1.1": true})
 
 	newResolver := func(t *testing.T) *Resolver {
 		t.Helper()
-		resolver, err := New(Options{HTTPClient: client, Limits: generousLimits()})
+		resolver, err := New(Options{HTTPClient: server.Client(), Limits: generousLimits()})
 		if err != nil {
 			t.Fatal(err)
 		}
 		return resolver
 	}
-
-	t.Run("allows public target", func(t *testing.T) {
-		resource, err := newResolver(t).Resolve(context.Background(), "http://8.8.8.8:"+port+"/image")
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertResource(t, resource, KindRaster, "image/png", 2, 3)
-		if imageHits.Load() != 1 {
-			t.Fatalf("image endpoint received %d requests", imageHits.Load())
-		}
-	})
 
 	t.Run("blocks direct private target", func(t *testing.T) {
 		_, err := newResolver(t).Resolve(context.Background(), server.URL+"/private")
@@ -80,19 +43,6 @@ func TestHTTPNetworkPolicy(t *testing.T) {
 		}
 		if privateHits.Load() != 0 {
 			t.Fatalf("private endpoint received %d requests", privateHits.Load())
-		}
-	})
-
-	t.Run("checks every redirect", func(t *testing.T) {
-		_, err := newResolver(t).Resolve(context.Background(), "http://8.8.8.8:"+port+"/redirect-one")
-		if !errors.Is(err, netpolicy.ErrBlockedAddress) {
-			t.Fatalf("Resolve error = %v, want ErrBlockedAddress", err)
-		}
-		if firstRedirectHits.Load() != 1 || secondRedirectHits.Load() != 1 {
-			t.Fatalf("redirect hits = %d/%d, want 1/1", firstRedirectHits.Load(), secondRedirectHits.Load())
-		}
-		if privateHits.Load() != 0 {
-			t.Fatalf("private redirect endpoint received %d requests", privateHits.Load())
 		}
 	})
 
@@ -152,20 +102,4 @@ func TestHTTPNetworkPolicy(t *testing.T) {
 			t.Fatalf("private endpoint received %d new requests, want one trusted request", privateHits.Load()-before)
 		}
 	})
-}
-
-func mappedPublicClient(localAddress string, allowed map[string]bool) *http.Client {
-	transport := &http.Transport{}
-	dialer := &net.Dialer{}
-	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		host, _, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
-		}
-		if !allowed[host] {
-			return nil, fmt.Errorf("test dialer received unexpected address %s", address)
-		}
-		return dialer.DialContext(ctx, network, localAddress)
-	}
-	return &http.Client{Transport: transport}
 }

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/andybalholm/brotli"
 
+	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/simplelog"
 	"github.com/d2lang/util-go/xdefer"
 )
@@ -34,11 +35,18 @@ const maxImageSize int64 = 1 << 25 // 33_554_432
 var imageRegex = regexp.MustCompile(`<image href="([^"]+)"`)
 
 func BundleLocal(ctx context.Context, l simplelog.Logger, inputPath string, in []byte, cacheImages bool) ([]byte, error) {
-	return bundle(ctx, l, inputPath, in, false, cacheImages)
+	return bundle(ctx, l, inputPath, in, false, cacheImages, netpolicy.Policy{})
 }
 
 func BundleRemote(ctx context.Context, l simplelog.Logger, in []byte, cacheImages bool) ([]byte, error) {
-	return bundle(ctx, l, "", in, true, cacheImages)
+	return BundleRemoteWithPolicy(ctx, l, in, cacheImages, netpolicy.Policy{})
+}
+
+// BundleRemoteWithPolicy bundles HTTP(S) images under policy. The zero policy
+// permits public destinations only; trusted callers may explicitly opt into
+// private-network assets.
+func BundleRemoteWithPolicy(ctx context.Context, l simplelog.Logger, in []byte, cacheImages bool, policy netpolicy.Policy) ([]byte, error) {
+	return bundle(ctx, l, "", in, true, cacheImages, policy)
 }
 
 type repl struct {
@@ -46,7 +54,7 @@ type repl struct {
 	to   []byte
 }
 
-func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, isRemote, cacheImages bool) (_ []byte, err error) {
+func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, isRemote, cacheImages bool, policy netpolicy.Policy) (_ []byte, err error) {
 	if isRemote {
 		defer xdefer.Errorf(&err, "failed to bundle remote images")
 	} else {
@@ -58,11 +66,18 @@ func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byt
 	if len(imgs) == 0 {
 		return svg, nil
 	}
+	var client *http.Client
+	if isRemote {
+		client, err = netpolicy.NewHTTPClient(httpClient, policy)
+		if err != nil {
+			return svg, err
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 
-	return runWorkers(ctx, l, inputPath, svg, imgs, isRemote, cacheImages)
+	return runWorkers(ctx, l, inputPath, svg, imgs, isRemote, cacheImages, client, policy)
 }
 
 // filterImageElements finds all unique image elements in imgs that are
@@ -92,7 +107,7 @@ func filterImageElements(imgs [][][]byte, isRemote bool) [][][]byte {
 	return imgs2
 }
 
-func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, imgs [][][]byte, isRemote, cacheImages bool) (_ []byte, err error) {
+func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, imgs [][][]byte, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) (_ []byte, err error) {
 	var wg sync.WaitGroup
 	replc := make(chan repl)
 
@@ -119,7 +134,7 @@ func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg [
 					<-sema
 				}()
 
-				bundledImage, err := worker(ctx, l, inputPath, img[1], isRemote, cacheImages)
+				bundledImage, err := worker(ctx, l, inputPath, img[1], isRemote, cacheImages, client, policy)
 				if err != nil {
 					l.Error(fmt.Sprintf("failed to bundle %s: %v", img[1], err))
 					errhrefsMu.Lock()
@@ -158,9 +173,16 @@ func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg [
 	}
 }
 
-func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []byte, isRemote, cacheImages bool) ([]byte, error) {
+type imageCacheKey struct {
+	href                 string
+	isRemote             bool
+	allowPrivateNetworks bool
+}
+
+func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []byte, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) ([]byte, error) {
+	cacheKey := imageCacheKey{href: string(href), isRemote: isRemote, allowPrivateNetworks: policy.AllowPrivateNetworks}
 	if cacheImages {
-		if hit, ok := imgCache.Load(string(href)); ok {
+		if hit, ok := imgCache.Load(cacheKey); ok {
 			return hit.([]byte), nil
 		}
 	}
@@ -169,7 +191,7 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 	var err error
 	if isRemote {
 		l.Debug(fmt.Sprintf("fetching %s remotely", string(href)))
-		buf, mimeType, err = httpGet(ctx, l, html.UnescapeString(string(href)))
+		buf, mimeType, err = httpGet(ctx, l, client, html.UnescapeString(string(href)))
 	} else {
 		l.Debug(fmt.Sprintf("reading %s from disk", string(href)))
 		path := html.UnescapeString(string(href))
@@ -197,14 +219,14 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 
 	out := []byte(fmt.Sprintf(`<image href="data:%s;base64,%s"`, mimeType, b64))
 	if cacheImages {
-		imgCache.Store(string(href), out)
+		imgCache.Store(cacheKey, out)
 	}
 	return out, nil
 }
 
 var httpClient = &http.Client{}
 
-func httpGet(ctx context.Context, l simplelog.Logger, href string) ([]byte, string, error) {
+func httpGet(ctx context.Context, l simplelog.Logger, client *http.Client, href string) ([]byte, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
@@ -223,7 +245,7 @@ func httpGet(ctx context.Context, l simplelog.Logger, href string) ([]byte, stri
 	req.Header.Set("Sec-Fetch-Mode", "no-cors")
 	req.Header.Set("Sec-Fetch-Site", "cross-site")
 
-	resp, err := httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/d2lang/d2/internal/testlog"
 	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/simplelog"
 	"github.com/d2lang/util-go/go2"
 )
@@ -32,6 +33,10 @@ type roundTripFunc func(req *http.Request) *http.Response
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
+}
+
+func bundleRemoteForTest(ctx context.Context, l simplelog.Logger, in []byte, cacheImages bool) ([]byte, error) {
+	return BundleRemoteWithPolicy(ctx, l, in, cacheImages, netpolicy.Policy{AllowPrivateNetworks: true})
 }
 
 func TestRegex(t *testing.T) {
@@ -103,7 +108,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	})
 
 	l := simplelog.FromLibLog(ctx)
-	out, err := BundleRemote(ctx, l, []byte(sampleSVG), false)
+	out, err := bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +132,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +147,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -154,7 +159,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(500)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -303,7 +308,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	})
 
 	l := simplelog.FromLibLog(ctx)
-	out, err := BundleRemote(ctx, l, []byte(sampleSVG), false)
+	out, err := bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +390,7 @@ func TestInlineRemoteCompressedSVG(t *testing.T) {
 				return respRecorder.Result()
 			})
 
-			out, err := BundleRemote(ctx, simplelog.FromLibLog(ctx), sampleSVG, false)
+			out, err := bundleRemoteForTest(ctx, simplelog.FromLibLog(ctx), sampleSVG, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -452,11 +457,11 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 	l := simplelog.FromLibLog(ctx)
 	// Using a cache, imgs are not refetched on multiple runs
-	_, err := BundleRemote(ctx, l, []byte(sampleSVG), true)
+	_, err := bundleRemoteForTest(ctx, l, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), true)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,11 +469,11 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 	// With cache disabled, it refetches
 	count = 0
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
+	_, err = bundleRemoteForTest(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/imgbundler/network_policy_test.go
+++ b/lib/imgbundler/network_policy_test.go
@@ -3,10 +3,8 @@ package imgbundler
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,24 +17,10 @@ import (
 )
 
 func TestBundleRemoteNetworkPolicy(t *testing.T) {
-	var imageHits atomic.Int32
-	var firstRedirectHits atomic.Int32
-	var secondRedirectHits atomic.Int32
 	var privateHits atomic.Int32
 
-	var port string
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
-		case "/image":
-			imageHits.Add(1)
-			response.Header().Set("Content-Type", "image/png")
-			_, _ = response.Write(testPNGFile)
-		case "/redirect-one":
-			firstRedirectHits.Add(1)
-			http.Redirect(response, request, "http://1.1.1.1:"+port+"/redirect-two", http.StatusFound)
-		case "/redirect-two":
-			secondRedirectHits.Add(1)
-			http.Redirect(response, request, "http://127.0.0.1:"+port+"/private", http.StatusFound)
 		case "/private":
 			privateHits.Add(1)
 			response.Header().Set("Content-Type", "image/png")
@@ -46,30 +30,12 @@ func TestBundleRemoteNetworkPolicy(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	parsedServer, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, port, err = net.SplitHostPort(parsedServer.Host)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	previousClient := httpClient
-	httpClient = mappedPublicClient(parsedServer.Host, map[string]bool{"8.8.8.8": true, "1.1.1.1": true})
+	httpClient = server.Client()
 	t.Cleanup(func() { httpClient = previousClient })
 	ctx := log.With(context.Background(), testlog.New(t))
 	logger := simplelog.FromLibLog(ctx)
-
-	t.Run("allows public target", func(t *testing.T) {
-		output, err := BundleRemote(ctx, logger, remoteImageSVG("http://8.8.8.8:"+port+"/image"), false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if imageHits.Load() != 1 || !strings.Contains(string(output), "data:image/png;base64,") {
-			t.Fatalf("image hits = %d, output = %s", imageHits.Load(), output)
-		}
-	})
 
 	t.Run("blocks direct private target", func(t *testing.T) {
 		_, err := BundleRemote(ctx, logger, remoteImageSVG(server.URL+"/private"), false)
@@ -78,19 +44,6 @@ func TestBundleRemoteNetworkPolicy(t *testing.T) {
 		}
 		if privateHits.Load() != 0 {
 			t.Fatalf("private endpoint received %d requests", privateHits.Load())
-		}
-	})
-
-	t.Run("checks every redirect", func(t *testing.T) {
-		_, err := BundleRemote(ctx, logger, remoteImageSVG("http://8.8.8.8:"+port+"/redirect-one"), false)
-		if err == nil {
-			t.Fatal("expected redirect to private network to fail")
-		}
-		if firstRedirectHits.Load() != 1 || secondRedirectHits.Load() != 1 {
-			t.Fatalf("redirect hits = %d/%d, want 1/1", firstRedirectHits.Load(), secondRedirectHits.Load())
-		}
-		if privateHits.Load() != 0 {
-			t.Fatalf("private redirect endpoint received %d requests", privateHits.Load())
 		}
 	})
 
@@ -131,20 +84,4 @@ func TestBundleRemoteNetworkPolicy(t *testing.T) {
 
 func remoteImageSVG(source string) []byte {
 	return []byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg"><image href="%s"/></svg>`, source))
-}
-
-func mappedPublicClient(localAddress string, allowed map[string]bool) *http.Client {
-	transport := &http.Transport{}
-	dialer := &net.Dialer{}
-	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		host, _, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
-		}
-		if !allowed[host] {
-			return nil, fmt.Errorf("test dialer received unexpected address %s", address)
-		}
-		return dialer.DialContext(ctx, network, localAddress)
-	}
-	return &http.Client{Transport: transport}
 }

--- a/lib/imgbundler/network_policy_test.go
+++ b/lib/imgbundler/network_policy_test.go
@@ -1,0 +1,150 @@
+package imgbundler
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d2lang/d2/internal/testlog"
+	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/netpolicy"
+	"github.com/d2lang/d2/lib/simplelog"
+)
+
+func TestBundleRemoteNetworkPolicy(t *testing.T) {
+	var imageHits atomic.Int32
+	var firstRedirectHits atomic.Int32
+	var secondRedirectHits atomic.Int32
+	var privateHits atomic.Int32
+
+	var port string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/image":
+			imageHits.Add(1)
+			response.Header().Set("Content-Type", "image/png")
+			_, _ = response.Write(testPNGFile)
+		case "/redirect-one":
+			firstRedirectHits.Add(1)
+			http.Redirect(response, request, "http://1.1.1.1:"+port+"/redirect-two", http.StatusFound)
+		case "/redirect-two":
+			secondRedirectHits.Add(1)
+			http.Redirect(response, request, "http://127.0.0.1:"+port+"/private", http.StatusFound)
+		case "/private":
+			privateHits.Add(1)
+			response.Header().Set("Content-Type", "image/png")
+			_, _ = response.Write(testPNGFile)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	parsedServer, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err = net.SplitHostPort(parsedServer.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousClient := httpClient
+	httpClient = mappedPublicClient(parsedServer.Host, map[string]bool{"8.8.8.8": true, "1.1.1.1": true})
+	t.Cleanup(func() { httpClient = previousClient })
+	ctx := log.With(context.Background(), testlog.New(t))
+	logger := simplelog.FromLibLog(ctx)
+
+	t.Run("allows public target", func(t *testing.T) {
+		output, err := BundleRemote(ctx, logger, remoteImageSVG("http://8.8.8.8:"+port+"/image"), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if imageHits.Load() != 1 || !strings.Contains(string(output), "data:image/png;base64,") {
+			t.Fatalf("image hits = %d, output = %s", imageHits.Load(), output)
+		}
+	})
+
+	t.Run("blocks direct private target", func(t *testing.T) {
+		_, err := BundleRemote(ctx, logger, remoteImageSVG(server.URL+"/private"), false)
+		if err == nil {
+			t.Fatal("expected direct private-network request to fail")
+		}
+		if privateHits.Load() != 0 {
+			t.Fatalf("private endpoint received %d requests", privateHits.Load())
+		}
+	})
+
+	t.Run("checks every redirect", func(t *testing.T) {
+		_, err := BundleRemote(ctx, logger, remoteImageSVG("http://8.8.8.8:"+port+"/redirect-one"), false)
+		if err == nil {
+			t.Fatal("expected redirect to private network to fail")
+		}
+		if firstRedirectHits.Load() != 1 || secondRedirectHits.Load() != 1 {
+			t.Fatalf("redirect hits = %d/%d, want 1/1", firstRedirectHits.Load(), secondRedirectHits.Load())
+		}
+		if privateHits.Load() != 0 {
+			t.Fatalf("private redirect endpoint received %d requests", privateHits.Load())
+		}
+	})
+
+	t.Run("explicit opt-in allows trusted private target", func(t *testing.T) {
+		mappedClient := httpClient
+		httpClient = server.Client()
+		defer func() { httpClient = mappedClient }()
+		before := privateHits.Load()
+		output, err := BundleRemoteWithPolicy(ctx, logger, remoteImageSVG(server.URL+"/private"), false, netpolicy.Policy{AllowPrivateNetworks: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if privateHits.Load() != before+1 || !strings.Contains(string(output), "data:image/png;base64,") {
+			t.Fatalf("private hits = %d, output = %s", privateHits.Load(), output)
+		}
+	})
+
+	t.Run("cache is separated by policy", func(t *testing.T) {
+		imgCache = sync.Map{}
+		mappedClient := httpClient
+		httpClient = server.Client()
+		before := privateHits.Load()
+		_, err := BundleRemoteWithPolicy(ctx, logger, remoteImageSVG(server.URL+"/private"), true, netpolicy.Policy{AllowPrivateNetworks: true})
+		if err != nil {
+			httpClient = mappedClient
+			t.Fatal(err)
+		}
+		httpClient = mappedClient
+		_, err = BundleRemote(ctx, logger, remoteImageSVG(server.URL+"/private"), true)
+		if err == nil {
+			t.Fatal("public-only request reused a private-policy cache entry")
+		}
+		if privateHits.Load() != before+1 {
+			t.Fatalf("private endpoint received %d new requests, want one trusted request", privateHits.Load()-before)
+		}
+	})
+}
+
+func remoteImageSVG(source string) []byte {
+	return []byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg"><image href="%s"/></svg>`, source))
+}
+
+func mappedPublicClient(localAddress string, allowed map[string]bool) *http.Client {
+	transport := &http.Transport{}
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed[host] {
+			return nil, fmt.Errorf("test dialer received unexpected address %s", address)
+		}
+		return dialer.DialContext(ctx, network, localAddress)
+	}
+	return &http.Client{Transport: transport}
+}

--- a/lib/netpolicy/netpolicy.go
+++ b/lib/netpolicy/netpolicy.go
@@ -51,16 +51,21 @@ type ipResolver interface {
 // NewHTTPClient clones base and applies policy without mutating the caller's
 // client or transport. Public-only clients resolve each hostname themselves,
 // reject the entire resolution if any address is non-public, and pass only a
-// validated numeric address to the transport dialer. This prevents redirects
-// and DNS rebinding from bypassing the policy.
+// validated numeric address to a policy-owned transport dialer. Caller proxy,
+// dial, and alternate-protocol hooks are not retained. Every new connection
+// resolves and validates its destination, so redirects and DNS rebinding cannot
+// bypass the policy.
 //
 // A public-only client requires a standard *http.Transport. Custom protocol
 // RoundTrippers can opt into trusted private-network behavior explicitly.
 func NewHTTPClient(base *http.Client, policy Policy) (*http.Client, error) {
-	return newHTTPClient(base, policy, net.DefaultResolver)
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	return newHTTPClient(base, policy, net.DefaultResolver, dialer.DialContext)
 }
 
-func newHTTPClient(base *http.Client, policy Policy, resolver ipResolver) (*http.Client, error) {
+// newHTTPClient keeps resolver and dial injection unexported for deterministic
+// tests. NewHTTPClient always supplies a package-owned net.Dialer.
+func newHTTPClient(base *http.Client, policy Policy, resolver ipResolver, policyDial dialContextFunc) (*http.Client, error) {
 	if base == nil {
 		base = &http.Client{}
 	}
@@ -74,6 +79,8 @@ func newHTTPClient(base *http.Client, policy Policy, resolver ipResolver) (*http
 	case nil:
 		transport = defaultTransport()
 	case *http.Transport:
+		// Clone copies exported configuration but deliberately excludes live
+		// connection pools and handlers installed with RegisterProtocol.
 		transport = baseTransport.Clone()
 	default:
 		return nil, fmt.Errorf("public-only network policy requires *http.Transport, got %T", client.Transport)
@@ -83,15 +90,23 @@ func newHTTPClient(base *http.Client, policy Policy, resolver ipResolver) (*http
 	// boundary, so it cannot uphold the public-only policy. Trusted proxy users
 	// can explicitly opt into private-network behavior.
 	transport.Proxy = nil
-	baseDial := transport.DialContext
-	if baseDial == nil {
-		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
-		baseDial = dialer.DialContext
+	transport.OnProxyConnectResponse = nil
+	transport.GetProxyConnectHeader = nil
+	transport.ProxyConnectHeader = nil
+	if resolver == nil || policyDial == nil {
+		return nil, errors.New("public-only network policy requires its resolver and dialer")
 	}
-	transport.DialContext = validatedDialContext(resolver, baseDial)
+	// Never delegate a validated numeric destination to caller-provided dial
+	// hooks: a hook can ignore that destination and connect to a private address.
+	transport.Dial = nil
+	transport.DialContext = validatedDialContext(resolver, policyDial)
 	// Either hook bypasses DialContext for HTTPS.
 	transport.DialTLS = nil
 	transport.DialTLSContext = nil
+	// A caller-provided TLSNextProto callback is an arbitrary RoundTripper and
+	// can create connections outside DialContext. Clearing it still permits the
+	// standard library to configure its built-in HTTP/2 implementation.
+	transport.TLSNextProto = nil
 	client.Transport = transport
 	return &client, nil
 }

--- a/lib/netpolicy/netpolicy.go
+++ b/lib/netpolicy/netpolicy.go
@@ -1,0 +1,229 @@
+// Package netpolicy applies a network-boundary policy to HTTP clients used to
+// fetch untrusted resources.
+package netpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+)
+
+// ErrBlockedAddress means a request resolved to a non-public address.
+var ErrBlockedAddress = errors.New("network policy blocked a non-public address")
+
+// Policy controls which network destinations an HTTP client may reach. The
+// zero value permits only public IP addresses. AllowPrivateNetworks is intended
+// for trusted diagrams in environments that deliberately serve assets from a
+// private network.
+type Policy struct {
+	AllowPrivateNetworks bool
+}
+
+type policyContextKey struct{}
+
+// WithPolicy records a policy in ctx for render pipelines that construct their
+// asset resolver below a public API boundary.
+func WithPolicy(ctx context.Context, policy Policy) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, policyContextKey{}, policy)
+}
+
+// FromContext returns the policy stored in ctx, or the public-only zero value.
+func FromContext(ctx context.Context) Policy {
+	if ctx == nil {
+		return Policy{}
+	}
+	policy, _ := ctx.Value(policyContextKey{}).(Policy)
+	return policy
+}
+
+type ipResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+// NewHTTPClient clones base and applies policy without mutating the caller's
+// client or transport. Public-only clients resolve each hostname themselves,
+// reject the entire resolution if any address is non-public, and pass only a
+// validated numeric address to the transport dialer. This prevents redirects
+// and DNS rebinding from bypassing the policy.
+//
+// A public-only client requires a standard *http.Transport. Custom protocol
+// RoundTrippers can opt into trusted private-network behavior explicitly.
+func NewHTTPClient(base *http.Client, policy Policy) (*http.Client, error) {
+	return newHTTPClient(base, policy, net.DefaultResolver)
+}
+
+func newHTTPClient(base *http.Client, policy Policy, resolver ipResolver) (*http.Client, error) {
+	if base == nil {
+		base = &http.Client{}
+	}
+	client := *base
+	if policy.AllowPrivateNetworks {
+		return &client, nil
+	}
+
+	var transport *http.Transport
+	switch baseTransport := client.Transport.(type) {
+	case nil:
+		transport = defaultTransport()
+	case *http.Transport:
+		transport = baseTransport.Clone()
+	default:
+		return nil, fmt.Errorf("public-only network policy requires *http.Transport, got %T", client.Transport)
+	}
+
+	// A proxy resolves or connects to the target outside this transport's dial
+	// boundary, so it cannot uphold the public-only policy. Trusted proxy users
+	// can explicitly opt into private-network behavior.
+	transport.Proxy = nil
+	baseDial := transport.DialContext
+	if baseDial == nil {
+		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		baseDial = dialer.DialContext
+	}
+	transport.DialContext = validatedDialContext(resolver, baseDial)
+	// Either hook bypasses DialContext for HTTPS.
+	transport.DialTLS = nil
+	transport.DialTLSContext = nil
+	client.Transport = transport
+	return &client, nil
+}
+
+func defaultTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return &http.Transport{
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func validatedDialContext(resolver ipResolver, dial dialContextFunc) dialContextFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("network policy could not parse destination: %w", err)
+		}
+		addresses, err := resolvePublicAddresses(ctx, resolver, network, host)
+		if err != nil {
+			return nil, err
+		}
+
+		var dialErrors []error
+		for _, resolved := range addresses {
+			conn, err := dial(ctx, network, net.JoinHostPort(resolved.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			dialErrors = append(dialErrors, err)
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+		}
+		return nil, errors.Join(dialErrors...)
+	}
+}
+
+func resolvePublicAddresses(ctx context.Context, resolver ipResolver, network, host string) ([]netip.Addr, error) {
+	host = strings.TrimSuffix(host, ".")
+	if isLocalHostname(host) {
+		return nil, ErrBlockedAddress
+	}
+
+	var addresses []netip.Addr
+	if literal, err := netip.ParseAddr(host); err == nil {
+		addresses = []netip.Addr{literal}
+	} else {
+		lookupNetwork := "ip"
+		if strings.HasSuffix(network, "4") {
+			lookupNetwork = "ip4"
+		} else if strings.HasSuffix(network, "6") {
+			lookupNetwork = "ip6"
+		}
+		resolved, err := resolver.LookupNetIP(ctx, lookupNetwork, host)
+		if err != nil {
+			return nil, err
+		}
+		addresses = resolved
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("network policy: destination resolved to no addresses")
+	}
+
+	// Validate every answer before dialing any one of them. A hostname that
+	// mixes public and private answers is rejected instead of falling through to
+	// a private answer after a public connection failure.
+	unique := make([]netip.Addr, 0, len(addresses))
+	seen := make(map[netip.Addr]struct{}, len(addresses))
+	for _, address := range addresses {
+		address = address.Unmap()
+		if !isPublicAddress(address) {
+			return nil, ErrBlockedAddress
+		}
+		if _, ok := seen[address]; ok {
+			continue
+		}
+		seen[address] = struct{}{}
+		unique = append(unique, address)
+	}
+	return unique, nil
+}
+
+func isLocalHostname(host string) bool {
+	host = strings.ToLower(host)
+	return host == "localhost" || strings.HasSuffix(host, ".localhost") ||
+		host == "metadata.google.internal" || strings.HasSuffix(host, ".metadata.google.internal") ||
+		host == "metadata.goog" || strings.HasSuffix(host, ".metadata.goog") ||
+		host == "metadata.azure.internal" || strings.HasSuffix(host, ".metadata.azure.internal") ||
+		host == "instance-data.ec2.internal" || strings.HasSuffix(host, ".instance-data.ec2.internal")
+}
+
+var nonPublicPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("168.63.129.16/32"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/96"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("3fff::/20"),
+	netip.MustParsePrefix("5f00::/16"),
+	netip.MustParsePrefix("fec0::/10"),
+}
+
+func isPublicAddress(address netip.Addr) bool {
+	if !address.IsValid() || address.Zone() != "" || !address.IsGlobalUnicast() ||
+		address.IsUnspecified() || address.IsLoopback() || address.IsPrivate() ||
+		address.IsLinkLocalUnicast() || address.IsLinkLocalMulticast() || address.IsMulticast() {
+		return false
+	}
+	for _, prefix := range nonPublicPrefixes {
+		if prefix.Contains(address) {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/netpolicy/netpolicy_test.go
+++ b/lib/netpolicy/netpolicy_test.go
@@ -2,10 +2,16 @@ package netpolicy
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/netip"
+	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -77,7 +83,7 @@ func TestValidatedDialUsesOnlyResolvedNumericAddress(t *testing.T) {
 			return nil, wantDialError
 		},
 	}}
-	client, err := newHTTPClient(base, Policy{}, resolver)
+	client, err := newHTTPClient(base, Policy{}, resolver, base.Transport.(*http.Transport).DialContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +114,7 @@ func TestValidatedDialRejectsMixedResolutionBeforeDial(t *testing.T) {
 			return nil, errors.New("unexpected dial")
 		},
 	}}
-	client, err := newHTTPClient(base, Policy{}, resolver)
+	client, err := newHTTPClient(base, Policy{}, resolver, base.Transport.(*http.Transport).DialContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,6 +124,216 @@ func TestValidatedDialRejectsMixedResolutionBeforeDial(t *testing.T) {
 	}
 	if dialed {
 		t.Fatal("transport dialer was called for a mixed public/private resolution")
+	}
+}
+
+func TestValidatedDialRechecksDNSForEachConnection(t *testing.T) {
+	t.Parallel()
+	lookupCalls := 0
+	resolver := resolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+		lookupCalls++
+		if lookupCalls == 1 {
+			return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+		}
+		return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+	})
+	wantDialError := errors.New("dial stopped by test")
+	dialCalls := 0
+	policyDial := func(context.Context, string, string) (net.Conn, error) {
+		dialCalls++
+		return nil, wantDialError
+	}
+	client, err := newHTTPClient(nil, Policy{}, resolver, policyDial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dial := client.Transport.(*http.Transport).DialContext
+	_, err = dial(context.Background(), "tcp", "assets.example:80")
+	if !errors.Is(err, wantDialError) {
+		t.Fatalf("first DialContext error = %v, want test dial error", err)
+	}
+	_, err = dial(context.Background(), "tcp", "assets.example:80")
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("second DialContext error = %v, want ErrBlockedAddress", err)
+	}
+	if lookupCalls != 2 || dialCalls != 1 {
+		t.Fatalf("lookups/dials = %d/%d, want 2/1", lookupCalls, dialCalls)
+	}
+}
+
+func TestPublicOnlyClientChecksEveryRedirect(t *testing.T) {
+	t.Parallel()
+	var firstHits atomic.Int32
+	var secondHits atomic.Int32
+	var privateHits atomic.Int32
+
+	var port string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/first":
+			firstHits.Add(1)
+			http.Redirect(response, request, "http://second.example:"+port+"/second", http.StatusFound)
+		case "/second":
+			secondHits.Add(1)
+			http.Redirect(response, request, "http://127.0.0.1:"+port+"/private", http.StatusFound)
+		case "/private":
+			privateHits.Add(1)
+			_, _ = io.WriteString(response, "private")
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	var err error
+	_, port, err = net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := resolverFunc(func(_ context.Context, _ string, host string) ([]netip.Addr, error) {
+		switch host {
+		case "first.example":
+			return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+		case "second.example":
+			return []netip.Addr{netip.MustParseAddr("1.1.1.1")}, nil
+		case "127.0.0.1":
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		default:
+			return nil, errors.New("unexpected test hostname")
+		}
+	})
+	dialer := &net.Dialer{}
+	policyDial := func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	client, err := newHTTPClient(nil, Policy{}, resolver, policyDial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Get("http://first.example:" + port + "/first")
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("Get error = %v, want ErrBlockedAddress", err)
+	}
+	if firstHits.Load() != 1 || secondHits.Load() != 1 {
+		t.Fatalf("redirect hits = %d/%d, want 1/1", firstHits.Load(), secondHits.Load())
+	}
+	if privateHits.Load() != 0 {
+		t.Fatalf("private redirect endpoint received %d requests", privateHits.Load())
+	}
+}
+
+func TestNewHTTPClientIgnoresCallerDialHooks(t *testing.T) {
+	t.Parallel()
+	callerDialed := false
+	base := &http.Client{Transport: &http.Transport{
+		Dial: func(string, string) (net.Conn, error) {
+			callerDialed = true
+			return nil, errors.New("caller Dial used")
+		},
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			callerDialed = true
+			return nil, errors.New("caller DialContext used")
+		},
+		DialTLS: func(string, string) (net.Conn, error) {
+			callerDialed = true
+			return nil, errors.New("caller DialTLS used")
+		},
+		DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+			callerDialed = true
+			return nil, errors.New("caller DialTLSContext used")
+		},
+	}}
+	client, err := NewHTTPClient(base, Policy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if transport.Dial != nil || transport.DialTLS != nil || transport.DialTLSContext != nil {
+		t.Fatal("public-only transport retained a caller dial hook")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = transport.DialContext(ctx, "tcp", "8.8.8.8:443")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DialContext error = %v, want context.Canceled from policy dialer", err)
+	}
+	if callerDialed {
+		t.Fatal("public-only transport invoked a caller dial hook")
+	}
+}
+
+func TestPublicOnlyTransportClearsBypassHooks(t *testing.T) {
+	t.Parallel()
+	proxyCalled := false
+	tlsNextProtoCalled := false
+	baseTransport := &http.Transport{
+		Proxy: func(*http.Request) (*url.URL, error) {
+			proxyCalled = true
+			return nil, errors.New("caller proxy used")
+		},
+		OnProxyConnectResponse: func(context.Context, *url.URL, *http.Request, *http.Response) error {
+			proxyCalled = true
+			return errors.New("caller proxy response hook used")
+		},
+		GetProxyConnectHeader: func(context.Context, *url.URL, string) (http.Header, error) {
+			proxyCalled = true
+			return nil, errors.New("caller proxy header hook used")
+		},
+		ProxyConnectHeader: http.Header{"X-Test": {"unsafe"}},
+		TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{
+			"bypass": func(string, *tls.Conn) http.RoundTripper {
+				tlsNextProtoCalled = true
+				return roundTripperFunc(func(*http.Request) (*http.Response, error) {
+					return nil, errors.New("caller TLSNextProto used")
+				})
+			},
+		},
+	}
+	baseTransport.RegisterProtocol("http", roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("registered bypass")),
+		}, nil
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(response, "normal transport")
+	}))
+	defer server.Close()
+	localAddress := server.Listener.Addr().String()
+	resolver := resolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	})
+	dialer := &net.Dialer{}
+	policyDial := func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, localAddress)
+	}
+	client, err := newHTTPClient(&http.Client{Transport: baseTransport}, Policy{}, resolver, policyDial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if transport.Proxy != nil || transport.OnProxyConnectResponse != nil || transport.GetProxyConnectHeader != nil || transport.ProxyConnectHeader != nil {
+		t.Fatal("public-only transport retained proxy hooks")
+	}
+	if transport.TLSNextProto != nil {
+		t.Fatal("public-only transport retained TLSNextProto callbacks")
+	}
+	response, err := client.Get("http://assets.example/image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "normal transport" {
+		t.Fatalf("response body = %q, want normal transport", body)
+	}
+	if proxyCalled || tlsNextProtoCalled {
+		t.Fatalf("caller hook invoked: proxy=%v TLSNextProto=%v", proxyCalled, tlsNextProtoCalled)
 	}
 }
 

--- a/lib/netpolicy/netpolicy_test.go
+++ b/lib/netpolicy/netpolicy_test.go
@@ -1,0 +1,146 @@
+package netpolicy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"testing"
+)
+
+type resolverFunc func(context.Context, string, string) ([]netip.Addr, error)
+
+func (f resolverFunc) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	return f(ctx, network, host)
+}
+
+func TestNonPublicAddressRanges(t *testing.T) {
+	t.Parallel()
+	for _, address := range []string{
+		"0.0.0.1",
+		"10.0.0.1",
+		"100.100.100.200",
+		"127.0.0.1",
+		"168.63.129.16",
+		"169.254.169.254",
+		"172.16.0.1",
+		"192.168.0.1",
+		"198.18.0.1",
+		"224.0.0.1",
+		"255.255.255.255",
+		"::",
+		"::1",
+		"::ffff:127.0.0.1",
+		"64:ff9b::7f00:1",
+		"2001::1",
+		"2002:7f00:1::",
+		"fc00::1",
+		"fd00:ec2::254",
+		"fe80::1",
+		"ff02::1",
+		"fec0::1",
+	} {
+		t.Run(address, func(t *testing.T) {
+			if isPublicAddress(netip.MustParseAddr(address).Unmap()) {
+				t.Fatalf("isPublicAddress(%s) = true", address)
+			}
+		})
+	}
+	for _, address := range []string{"8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"} {
+		t.Run("public_"+address, func(t *testing.T) {
+			if !isPublicAddress(netip.MustParseAddr(address)) {
+				t.Fatalf("isPublicAddress(%s) = false", address)
+			}
+		})
+	}
+}
+
+func TestValidatedDialUsesOnlyResolvedNumericAddress(t *testing.T) {
+	t.Parallel()
+	lookupCalls := 0
+	resolver := resolverFunc(func(_ context.Context, network, host string) ([]netip.Addr, error) {
+		lookupCalls++
+		if network != "ip" || host != "assets.example" {
+			t.Fatalf("LookupNetIP(%q, %q)", network, host)
+		}
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	})
+	wantDialError := errors.New("dial stopped by test")
+	var dialedAddress string
+	base := &http.Client{Transport: &http.Transport{
+		DialContext: func(_ context.Context, network, address string) (net.Conn, error) {
+			if network != "tcp" {
+				t.Fatalf("network = %q", network)
+			}
+			dialedAddress = address
+			return nil, wantDialError
+		},
+	}}
+	client, err := newHTTPClient(base, Policy{}, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Transport.(*http.Transport).DialContext(context.Background(), "tcp", "assets.example:443")
+	if !errors.Is(err, wantDialError) {
+		t.Fatalf("DialContext error = %v", err)
+	}
+	if lookupCalls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", lookupCalls)
+	}
+	if dialedAddress != "93.184.216.34:443" {
+		t.Fatalf("dialed address = %q, want validated numeric address", dialedAddress)
+	}
+}
+
+func TestValidatedDialRejectsMixedResolutionBeforeDial(t *testing.T) {
+	t.Parallel()
+	resolver := resolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{
+			netip.MustParseAddr("93.184.216.34"),
+			netip.MustParseAddr("127.0.0.1"),
+		}, nil
+	})
+	dialed := false
+	base := &http.Client{Transport: &http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed = true
+			return nil, errors.New("unexpected dial")
+		},
+	}}
+	client, err := newHTTPClient(base, Policy{}, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Transport.(*http.Transport).DialContext(context.Background(), "tcp", "assets.example:80")
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("DialContext error = %v, want ErrBlockedAddress", err)
+	}
+	if dialed {
+		t.Fatal("transport dialer was called for a mixed public/private resolution")
+	}
+}
+
+func TestPrivateNetworkOptInPreservesCustomRoundTripper(t *testing.T) {
+	t.Parallel()
+	transport := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("stopped by test")
+	})
+	base := &http.Client{Transport: transport}
+	client, err := NewHTTPClient(base, Policy{AllowPrivateNetworks: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := client.Transport.(roundTripperFunc); !ok {
+		t.Fatal("trusted opt-in replaced the caller's custom transport")
+	}
+	if _, err := NewHTTPClient(base, Policy{}); err == nil {
+		t.Fatal("public-only policy accepted a custom protocol RoundTripper")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}


### PR DESCRIPTION
## Human

---

## AI

Applies a shared public-network-only policy to remote assets in both SVG and raster paths. Every DNS result, redirect, and new connection is validated at a policy-owned dial boundary; proxy, custom-dial, and alternate-protocol bypass hooks are removed. Policy-specific caches are isolated, while trusted callers can explicitly opt into private-network access and their custom client behavior. The CLI flag and environment opt-in are documented without triggering the current help formatter's alignment bug.

Tests:

- `go test ./...`
- `go vet ./...`
