### PR TITLE
d2cli: contain multiboard output paths

### DIFF
--- a/d2cli/board_output.go
+++ b/d2cli/board_output.go
@@ -1,0 +1,507 @@
+package d2cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/d2lang/d2/d2target"
+)
+
+const escapedBoardOutputPrefix = "_d2_"
+
+// boardOutputComponent preserves ordinary board names while mapping names that
+// have filesystem meaning to a portable, single path component. The prefix is
+// reserved so a literal board name cannot collide with an escaped name.
+func boardOutputComponent(name string) string {
+	if isPortableBoardOutputComponent(name) && !isReservedBoardOutputComponent(name) {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	return escapedBoardOutputPrefix + hex.EncodeToString(sum[:])
+}
+
+func isReservedBoardOutputComponent(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.HasPrefix(lower, escapedBoardOutputPrefix) {
+		return true
+	}
+	switch lower {
+	case "index", "layers", "scenarios", "steps":
+		return true
+	default:
+		return false
+	}
+}
+
+func isPortableBoardOutputComponent(name string) bool {
+	if name == "" || name == "." || name == ".." || strings.HasSuffix(name, ".") || strings.HasSuffix(name, " ") {
+		return false
+	}
+	if !filepath.IsLocal(name) || filepath.IsAbs(name) || filepath.VolumeName(name) != "" || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
+		return false
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f || strings.ContainsRune(`<>:"/\|?*`, r) {
+			return false
+		}
+	}
+
+	// Windows reserves these names even when they have an extension.
+	base := name
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	switch strings.ToUpper(base) {
+	case "CON", "PRN", "AUX", "NUL", "CLOCK$",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return false
+	}
+	return true
+}
+
+func appendBoardOutputName(outputPath, boardName string) (string, error) {
+	return appendBoardOutputComponent(outputPath, boardOutputComponent(boardName))
+}
+
+func appendBoardOutputComponent(outputPath, component string) (string, error) {
+	outputDir, ext := splitBoardOutputPath(outputPath)
+	joined := filepath.Join(outputDir, component)
+	if err := ensurePathWithin(outputDir, joined); err != nil {
+		return "", fmt.Errorf("invalid board output component %q: %w", component, err)
+	}
+	return joined + ext, nil
+}
+
+func splitBoardOutputPath(outputPath string) (root, ext string) {
+	ext = filepath.Ext(outputPath)
+	if strings.TrimSuffix(filepath.Base(outputPath), ext) == "" {
+		return outputPath, ext
+	}
+	return strings.TrimSuffix(outputPath, ext), ext
+}
+
+func ensurePathWithin(root, path string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes root %q", path, root)
+	}
+	return nil
+}
+
+type boardOutputPaths struct {
+	writePath   string
+	displayPath string
+}
+
+type boardOutputPlan struct {
+	base      boardOutputPaths
+	board     boardOutputPaths
+	layers    boardOutputPaths
+	scenarios boardOutputPaths
+	steps     boardOutputPaths
+}
+
+func newBoardOutputPaths(path string) boardOutputPaths {
+	return boardOutputPaths{writePath: path, displayPath: path}
+}
+
+func (p boardOutputPaths) withBoardName(name string) (boardOutputPaths, error) {
+	writePath, err := appendBoardOutputName(p.writePath, name)
+	if err != nil {
+		return boardOutputPaths{}, err
+	}
+	displayPath, err := appendBoardOutputName(p.displayPath, name)
+	if err != nil {
+		return boardOutputPaths{}, err
+	}
+	return boardOutputPaths{writePath: writePath, displayPath: displayPath}, nil
+}
+
+func (p boardOutputPaths) withComponent(component string) (boardOutputPaths, error) {
+	writePath, err := appendBoardOutputComponent(p.writePath, component)
+	if err != nil {
+		return boardOutputPaths{}, err
+	}
+	displayPath, err := appendBoardOutputComponent(p.displayPath, component)
+	if err != nil {
+		return boardOutputPaths{}, err
+	}
+	return boardOutputPaths{writePath: writePath, displayPath: displayPath}, nil
+}
+
+func planBoardOutput(paths boardOutputPaths, diagram *d2target.Diagram) (boardOutputPlan, error) {
+	var err error
+	if diagram.Name != "" {
+		paths, err = paths.withBoardName(diagram.Name)
+		if err != nil {
+			return boardOutputPlan{}, err
+		}
+	}
+
+	plan := boardOutputPlan{
+		base:      paths,
+		board:     paths,
+		layers:    paths,
+		scenarios: paths,
+		steps:     paths,
+	}
+	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
+		plan.board, err = plan.board.withComponent("index")
+		if err != nil {
+			return boardOutputPlan{}, err
+		}
+	}
+	if len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
+		plan.layers, err = plan.layers.withComponent("layers")
+		if err != nil {
+			return boardOutputPlan{}, err
+		}
+	}
+	if len(diagram.Layers) > 0 || len(diagram.Steps) > 0 {
+		plan.scenarios, err = plan.scenarios.withComponent("scenarios")
+		if err != nil {
+			return boardOutputPlan{}, err
+		}
+	}
+	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 {
+		plan.steps, err = plan.steps.withComponent("steps")
+		if err != nil {
+			return boardOutputPlan{}, err
+		}
+	}
+	return plan, nil
+}
+
+func validateBoardOutputPaths(outputPath string, diagram *d2target.Diagram) error {
+	return validateBoardOutputPathsRecursive("root", newBoardOutputPaths(outputPath), diagram, make(map[string]string))
+}
+
+func validateBoardOutputPathsRecursive(diagramPath string, outputPaths boardOutputPaths, diagram *d2target.Diagram, seen map[string]string) error {
+	plan, err := planBoardOutput(outputPaths, diagram)
+	if err != nil {
+		return err
+	}
+	if !diagram.IsFolderOnly {
+		key := boardOutputCollisionKey(plan.board.displayPath)
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("boards %q and %q resolve to the same output path %q", previous, diagramPath, plan.board.displayPath)
+		}
+		seen[key] = diagramPath
+	}
+	for _, child := range diagram.Layers {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".layers."+child.Name, plan.layers, child, seen); err != nil {
+			return err
+		}
+	}
+	for _, child := range diagram.Scenarios {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".scenarios."+child.Name, plan.scenarios, child, seen); err != nil {
+			return err
+		}
+	}
+	for _, child := range diagram.Steps {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".steps."+child.Name, plan.steps, child, seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func boardOutputCollisionKey(path string) string {
+	return norm.NFC.String(strings.ToLower(filepath.Clean(path)))
+}
+
+// boardOutputWorkspace keeps all content-derived paths inside a directory
+// created by this process. Publishing merges generated files into an existing
+// output tree without recursively deleting that tree or unrelated files.
+type boardOutputWorkspace struct {
+	finalRoot string
+	stageRoot string
+	stageInfo fs.FileInfo
+	extension string
+}
+
+func newBoardOutputWorkspace(outputPath string) (*boardOutputWorkspace, error) {
+	finalRoot, ext := splitBoardOutputPath(outputPath)
+	if err := validateBoardOutputRoot(finalRoot); err != nil {
+		return nil, err
+	}
+	parent := filepath.Dir(finalRoot)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return nil, fmt.Errorf("create board output parent: %w", err)
+	}
+	stageRoot, err := os.MkdirTemp(parent, ".d2-board-output-")
+	if err != nil {
+		return nil, fmt.Errorf("create board output staging directory: %w", err)
+	}
+	if err := os.Chmod(stageRoot, 0o755); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("set board output staging permissions: %w", err),
+			func() error {
+				if cleanupErr := os.Remove(stageRoot); cleanupErr != nil {
+					return fmt.Errorf("remove board output staging directory %q: %w", stageRoot, cleanupErr)
+				}
+				return nil
+			}(),
+		)
+	}
+	stageInfo, err := os.Lstat(stageRoot)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("inspect board output staging directory: %w", err),
+			func() error {
+				if cleanupErr := os.Remove(stageRoot); cleanupErr != nil {
+					return fmt.Errorf("remove board output staging directory %q: %w", stageRoot, cleanupErr)
+				}
+				return nil
+			}(),
+		)
+	}
+	return &boardOutputWorkspace{finalRoot: finalRoot, stageRoot: stageRoot, stageInfo: stageInfo, extension: ext}, nil
+}
+
+func validateBoardOutputRoot(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect board output root: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("board output root %q must be a real directory", path)
+	}
+	return nil
+}
+
+func (w *boardOutputWorkspace) outputPaths(displayPath string) boardOutputPaths {
+	return boardOutputPaths{
+		writePath:   w.stageRoot + w.extension,
+		displayPath: displayPath,
+	}
+}
+
+func (w *boardOutputWorkspace) discard() error {
+	if w.stageRoot == "" {
+		return nil
+	}
+	stageRoot := w.stageRoot
+	stageInfo, err := os.Lstat(stageRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		w.stageRoot = ""
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect board output staging directory %q: %w", stageRoot, err)
+	}
+	if stageInfo.Mode()&os.ModeSymlink != 0 || !stageInfo.IsDir() || !os.SameFile(w.stageInfo, stageInfo) {
+		return fmt.Errorf("refusing to remove replaced board output staging path %q", stageRoot)
+	}
+	if err := os.RemoveAll(stageRoot); err != nil {
+		return fmt.Errorf("remove board output staging directory %q: %w", stageRoot, err)
+	}
+	w.stageRoot = ""
+	return nil
+}
+
+type stagedBoardOutput struct {
+	rel  string
+	mode fs.FileMode
+	dir  bool
+}
+
+func (w *boardOutputWorkspace) publish() (touched bool, err error) {
+	defer func() {
+		if cleanupErr := w.discard(); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+
+	if err := validateBoardOutputRoot(w.finalRoot); err != nil {
+		return false, err
+	}
+	if _, err := os.Lstat(w.finalRoot); errors.Is(err, os.ErrNotExist) {
+		if err := os.Rename(w.stageRoot, w.finalRoot); err != nil {
+			return false, fmt.Errorf("publish board output tree: %w", err)
+		}
+		w.stageRoot = ""
+		return true, nil
+	} else if err != nil {
+		return false, fmt.Errorf("inspect board output root: %w", err)
+	}
+
+	entries, err := w.preflightMerge()
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		destination := filepath.Join(w.finalRoot, entry.rel)
+		if entry.dir {
+			if entry.rel == "." {
+				continue
+			}
+			if err := ensureRealDirectory(destination, entry.mode.Perm()); err != nil {
+				return touched, err
+			}
+			continue
+		}
+		source := filepath.Join(w.stageRoot, entry.rel)
+		if err := publishBoardOutputFile(source, destination, entry.mode.Perm()); err != nil {
+			return touched, err
+		}
+		touched = true
+	}
+	return touched, nil
+}
+
+func (w *boardOutputWorkspace) preflightMerge() ([]stagedBoardOutput, error) {
+	var entries []stagedBoardOutput
+	err := filepath.WalkDir(w.stageRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(w.stageRoot, path)
+		if err != nil {
+			return err
+		}
+		destination := filepath.Join(w.finalRoot, rel)
+		if err := ensurePathWithin(w.finalRoot, destination); err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("staged board output %q is not a regular file or directory", path)
+		}
+
+		destinationInfo, err := os.Lstat(destination)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err == nil {
+			if destinationInfo.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to publish board output through symlink %q", destination)
+			}
+			if info.IsDir() != destinationInfo.IsDir() || (!info.IsDir() && !destinationInfo.Mode().IsRegular()) {
+				return fmt.Errorf("board output path %q has an incompatible existing type", destination)
+			}
+		}
+		entries = append(entries, stagedBoardOutput{rel: rel, mode: info.Mode(), dir: info.IsDir()})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("preflight board output tree: %w", err)
+	}
+	return entries, nil
+}
+
+func ensureRealDirectory(path string, mode fs.FileMode) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(path, mode); err != nil {
+			return fmt.Errorf("create board output directory %q: %w", path, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("board output directory %q is not a real directory", path)
+	}
+	return nil
+}
+
+func publishBoardOutputFile(source, destination string, mode fs.FileMode) (err error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open staged board output %q: %w", source, err)
+	}
+	defer func() {
+		err = errors.Join(err, input.Close())
+	}()
+
+	temporary, err := os.CreateTemp(filepath.Dir(destination), ".d2-board-file-")
+	if err != nil {
+		return fmt.Errorf("create temporary board output for %q: %w", destination, err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if removeErr := os.Remove(temporaryPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, removeErr)
+		}
+	}()
+
+	if _, err := io.Copy(temporary, input); err != nil {
+		return errors.Join(
+			fmt.Errorf("copy board output to %q: %w", destination, err),
+			temporary.Close(),
+		)
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		return errors.Join(
+			fmt.Errorf("set board output permissions for %q: %w", destination, err),
+			temporary.Close(),
+		)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary board output for %q: %w", destination, err)
+	}
+
+	renameErr := os.Rename(temporaryPath, destination)
+	if renameErr == nil {
+		return nil
+	}
+
+	// Windows does not replace an existing file with os.Rename. Move the old
+	// regular file aside, install the completed replacement, then remove it.
+	destinationInfo, statErr := os.Lstat(destination)
+	if statErr != nil {
+		return fmt.Errorf("publish board output %q: %w", destination, renameErr)
+	}
+	if !destinationInfo.Mode().IsRegular() {
+		return fmt.Errorf("refusing to replace non-regular board output %q", destination)
+	}
+	backupPath := temporaryPath + ".old"
+	if renameErr := os.Rename(destination, backupPath); renameErr != nil {
+		return fmt.Errorf("prepare existing board output %q for replacement: %w", destination, renameErr)
+	}
+	if renameErr := os.Rename(temporaryPath, destination); renameErr != nil {
+		rollbackErr := os.Rename(backupPath, destination)
+		return errors.Join(
+			fmt.Errorf("publish board output %q: %w", destination, renameErr),
+			func() error {
+				if rollbackErr != nil {
+					return fmt.Errorf("restore existing board output %q: %w", destination, rollbackErr)
+				}
+				return nil
+			}(),
+		)
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return fmt.Errorf("remove replaced board output backup %q: %w", backupPath, err)
+	}
+	return nil
+}

--- a/d2cli/board_output.go
+++ b/d2cli/board_output.go
@@ -5,18 +5,23 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
+	"golang.org/x/text/cases"
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/d2lang/d2/d2target"
 )
 
-const escapedBoardOutputPrefix = "_d2_"
+const (
+	escapedBoardOutputPrefix             = "_d2_"
+	maxPortableBoardOutputComponentBytes = 200
+	boardOutputManifestName              = ".d2-board-output-manifest-v1.json"
+)
 
 // boardOutputComponent preserves ordinary board names while mapping names that
 // have filesystem meaning to a portable, single path component. The prefix is
@@ -35,7 +40,7 @@ func isReservedBoardOutputComponent(name string) bool {
 		return true
 	}
 	switch lower {
-	case "index", "layers", "scenarios", "steps":
+	case "index", "layers", "scenarios", "steps", boardOutputManifestName:
 		return true
 	default:
 		return false
@@ -43,7 +48,7 @@ func isReservedBoardOutputComponent(name string) bool {
 }
 
 func isPortableBoardOutputComponent(name string) bool {
-	if name == "" || name == "." || name == ".." || strings.HasSuffix(name, ".") || strings.HasSuffix(name, " ") {
+	if name == "" || !utf8.ValidString(name) || len(name) > maxPortableBoardOutputComponentBytes || name == "." || name == ".." || strings.HasSuffix(name, ".") || strings.HasSuffix(name, " ") {
 		return false
 	}
 	if !filepath.IsLocal(name) || filepath.IsAbs(name) || filepath.VolumeName(name) != "" || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
@@ -57,13 +62,15 @@ func isPortableBoardOutputComponent(name string) bool {
 
 	// Windows reserves these names even when they have an extension.
 	base := name
-	if i := strings.IndexByte(base, '.'); i >= 0 {
+	if i := strings.IndexAny(base, ".:"); i >= 0 {
 		base = base[:i]
 	}
+	base = strings.TrimRight(base, " ")
 	switch strings.ToUpper(base) {
 	case "CON", "PRN", "AUX", "NUL", "CLOCK$",
 		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+		"COM¹", "COM²", "COM³", "LPT¹", "LPT²", "LPT³", "CONIN$", "CONOUT$":
 		return false
 	}
 	return true
@@ -194,33 +201,77 @@ func planBoardOutput(paths boardOutputPaths, diagram *d2target.Diagram) (boardOu
 }
 
 func validateBoardOutputPaths(outputPath string, diagram *d2target.Diagram) error {
-	return validateBoardOutputPathsRecursive("root", newBoardOutputPaths(outputPath), diagram, make(map[string]string))
+	claims := &boardOutputClaims{
+		files: make(map[string]boardOutputClaim),
+		dirs:  make(map[string]boardOutputClaim),
+	}
+	return validateBoardOutputPathsRecursive("root", newBoardOutputPaths(outputPath), diagram, claims)
 }
 
-func validateBoardOutputPathsRecursive(diagramPath string, outputPaths boardOutputPaths, diagram *d2target.Diagram, seen map[string]string) error {
+type boardOutputClaim struct {
+	diagramPath string
+	path        string
+}
+
+type boardOutputClaims struct {
+	files map[string]boardOutputClaim
+	dirs  map[string]boardOutputClaim
+}
+
+func (c *boardOutputClaims) addFile(diagramPath, path string) error {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	key := boardOutputCollisionKey(absolutePath)
+	if previous, ok := c.files[key]; ok {
+		return fmt.Errorf("boards %q and %q resolve to the same output path %q", previous.diagramPath, diagramPath, path)
+	}
+	if previous, ok := c.dirs[key]; ok {
+		return fmt.Errorf("board %q output file %q collides with a directory required by board %q", diagramPath, path, previous.diagramPath)
+	}
+
+	dir := filepath.Dir(absolutePath)
+	for {
+		dirKey := boardOutputCollisionKey(dir)
+		if previous, ok := c.files[dirKey]; ok {
+			return fmt.Errorf("board %q output file %q requires a directory occupied by board %q output %q", diagramPath, path, previous.diagramPath, previous.path)
+		}
+		if _, ok := c.dirs[dirKey]; !ok {
+			c.dirs[dirKey] = boardOutputClaim{diagramPath: diagramPath, path: dir}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	c.files[key] = boardOutputClaim{diagramPath: diagramPath, path: path}
+	return nil
+}
+
+func validateBoardOutputPathsRecursive(diagramPath string, outputPaths boardOutputPaths, diagram *d2target.Diagram, claims *boardOutputClaims) error {
 	plan, err := planBoardOutput(outputPaths, diagram)
 	if err != nil {
 		return err
 	}
 	if !diagram.IsFolderOnly {
-		key := boardOutputCollisionKey(plan.board.displayPath)
-		if previous, ok := seen[key]; ok {
-			return fmt.Errorf("boards %q and %q resolve to the same output path %q", previous, diagramPath, plan.board.displayPath)
+		if err := claims.addFile(diagramPath, plan.board.displayPath); err != nil {
+			return err
 		}
-		seen[key] = diagramPath
 	}
 	for _, child := range diagram.Layers {
-		if err := validateBoardOutputPathsRecursive(diagramPath+".layers."+child.Name, plan.layers, child, seen); err != nil {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".layers."+child.Name, plan.layers, child, claims); err != nil {
 			return err
 		}
 	}
 	for _, child := range diagram.Scenarios {
-		if err := validateBoardOutputPathsRecursive(diagramPath+".scenarios."+child.Name, plan.scenarios, child, seen); err != nil {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".scenarios."+child.Name, plan.scenarios, child, claims); err != nil {
 			return err
 		}
 	}
 	for _, child := range diagram.Steps {
-		if err := validateBoardOutputPathsRecursive(diagramPath+".steps."+child.Name, plan.steps, child, seen); err != nil {
+		if err := validateBoardOutputPathsRecursive(diagramPath+".steps."+child.Name, plan.steps, child, claims); err != nil {
 			return err
 		}
 	}
@@ -228,17 +279,21 @@ func validateBoardOutputPathsRecursive(diagramPath string, outputPaths boardOutp
 }
 
 func boardOutputCollisionKey(path string) string {
-	return norm.NFC.String(strings.ToLower(filepath.Clean(path)))
+	return norm.NFC.String(cases.Fold().String(filepath.Clean(path)))
 }
 
-// boardOutputWorkspace keeps all content-derived paths inside a directory
-// created by this process. Publishing merges generated files into an existing
-// output tree without recursively deleting that tree or unrelated files.
+// boardOutputWorkspace keeps all content-derived paths inside a private
+// directory created by this process. Publishing transactionally replaces the
+// current generated files, removes only unchanged stale generated files, and
+// preserves unrelated files in an existing output tree.
 type boardOutputWorkspace struct {
 	finalRoot string
 	stageRoot string
 	stageInfo fs.FileInfo
 	extension string
+	// beforePublish is set only by tests to inject a deterministic failure at
+	// a specific visible mutation boundary.
+	beforePublish func(string) error
 }
 
 func newBoardOutputWorkspace(outputPath string) (*boardOutputWorkspace, error) {
@@ -253,17 +308,6 @@ func newBoardOutputWorkspace(outputPath string) (*boardOutputWorkspace, error) {
 	stageRoot, err := os.MkdirTemp(parent, ".d2-board-output-")
 	if err != nil {
 		return nil, fmt.Errorf("create board output staging directory: %w", err)
-	}
-	if err := os.Chmod(stageRoot, 0o755); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("set board output staging permissions: %w", err),
-			func() error {
-				if cleanupErr := os.Remove(stageRoot); cleanupErr != nil {
-					return fmt.Errorf("remove board output staging directory %q: %w", stageRoot, cleanupErr)
-				}
-				return nil
-			}(),
-		)
 	}
 	stageInfo, err := os.Lstat(stageRoot)
 	if err != nil {
@@ -317,10 +361,62 @@ func (w *boardOutputWorkspace) discard() error {
 	if stageInfo.Mode()&os.ModeSymlink != 0 || !stageInfo.IsDir() || !os.SameFile(w.stageInfo, stageInfo) {
 		return fmt.Errorf("refusing to remove replaced board output staging path %q", stageRoot)
 	}
-	if err := os.RemoveAll(stageRoot); err != nil {
-		return fmt.Errorf("remove board output staging directory %q: %w", stageRoot, err)
+	stage, err := os.OpenRoot(stageRoot)
+	if err != nil {
+		return fmt.Errorf("open board output staging directory %q: %w", stageRoot, err)
+	}
+	openedInfo, err := stage.Stat(".")
+	if err != nil || !os.SameFile(w.stageInfo, openedInfo) {
+		return errors.Join(
+			fmt.Errorf("board output staging path %q changed while opening it", stageRoot),
+			err,
+			stage.Close(),
+		)
+	}
+	directory, err := stage.Open(".")
+	if err != nil {
+		return errors.Join(fmt.Errorf("open board output staging entries: %w", err), stage.Close())
+	}
+	entries, err := directory.ReadDir(-1)
+	if closeErr := directory.Close(); closeErr != nil {
+		err = errors.Join(err, closeErr)
+	}
+	if err != nil {
+		return errors.Join(fmt.Errorf("read board output staging entries: %w", err), stage.Close())
+	}
+	for _, entry := range entries {
+		if err := stage.RemoveAll(entry.Name()); err != nil {
+			return errors.Join(
+				fmt.Errorf("remove board output staging entry %q: %w", entry.Name(), err),
+				stage.Close(),
+			)
+		}
+	}
+	if err := stage.Close(); err != nil {
+		return fmt.Errorf("close board output staging directory %q: %w", stageRoot, err)
+	}
+	stageInfo, err = os.Lstat(stageRoot)
+	if err != nil {
+		return fmt.Errorf("inspect emptied board output staging directory %q: %w", stageRoot, err)
+	}
+	if stageInfo.Mode()&os.ModeSymlink != 0 || !stageInfo.IsDir() || !os.SameFile(w.stageInfo, stageInfo) {
+		return fmt.Errorf("refusing to remove replaced board output staging path %q", stageRoot)
+	}
+	if err := os.Remove(stageRoot); err != nil {
+		return fmt.Errorf("remove emptied board output staging directory %q: %w", stageRoot, err)
 	}
 	w.stageRoot = ""
+	return nil
+}
+
+func (w *boardOutputWorkspace) validateStageRoot() error {
+	stageInfo, err := os.Lstat(w.stageRoot)
+	if err != nil {
+		return fmt.Errorf("inspect board output staging directory %q: %w", w.stageRoot, err)
+	}
+	if stageInfo.Mode()&os.ModeSymlink != 0 || !stageInfo.IsDir() || !os.SameFile(w.stageInfo, stageInfo) {
+		return fmt.Errorf("board output staging path %q was replaced", w.stageRoot)
+	}
 	return nil
 }
 
@@ -331,47 +427,7 @@ type stagedBoardOutput struct {
 }
 
 func (w *boardOutputWorkspace) publish() (touched bool, err error) {
-	defer func() {
-		if cleanupErr := w.discard(); cleanupErr != nil {
-			err = errors.Join(err, cleanupErr)
-		}
-	}()
-
-	if err := validateBoardOutputRoot(w.finalRoot); err != nil {
-		return false, err
-	}
-	if _, err := os.Lstat(w.finalRoot); errors.Is(err, os.ErrNotExist) {
-		if err := os.Rename(w.stageRoot, w.finalRoot); err != nil {
-			return false, fmt.Errorf("publish board output tree: %w", err)
-		}
-		w.stageRoot = ""
-		return true, nil
-	} else if err != nil {
-		return false, fmt.Errorf("inspect board output root: %w", err)
-	}
-
-	entries, err := w.preflightMerge()
-	if err != nil {
-		return false, err
-	}
-	for _, entry := range entries {
-		destination := filepath.Join(w.finalRoot, entry.rel)
-		if entry.dir {
-			if entry.rel == "." {
-				continue
-			}
-			if err := ensureRealDirectory(destination, entry.mode.Perm()); err != nil {
-				return touched, err
-			}
-			continue
-		}
-		source := filepath.Join(w.stageRoot, entry.rel)
-		if err := publishBoardOutputFile(source, destination, entry.mode.Perm()); err != nil {
-			return touched, err
-		}
-		touched = true
-	}
-	return touched, nil
+	return publishBoardOutputWorkspace(w)
 }
 
 func (w *boardOutputWorkspace) preflightMerge() ([]stagedBoardOutput, error) {
@@ -415,93 +471,4 @@ func (w *boardOutputWorkspace) preflightMerge() ([]stagedBoardOutput, error) {
 		return nil, fmt.Errorf("preflight board output tree: %w", err)
 	}
 	return entries, nil
-}
-
-func ensureRealDirectory(path string, mode fs.FileMode) error {
-	info, err := os.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		if err := os.Mkdir(path, mode); err != nil {
-			return fmt.Errorf("create board output directory %q: %w", path, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		return fmt.Errorf("board output directory %q is not a real directory", path)
-	}
-	return nil
-}
-
-func publishBoardOutputFile(source, destination string, mode fs.FileMode) (err error) {
-	input, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("open staged board output %q: %w", source, err)
-	}
-	defer func() {
-		err = errors.Join(err, input.Close())
-	}()
-
-	temporary, err := os.CreateTemp(filepath.Dir(destination), ".d2-board-file-")
-	if err != nil {
-		return fmt.Errorf("create temporary board output for %q: %w", destination, err)
-	}
-	temporaryPath := temporary.Name()
-	defer func() {
-		if removeErr := os.Remove(temporaryPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			err = errors.Join(err, removeErr)
-		}
-	}()
-
-	if _, err := io.Copy(temporary, input); err != nil {
-		return errors.Join(
-			fmt.Errorf("copy board output to %q: %w", destination, err),
-			temporary.Close(),
-		)
-	}
-	if err := temporary.Chmod(mode); err != nil {
-		return errors.Join(
-			fmt.Errorf("set board output permissions for %q: %w", destination, err),
-			temporary.Close(),
-		)
-	}
-	if err := temporary.Close(); err != nil {
-		return fmt.Errorf("close temporary board output for %q: %w", destination, err)
-	}
-
-	renameErr := os.Rename(temporaryPath, destination)
-	if renameErr == nil {
-		return nil
-	}
-
-	// Windows does not replace an existing file with os.Rename. Move the old
-	// regular file aside, install the completed replacement, then remove it.
-	destinationInfo, statErr := os.Lstat(destination)
-	if statErr != nil {
-		return fmt.Errorf("publish board output %q: %w", destination, renameErr)
-	}
-	if !destinationInfo.Mode().IsRegular() {
-		return fmt.Errorf("refusing to replace non-regular board output %q", destination)
-	}
-	backupPath := temporaryPath + ".old"
-	if renameErr := os.Rename(destination, backupPath); renameErr != nil {
-		return fmt.Errorf("prepare existing board output %q for replacement: %w", destination, renameErr)
-	}
-	if renameErr := os.Rename(temporaryPath, destination); renameErr != nil {
-		rollbackErr := os.Rename(backupPath, destination)
-		return errors.Join(
-			fmt.Errorf("publish board output %q: %w", destination, renameErr),
-			func() error {
-				if rollbackErr != nil {
-					return fmt.Errorf("restore existing board output %q: %w", destination, rollbackErr)
-				}
-				return nil
-			}(),
-		)
-	}
-	if err := os.Remove(backupPath); err != nil {
-		return fmt.Errorf("remove replaced board output backup %q: %w", backupPath, err)
-	}
-	return nil
 }

--- a/d2cli/board_output_publish.go
+++ b/d2cli/board_output_publish.go
@@ -1,0 +1,819 @@
+package d2cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	boardOutputManifestFormat   = "d2-board-output"
+	boardOutputManifestVersion  = 1
+	maxBoardOutputManifestBytes = 16 << 20
+	maxBoardOutputManifestPaths = 100_000
+)
+
+type boardOutputManifest struct {
+	Format      string                    `json:"format"`
+	Version     int                       `json:"version"`
+	Files       []boardOutputManifestFile `json:"files"`
+	Directories []string                  `json:"directories"`
+}
+
+type boardOutputManifestFile struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+func publishBoardOutputWorkspace(w *boardOutputWorkspace) (touched bool, err error) {
+	defer func() {
+		if cleanupErr := w.discard(); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+
+	if err := w.validateStageRoot(); err != nil {
+		return false, err
+	}
+	if err := validateBoardOutputRoot(w.finalRoot); err != nil {
+		return false, err
+	}
+	entries, err := w.preflightMerge()
+	if err != nil {
+		return false, err
+	}
+	manifest, err := w.buildManifest(entries)
+	if err != nil {
+		return false, err
+	}
+	manifestSource := filepath.Join(w.stageRoot, boardOutputManifestName)
+	if err := writeBoardOutputManifest(manifestSource, manifest); err != nil {
+		return false, err
+	}
+	if err := w.validateStageRoot(); err != nil {
+		return false, err
+	}
+
+	if _, err := os.Lstat(w.finalRoot); errors.Is(err, os.ErrNotExist) {
+		if w.beforePublish != nil {
+			if err := w.beforePublish(w.finalRoot); err != nil {
+				return false, err
+			}
+		}
+		if err := os.Chmod(w.stageRoot, 0o755); err != nil {
+			return false, fmt.Errorf("set published board output directory permissions: %w", err)
+		}
+		if err := w.validateStageRoot(); err != nil {
+			return false, err
+		}
+		if err := os.Rename(w.stageRoot, w.finalRoot); err != nil {
+			return false, fmt.Errorf("publish board output tree: %w", err)
+		}
+		w.stageRoot = ""
+		return true, nil
+	} else if err != nil {
+		return false, fmt.Errorf("inspect board output root: %w", err)
+	}
+
+	previous, _, err := readBoardOutputManifest(w.finalRoot)
+	if err != nil {
+		return false, err
+	}
+	transaction := boardOutputTransaction{workspace: w}
+	if err := transaction.apply(entries, previous, manifest, manifestSource); err != nil {
+		rollbackErr := transaction.rollback()
+		return rollbackErr != nil, errors.Join(err, rollbackErr)
+	}
+	return transaction.touched(), nil
+}
+
+func (w *boardOutputWorkspace) buildManifest(entries []stagedBoardOutput) (boardOutputManifest, error) {
+	manifest := boardOutputManifest{
+		Format: boardOutputManifestFormat, Version: boardOutputManifestVersion,
+		Files: []boardOutputManifestFile{}, Directories: []string{},
+	}
+	for _, entry := range entries {
+		if entry.rel == "." {
+			continue
+		}
+		rel := filepath.ToSlash(entry.rel)
+		if entry.dir {
+			manifest.Directories = append(manifest.Directories, rel)
+			continue
+		}
+		digest, err := boardOutputFileDigest(filepath.Join(w.stageRoot, entry.rel))
+		if err != nil {
+			return boardOutputManifest{}, fmt.Errorf("hash staged board output %q: %w", entry.rel, err)
+		}
+		manifest.Files = append(manifest.Files, boardOutputManifestFile{Path: rel, SHA256: digest})
+	}
+	sort.Slice(manifest.Files, func(i, j int) bool { return manifest.Files[i].Path < manifest.Files[j].Path })
+	sort.Strings(manifest.Directories)
+	if err := validateBoardOutputManifest(w.finalRoot, manifest); err != nil {
+		return boardOutputManifest{}, fmt.Errorf("validate generated board output manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func writeBoardOutputManifest(path string, manifest boardOutputManifest) (err error) {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode board output manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxBoardOutputManifestBytes {
+		return fmt.Errorf("board output manifest exceeds %d bytes", maxBoardOutputManifestBytes)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create board output manifest: %w", err)
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write board output manifest: %w", err)
+	}
+	return nil
+}
+
+func readBoardOutputManifest(root string) (boardOutputManifest, bool, error) {
+	path := filepath.Join(root, boardOutputManifestName)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return boardOutputManifest{}, false, nil
+	}
+	if err != nil {
+		return boardOutputManifest{}, false, fmt.Errorf("inspect board output manifest: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return boardOutputManifest{}, false, fmt.Errorf("board output manifest %q is not a regular file", path)
+	}
+	if info.Size() > maxBoardOutputManifestBytes {
+		return boardOutputManifest{}, false, fmt.Errorf("board output manifest exceeds %d bytes", maxBoardOutputManifestBytes)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return boardOutputManifest{}, false, fmt.Errorf("open board output manifest: %w", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxBoardOutputManifestBytes+1))
+	if err != nil {
+		return boardOutputManifest{}, false, fmt.Errorf("read board output manifest: %w", err)
+	}
+	if len(data) > maxBoardOutputManifestBytes {
+		return boardOutputManifest{}, false, fmt.Errorf("board output manifest exceeds %d bytes", maxBoardOutputManifestBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest boardOutputManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return boardOutputManifest{}, false, fmt.Errorf("decode board output manifest: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return boardOutputManifest{}, false, fmt.Errorf("decode board output manifest: trailing data")
+	}
+	if err := validateBoardOutputManifest(root, manifest); err != nil {
+		return boardOutputManifest{}, false, err
+	}
+	return manifest, true, nil
+}
+
+func validateBoardOutputManifest(root string, manifest boardOutputManifest) error {
+	if manifest.Format != boardOutputManifestFormat || manifest.Version != boardOutputManifestVersion {
+		return fmt.Errorf("unsupported board output manifest format or version")
+	}
+	if len(manifest.Files)+len(manifest.Directories) > maxBoardOutputManifestPaths {
+		return fmt.Errorf("board output manifest exceeds %d paths", maxBoardOutputManifestPaths)
+	}
+	seen := make(map[string]string, len(manifest.Files)+len(manifest.Directories))
+	pathKinds := make(map[string]bool, len(manifest.Files)+len(manifest.Directories)) // true for files
+	validatePath := func(path string, file bool) error {
+		native := filepath.FromSlash(path)
+		if path == "" || path == "." || strings.Contains(path, `\`) || filepath.ToSlash(filepath.Clean(native)) != path || !filepath.IsLocal(native) || filepath.IsAbs(native) || filepath.VolumeName(native) != "" {
+			return fmt.Errorf("board output manifest contains invalid path %q", path)
+		}
+		if err := ensurePathWithin(root, filepath.Join(root, native)); err != nil {
+			return fmt.Errorf("board output manifest contains invalid path %q: %w", path, err)
+		}
+		key := boardOutputCollisionKey(native)
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("board output manifest paths %q and %q collide", previous, path)
+		}
+		if key == boardOutputCollisionKey(boardOutputManifestName) {
+			return fmt.Errorf("board output manifest cannot own itself")
+		}
+		seen[key] = path
+		pathKinds[key] = file
+		return nil
+	}
+	for _, file := range manifest.Files {
+		if err := validatePath(file.Path, true); err != nil {
+			return err
+		}
+		digest, err := hex.DecodeString(file.SHA256)
+		if err != nil || len(digest) != sha256.Size {
+			return fmt.Errorf("board output manifest contains invalid digest for %q", file.Path)
+		}
+	}
+	for _, dir := range manifest.Directories {
+		if err := validatePath(dir, false); err != nil {
+			return err
+		}
+	}
+	for _, path := range seen {
+		for ancestor := filepath.Dir(filepath.FromSlash(path)); ancestor != "."; ancestor = filepath.Dir(ancestor) {
+			if pathKinds[boardOutputCollisionKey(ancestor)] {
+				return fmt.Errorf("board output manifest path %q is beneath a file path", path)
+			}
+		}
+	}
+	return nil
+}
+
+func boardOutputFileDigest(path string) (digest string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+type boardOutputFileChange struct {
+	rel            string
+	source         string
+	destination    string
+	remove         bool
+	existed        bool
+	originalInfo   fs.FileInfo
+	originalMode   fs.FileMode
+	backup         string
+	expectedSHA256 string
+	skip           bool
+	applied        bool
+	installedInfo  fs.FileInfo
+}
+
+type boardOutputRemovedDirectory struct {
+	path string
+	mode fs.FileMode
+}
+
+type boardOutputTransaction struct {
+	workspace       *boardOutputWorkspace
+	changes         []*boardOutputFileChange
+	appliedChanges  []*boardOutputFileChange
+	createdDirs     []string
+	removedDirs     []boardOutputRemovedDirectory
+	visibleMutation bool
+}
+
+func (t *boardOutputTransaction) touched() bool {
+	return t.visibleMutation
+}
+
+func (t *boardOutputTransaction) apply(entries []stagedBoardOutput, previous, current boardOutputManifest, manifestSource string) error {
+	currentFiles := make(map[string]string, len(current.Files))
+	for _, file := range current.Files {
+		currentFiles[boardOutputCollisionKey(filepath.FromSlash(file.Path))] = filepath.FromSlash(file.Path)
+	}
+	for _, entry := range entries {
+		if entry.dir {
+			continue
+		}
+		t.changes = append(t.changes, &boardOutputFileChange{
+			rel: entry.rel, source: filepath.Join(t.workspace.stageRoot, entry.rel),
+			destination: filepath.Join(t.workspace.finalRoot, entry.rel),
+		})
+	}
+	staleChanges, err := t.staleFileChanges(previous, currentFiles)
+	if err != nil {
+		return err
+	}
+	t.changes = append(t.changes, staleChanges...)
+	manifestChange := &boardOutputFileChange{
+		rel: boardOutputManifestName, source: manifestSource,
+		destination: filepath.Join(t.workspace.finalRoot, boardOutputManifestName),
+	}
+
+	allChanges := append(append([]*boardOutputFileChange(nil), t.changes...), manifestChange)
+	if err := t.prepareBackups(allChanges); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.dir || entry.rel == "." {
+			continue
+		}
+		if err := t.ensureDirectory(filepath.Join(t.workspace.finalRoot, entry.rel), entry.mode.Perm()); err != nil {
+			return err
+		}
+	}
+	for _, change := range t.changes {
+		if err := t.applyChange(change); err != nil {
+			return err
+		}
+	}
+	if err := t.removeStaleDirectories(previous, current); err != nil {
+		return err
+	}
+	if err := t.applyChange(manifestChange); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *boardOutputTransaction) staleFileChanges(previous boardOutputManifest, currentFiles map[string]string) ([]*boardOutputFileChange, error) {
+	var changes []*boardOutputFileChange
+	for _, file := range previous.Files {
+		rel := filepath.FromSlash(file.Path)
+		if currentRel, ok := currentFiles[boardOutputCollisionKey(rel)]; ok {
+			if currentRel == rel || sameBoardOutputPath(t.workspace.finalRoot, rel, currentRel) {
+				continue
+			}
+		}
+		info, err := lstatBoardOutputPath(t.workspace.finalRoot, rel)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			continue
+		}
+		destination := filepath.Join(t.workspace.finalRoot, rel)
+		digest, err := boardOutputFileDigest(destination)
+		if err != nil {
+			return nil, fmt.Errorf("hash prior board output %q: %w", rel, err)
+		}
+		if digest != strings.ToLower(file.SHA256) {
+			// The user changed the file after D2 generated it. Preserve it and
+			// relinquish ownership in the new manifest.
+			continue
+		}
+		changes = append(changes, &boardOutputFileChange{
+			rel: rel, destination: destination, remove: true,
+			expectedSHA256: strings.ToLower(file.SHA256),
+		})
+	}
+	return changes, nil
+}
+
+func (t *boardOutputTransaction) prepareBackups(changes []*boardOutputFileChange) error {
+	var backupRoot string
+	for index, change := range changes {
+		info, err := lstatBoardOutputPath(t.workspace.finalRoot, change.rel)
+		if errors.Is(err, os.ErrNotExist) {
+			if change.remove {
+				continue
+			}
+			change.existed = false
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("board output path %q is not a regular file", change.destination)
+		}
+		change.existed = true
+		change.originalInfo = info
+		change.originalMode = info.Mode().Perm()
+		if backupRoot == "" {
+			backupRoot, err = os.MkdirTemp(t.workspace.stageRoot, ".d2-board-rollback-")
+			if err != nil {
+				return fmt.Errorf("create board output rollback directory: %w", err)
+			}
+		}
+		change.backup = filepath.Join(backupRoot, fmt.Sprintf("%06d", index))
+		if err := copyBoardOutputFile(change.destination, change.backup, change.originalMode, true); err != nil {
+			return fmt.Errorf("back up board output %q: %w", change.destination, err)
+		}
+		if change.remove {
+			digest, err := boardOutputFileDigest(change.backup)
+			if err != nil {
+				return fmt.Errorf("verify board output backup %q: %w", change.destination, err)
+			}
+			if digest != change.expectedSHA256 {
+				// The file was edited while publication was being prepared. Keep it
+				// and drop it from the new manifest rather than deleting user data.
+				change.skip = true
+			}
+		}
+	}
+	return nil
+}
+
+func (t *boardOutputTransaction) ensureDirectory(path string, mode fs.FileMode) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := t.beforeMutation(path); err != nil {
+			return err
+		}
+		if err := os.Mkdir(path, mode); err != nil {
+			return fmt.Errorf("create board output directory %q: %w", path, err)
+		}
+		t.createdDirs = append(t.createdDirs, path)
+		t.visibleMutation = true
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("board output directory %q is not a real directory", path)
+	}
+	return nil
+}
+
+func (t *boardOutputTransaction) applyChange(change *boardOutputFileChange) error {
+	if change.skip || change.remove && !change.existed {
+		return nil
+	}
+	if err := t.beforeMutation(change.destination); err != nil {
+		return err
+	}
+	if err := verifyBoardOutputFileState(change); err != nil {
+		return err
+	}
+	if change.remove {
+		digest, err := boardOutputFileDigest(change.destination)
+		if err != nil {
+			return fmt.Errorf("verify stale board output %q: %w", change.destination, err)
+		}
+		if digest != change.expectedSHA256 {
+			// The user changed the file after it was backed up. Preserve it and
+			// relinquish ownership in the manifest being published.
+			change.skip = true
+			return nil
+		}
+		if err := os.Remove(change.destination); err != nil {
+			return fmt.Errorf("remove stale board output %q: %w", change.destination, err)
+		}
+		change.applied = true
+		t.appliedChanges = append(t.appliedChanges, change)
+		t.visibleMutation = true
+		return nil
+	}
+
+	applied, installedInfo, err := installBoardOutputFile(change.source, change.destination, change.existed)
+	change.applied = applied
+	change.installedInfo = installedInfo
+	if applied {
+		t.appliedChanges = append(t.appliedChanges, change)
+		t.visibleMutation = true
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyBoardOutputFileState(change *boardOutputFileChange) error {
+	info, err := os.Lstat(change.destination)
+	if !change.existed {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("board output path %q appeared during publication", change.destination)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect board output %q before publication: %w", change.destination, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !os.SameFile(change.originalInfo, info) {
+		return fmt.Errorf("board output path %q changed during publication", change.destination)
+	}
+	return nil
+}
+
+func installBoardOutputFile(source, destination string, replacing bool) (applied bool, installedInfo fs.FileInfo, err error) {
+	temporary, err := prepareBoardOutputFile(source, filepath.Dir(destination))
+	if err != nil {
+		return false, nil, fmt.Errorf("prepare board output %q: %w", destination, err)
+	}
+	defer func() {
+		if removeErr := os.Remove(temporary); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, removeErr)
+		}
+	}()
+
+	if !replacing {
+		if linkErr := os.Link(temporary, destination); linkErr == nil {
+			installedInfo, err := os.Lstat(destination)
+			if err != nil {
+				return true, nil, fmt.Errorf("inspect published board output %q: %w", destination, err)
+			}
+			return true, installedInfo, nil
+		} else if _, statErr := os.Lstat(destination); statErr == nil {
+			return false, nil, fmt.Errorf("publish board output %q: destination appeared during publication", destination)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return false, nil, fmt.Errorf("inspect board output %q after link failure: %w", destination, statErr)
+		}
+
+		applied, installedInfo, err := copyBoardOutputFileExclusive(temporary, destination)
+		if err != nil {
+			return applied, installedInfo, fmt.Errorf("publish board output %q: %w", destination, err)
+		}
+		return applied, installedInfo, nil
+	}
+
+	if err := os.Rename(temporary, destination); err != nil {
+		if removeErr := os.Remove(destination); removeErr != nil {
+			return false, nil, fmt.Errorf("prepare board output %q for Windows replacement: %w", destination, removeErr)
+		}
+		applied = true
+		if err := os.Rename(temporary, destination); err != nil {
+			return true, nil, fmt.Errorf("publish board output %q: %w", destination, err)
+		}
+	} else {
+		applied = true
+	}
+	installedInfo, err = os.Lstat(destination)
+	if err != nil {
+		return true, nil, fmt.Errorf("inspect published board output %q: %w", destination, err)
+	}
+	return true, installedInfo, nil
+}
+
+func copyBoardOutputFileExclusive(source, destination string) (applied bool, installedInfo fs.FileInfo, err error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() { err = errors.Join(err, input.Close()) }()
+	info, err := input.Stat()
+	if err != nil {
+		return false, nil, err
+	}
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return false, nil, err
+	}
+	applied = true
+	installedInfo, statErr := output.Stat()
+	if statErr != nil {
+		return true, nil, errors.Join(statErr, output.Close())
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		return true, installedInfo, errors.Join(err, output.Close())
+	}
+	if err := output.Chmod(info.Mode().Perm()); err != nil {
+		return true, installedInfo, errors.Join(err, output.Close())
+	}
+	if err := output.Close(); err != nil {
+		return true, installedInfo, err
+	}
+	return true, installedInfo, nil
+}
+
+func prepareBoardOutputFile(source, destinationDir string) (temporaryPath string, err error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return "", err
+	}
+	defer func() { err = errors.Join(err, input.Close()) }()
+	info, err := input.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("source is not a regular file")
+	}
+	temporary, err := os.CreateTemp(destinationDir, ".d2-board-file-")
+	if err != nil {
+		return "", err
+	}
+	temporaryPath = temporary.Name()
+	remove := true
+	closed := false
+	defer func() {
+		if !closed {
+			closeErr := temporary.Close()
+			if err == nil {
+				err = closeErr
+			} else {
+				err = errors.Join(err, closeErr)
+			}
+		}
+		if remove {
+			if removeErr := os.Remove(temporaryPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				err = errors.Join(err, removeErr)
+			}
+		}
+	}()
+	if _, err := io.Copy(temporary, input); err != nil {
+		return "", err
+	}
+	if err := temporary.Chmod(info.Mode().Perm()); err != nil {
+		return "", err
+	}
+	if err := temporary.Close(); err != nil {
+		return "", err
+	}
+	closed = true
+	remove = false
+	return temporaryPath, nil
+}
+
+func copyBoardOutputFile(source, destination string, mode fs.FileMode, exclusive bool) (err error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, input.Close()) }()
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if exclusive {
+		flags |= os.O_EXCL
+	}
+	output, err := os.OpenFile(destination, flags, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, output.Close()) }()
+	if _, err := io.Copy(output, input); err != nil {
+		return err
+	}
+	return output.Chmod(mode)
+}
+
+func (t *boardOutputTransaction) removeStaleDirectories(previous, current boardOutputManifest) error {
+	currentDirs := make(map[string]string, len(current.Directories))
+	for _, dir := range current.Directories {
+		rel := filepath.FromSlash(dir)
+		currentDirs[boardOutputCollisionKey(rel)] = rel
+	}
+	stale := make([]string, 0, len(previous.Directories))
+	for _, dir := range previous.Directories {
+		rel := filepath.FromSlash(dir)
+		if currentRel, ok := currentDirs[boardOutputCollisionKey(rel)]; ok {
+			if currentRel == rel || sameBoardOutputPath(t.workspace.finalRoot, rel, currentRel) {
+				continue
+			}
+		}
+		stale = append(stale, rel)
+	}
+	sort.Slice(stale, func(i, j int) bool {
+		return strings.Count(filepath.Clean(stale[i]), string(filepath.Separator)) > strings.Count(filepath.Clean(stale[j]), string(filepath.Separator))
+	})
+	for _, rel := range stale {
+		info, err := lstatBoardOutputPath(t.workspace.finalRoot, rel)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			continue
+		}
+		path := filepath.Join(t.workspace.finalRoot, rel)
+		children, err := os.ReadDir(path)
+		if err != nil {
+			return err
+		}
+		if len(children) != 0 {
+			continue
+		}
+		if err := t.beforeMutation(path); err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil {
+			// A concurrent creator wins; preserve the directory rather than
+			// recursively removing anything D2 does not own.
+			if children, readErr := os.ReadDir(path); readErr == nil && len(children) != 0 {
+				continue
+			}
+			return fmt.Errorf("remove stale board output directory %q: %w", path, err)
+		}
+		t.removedDirs = append(t.removedDirs, boardOutputRemovedDirectory{path: path, mode: info.Mode().Perm()})
+		t.visibleMutation = true
+	}
+	return nil
+}
+
+func sameBoardOutputPath(root, first, second string) bool {
+	firstInfo, firstErr := lstatBoardOutputPath(root, first)
+	secondInfo, secondErr := lstatBoardOutputPath(root, second)
+	return firstErr == nil && secondErr == nil && os.SameFile(firstInfo, secondInfo)
+}
+
+func (t *boardOutputTransaction) beforeMutation(path string) error {
+	if t.workspace.beforePublish == nil {
+		return nil
+	}
+	if err := t.workspace.beforePublish(path); err != nil {
+		return fmt.Errorf("publish board output %q: %w", path, err)
+	}
+	return nil
+}
+
+func (t *boardOutputTransaction) rollback() error {
+	var rollbackErr error
+	for index := len(t.removedDirs) - 1; index >= 0; index-- {
+		dir := t.removedDirs[index]
+		if err := os.Mkdir(dir.path, dir.mode); err != nil && !errors.Is(err, os.ErrExist) {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore board output directory %q: %w", dir.path, err))
+		}
+	}
+	for index := len(t.appliedChanges) - 1; index >= 0; index-- {
+		change := t.appliedChanges[index]
+		if err := rollbackBoardOutputFile(change); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+		}
+	}
+	for index := len(t.createdDirs) - 1; index >= 0; index-- {
+		path := t.createdDirs[index]
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if children, readErr := os.ReadDir(path); readErr == nil && len(children) != 0 {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("refusing to remove non-empty transaction directory %q", path))
+			} else {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove transaction directory %q: %w", path, err))
+			}
+		}
+	}
+	if rollbackErr == nil {
+		t.visibleMutation = false
+	}
+	return rollbackErr
+}
+
+func rollbackBoardOutputFile(change *boardOutputFileChange) error {
+	if !change.applied {
+		return nil
+	}
+	info, err := os.Lstat(change.destination)
+	if change.installedInfo != nil {
+		if err != nil || !os.SameFile(change.installedInfo, info) {
+			return fmt.Errorf("refusing to roll back changed board output %q", change.destination)
+		}
+	} else if err == nil {
+		return fmt.Errorf("refusing to roll back recreated board output %q", change.destination)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if change.existed {
+		_, _, err := installBoardOutputFile(change.backup, change.destination, change.installedInfo != nil)
+		if err != nil {
+			return fmt.Errorf("restore board output %q: %w", change.destination, err)
+		}
+		return nil
+	}
+	if change.installedInfo == nil {
+		return nil
+	}
+	if err := os.Remove(change.destination); err != nil {
+		return fmt.Errorf("remove newly published board output %q: %w", change.destination, err)
+	}
+	return nil
+}
+
+// lstatBoardOutputPath rejects symlinks in every existing ancestor. It is not
+// a substitute for handle-relative operations, but it prevents deterministic
+// publication through a pre-existing symlink.
+func lstatBoardOutputPath(root, rel string) (fs.FileInfo, error) {
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return nil, err
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
+		return nil, fmt.Errorf("board output root %q is not a real directory", root)
+	}
+	if rel == "." {
+		return rootInfo, nil
+	}
+	current := root
+	parts := strings.Split(filepath.Clean(rel), string(filepath.Separator))
+	for index, part := range parts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 && index != len(parts)-1 {
+			return nil, fmt.Errorf("refusing to access board output through symlink %q", current)
+		}
+		if index != len(parts)-1 && !info.IsDir() {
+			return nil, fmt.Errorf("board output ancestor %q is not a directory", current)
+		}
+		if index == len(parts)-1 {
+			return info, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}

--- a/d2cli/board_output_test.go
+++ b/d2cli/board_output_test.go
@@ -1,0 +1,291 @@
+package d2cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/d2lang/util-go/xmain"
+
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestBoardOutputComponent(t *testing.T) {
+	for _, name := range []string{"board", "board name", "release.v2", "日本語"} {
+		if got := boardOutputComponent(name); got != name {
+			t.Errorf("boardOutputComponent(%q) = %q, want unchanged", name, got)
+		}
+	}
+
+	unsafeNames := []string{
+		".",
+		"..",
+		"../escape",
+		`..\escape`,
+		"nested/board",
+		`nested\board`,
+		"/absolute/board",
+		`\absolute\board`,
+		`C:\absolute\board`,
+		`C:drive-relative`,
+		`\\server\share\board`,
+		"NUL.txt",
+		"index",
+		"INDEX",
+		"layers",
+		"scenarios",
+		"steps",
+		escapedBoardOutputPrefix + "literal",
+		"_D2_literal",
+	}
+	seen := make(map[string]string)
+	for _, name := range unsafeNames {
+		got := boardOutputComponent(name)
+		if got != boardOutputComponent(name) {
+			t.Fatalf("boardOutputComponent(%q) is not deterministic", name)
+		}
+		if got == name || !strings.HasPrefix(got, escapedBoardOutputPrefix) {
+			t.Errorf("boardOutputComponent(%q) = %q, want escaped component", name, got)
+		}
+		if strings.ContainsAny(got, `/\`) || filepath.IsAbs(got) || got == "." || got == ".." {
+			t.Errorf("boardOutputComponent(%q) = unsafe component %q", name, got)
+		}
+		if previous, ok := seen[got]; ok {
+			t.Errorf("board names %q and %q map to the same component %q", previous, name, got)
+		}
+		seen[got] = name
+	}
+}
+
+func TestValidateBoardOutputPathsRejectsCollisions(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{name: "case insensitive filesystem", first: "Board", second: "board"},
+		{name: "same escaped component", first: "../board", second: "../board"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			diagram := &d2target.Diagram{Layers: []*d2target.Diagram{
+				{Name: test.first},
+				{Name: test.second},
+			}}
+			err := validateBoardOutputPaths(filepath.Join(t.TempDir(), "output.svg"), diagram)
+			if err == nil || !strings.Contains(err.Error(), "same output path") {
+				t.Fatalf("validateBoardOutputPaths() error = %v, want collision", err)
+			}
+		})
+	}
+}
+
+func TestAppendBoardOutputNameStaysContained(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "output")
+	for _, name := range []string{
+		"..",
+		"../../escape",
+		"nested/board",
+		`nested\board`,
+		"/absolute/board",
+		`C:\absolute\board`,
+		`\\server\share\board`,
+	} {
+		path, err := appendBoardOutputName(root+".svg", name)
+		if err != nil {
+			t.Fatalf("appendBoardOutputName(%q): %v", name, err)
+		}
+		path = strings.TrimSuffix(path, ".svg")
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Errorf("appendBoardOutputName(%q) produced escaping path %q", name, path)
+		}
+	}
+
+	if err := ensurePathWithin(root, filepath.Join(root, "..", "escape")); err == nil {
+		t.Fatal("ensurePathWithin accepted a parent traversal")
+	}
+
+	hiddenOutput := filepath.Join(t.TempDir(), ".svg")
+	hiddenBoard, err := appendBoardOutputComponent(hiddenOutput, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(hiddenOutput, "index") + ".svg"; hiddenBoard != want {
+		t.Fatalf("hidden output board path = %q, want %q", hiddenBoard, want)
+	}
+}
+
+func TestMultiboardOutputContainsUnsafeNames(t *testing.T) {
+	directory := t.TempDir()
+	workDirectory := filepath.Join(directory, "work")
+	victimDirectory := filepath.Join(directory, "victim")
+	if err := os.MkdirAll(workDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(victimDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(victimDirectory, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inputPath := filepath.Join(workDirectory, "input.d2")
+	if err := os.WriteFile(inputPath, []byte(`root
+layers: {
+  "../../victim": {
+    child
+    layers: {
+      nested: {
+        leaf
+      }
+    }
+  }
+  index: {
+    structural-name
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(workDirectory, "output.svg")
+	runBoardOutputCLI(t, workDirectory, inputPath, outputPath)
+
+	if got, err := os.ReadFile(sentinelPath); err != nil || string(got) != "keep me" {
+		t.Fatalf("outside sentinel = %q, %v; want unchanged", got, err)
+	}
+	escaped := boardOutputComponent("../../victim")
+	for _, path := range []string{
+		filepath.Join(workDirectory, "output", "index.svg"),
+		filepath.Join(workDirectory, "output", escaped, "index.svg"),
+		filepath.Join(workDirectory, "output", escaped, "nested.svg"),
+		filepath.Join(workDirectory, "output", boardOutputComponent("index")+".svg"),
+	} {
+		if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
+			t.Errorf("expected rendered board %q: %v", path, err)
+		}
+	}
+	if matches, err := filepath.Glob(filepath.Join(workDirectory, ".d2-board-output-*")); err != nil || len(matches) != 0 {
+		t.Fatalf("staging directories after successful render = %v, %v", matches, err)
+	}
+}
+
+func TestMultiboardOutputPreservesPreexistingDirectory(t *testing.T) {
+	directory := t.TempDir()
+	inputPath := filepath.Join(directory, "input.d2")
+	if err := os.WriteFile(inputPath, []byte(`root
+layers: {
+  parent: {
+    parent-shape
+    layers: {
+      child: {
+        child-shape
+      }
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(outputDirectory, "sentinel.txt")
+	stalePath := filepath.Join(outputDirectory, "previous-board.svg")
+	if err := os.WriteFile(sentinelPath, []byte("unrelated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stalePath, []byte("previous"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runBoardOutputCLI(t, directory, inputPath, outputPath)
+	// A second render exercises replacement of files generated by the first
+	// render while the unrelated pre-existing files remain in place.
+	runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+	for path, want := range map[string]string{sentinelPath: "unrelated", stalePath: "previous"} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Errorf("pre-existing file %q = %q, %v; want %q", path, got, err, want)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(outputDirectory, "index.svg"),
+		filepath.Join(outputDirectory, "parent", "index.svg"),
+		filepath.Join(outputDirectory, "parent", "child.svg"),
+	} {
+		if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
+			t.Errorf("expected rendered board %q: %v", path, err)
+		}
+	}
+}
+
+func TestMultiboardOutputRejectsPreexistingSymlink(t *testing.T) {
+	directory := t.TempDir()
+	inputPath := filepath.Join(directory, "input.d2")
+	if err := os.WriteFile(inputPath, []byte(`root
+layers: {
+  child: {
+    child-shape
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	victimPath := filepath.Join(directory, "victim.svg")
+	if err := os.WriteFile(victimPath, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victimPath, filepath.Join(outputDirectory, "child.svg")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := runBoardOutputCLIResult(t, directory, inputPath, outputPath)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Run() error = %v, want symlink rejection", err)
+	}
+	if got, err := os.ReadFile(victimPath); err != nil || string(got) != "keep me" {
+		t.Fatalf("symlink target = %q, %v; want unchanged", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDirectory, "index.svg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("root output was published before symlink preflight completed: %v", err)
+	}
+}
+
+func runBoardOutputCLI(t *testing.T, directory string, inputPath, outputPath string) {
+	t.Helper()
+	if err := runBoardOutputCLIResult(t, directory, inputPath, outputPath); err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+}
+
+func runBoardOutputCLIResult(t *testing.T, directory string, inputPath, outputPath string) error {
+	t.Helper()
+	state := &xmain.TestState{
+		Run:  Run,
+		Args: []string{"d2", inputPath, outputPath},
+		PWD:  directory,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	state.Start(t, ctx)
+	defer state.Cleanup(t)
+	return state.Wait(ctx)
+}

--- a/d2cli/board_output_test.go
+++ b/d2cli/board_output_test.go
@@ -15,7 +15,14 @@ import (
 )
 
 func TestBoardOutputComponent(t *testing.T) {
-	for _, name := range []string{"board", "board name", "release.v2", "日本語"} {
+	for _, name := range []string{
+		"board",
+		"board name",
+		"release.v2",
+		"日本語",
+		strings.Repeat("a", maxPortableBoardOutputComponentBytes),
+		strings.Repeat("é", maxPortableBoardOutputComponentBytes/len("é")),
+	} {
 		if got := boardOutputComponent(name); got != name {
 			t.Errorf("boardOutputComponent(%q) = %q, want unchanged", name, got)
 		}
@@ -34,11 +41,20 @@ func TestBoardOutputComponent(t *testing.T) {
 		`C:drive-relative`,
 		`\\server\share\board`,
 		"NUL.txt",
+		"NUL .txt",
+		"CONIN$.txt",
+		"CONOUT$",
+		"COM¹.log",
+		"LPT³",
 		"index",
 		"INDEX",
 		"layers",
 		"scenarios",
 		"steps",
+		boardOutputManifestName,
+		string([]byte{0xff}),
+		strings.Repeat("a", maxPortableBoardOutputComponentBytes+1),
+		strings.Repeat("é", maxPortableBoardOutputComponentBytes/len("é")+1),
 		escapedBoardOutputPrefix + "literal",
 		"_D2_literal",
 	}
@@ -80,6 +96,19 @@ func TestValidateBoardOutputPathsRejectsCollisions(t *testing.T) {
 				t.Fatalf("validateBoardOutputPaths() error = %v, want collision", err)
 			}
 		})
+	}
+}
+
+func TestValidateBoardOutputPathsRejectsFileDirectoryPrefixCollision(t *testing.T) {
+	diagram := &d2target.Diagram{Layers: []*d2target.Diagram{
+		{Name: "foo"},
+		{Name: "foo.svg", IsFolderOnly: true, Layers: []*d2target.Diagram{{Name: "nested"}}},
+	}}
+	for _, outputPath := range []string{"output.svg", filepath.Join(t.TempDir(), "output.svg")} {
+		err := validateBoardOutputPaths(outputPath, diagram)
+		if err == nil || !strings.Contains(err.Error(), "requires a directory occupied") {
+			t.Errorf("validateBoardOutputPaths(%q) error = %v, want file/directory collision", outputPath, err)
+		}
 	}
 }
 
@@ -177,6 +206,23 @@ layers: {
 	}
 }
 
+func TestMultiboardOutputHashesOverlongBoardName(t *testing.T) {
+	directory := t.TempDir()
+	longName := strings.Repeat("a", 252)
+	inputPath := filepath.Join(directory, "input.d2")
+	input := "root\nlayers: {\n  \"" + longName + "\": { child }\n}\n"
+	if err := os.WriteFile(inputPath, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(directory, "output.svg")
+	runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+	escapedPath := filepath.Join(directory, "output", boardOutputComponent(longName)+".svg")
+	if info, err := os.Stat(escapedPath); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("overlong board was not rendered to its escaped path %q: %v", escapedPath, err)
+	}
+}
+
 func TestMultiboardOutputPreservesPreexistingDirectory(t *testing.T) {
 	directory := t.TempDir()
 	inputPath := filepath.Join(directory, "input.d2")
@@ -231,6 +277,310 @@ layers: {
 	}
 }
 
+func TestMultiboardOutputRemovesOnlyUnmodifiedStaleGeneratedFiles(t *testing.T) {
+	directory := t.TempDir()
+	inputPath := filepath.Join(directory, "input.d2")
+	outputPath := filepath.Join(directory, "output.svg")
+	first := `root
+layers: {
+  old: {
+    layers: {
+      leaf: { old-shape }
+    }
+  }
+  edited: { edited-shape }
+  keep: { keep-shape }
+}
+`
+	if err := os.WriteFile(inputPath, []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+	outputDirectory := filepath.Join(directory, "output")
+	editedPath := filepath.Join(outputDirectory, "edited.svg")
+	if err := os.WriteFile(editedPath, []byte("user-edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(outputDirectory, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("unrelated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second := `root
+layers: {
+  keep: { keep-shape }
+}
+`
+	if err := os.WriteFile(inputPath, []byte(second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+	for _, path := range []string{
+		filepath.Join(outputDirectory, "old", "index.svg"),
+		filepath.Join(outputDirectory, "old", "leaf.svg"),
+	} {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("stale generated output %q still exists: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(outputDirectory, "old")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("empty stale generated directory still exists: %v", err)
+	}
+	for path, want := range map[string]string{editedPath: "user-edited", sentinelPath: "unrelated"} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Errorf("preserved file %q = %q, %v; want %q", path, got, err, want)
+		}
+	}
+	if info, err := os.Stat(filepath.Join(outputDirectory, boardOutputManifestName)); err != nil || !info.Mode().IsRegular() {
+		t.Errorf("board output ownership manifest missing: %v", err)
+	}
+}
+
+func TestMultiboardOutputHandlesEquivalentPathSpellingChanges(t *testing.T) {
+	for _, test := range []struct {
+		name                        string
+		oldParent, oldChild         string
+		currentParent, currentChild string
+	}{
+		{name: "case", oldParent: "Foo", oldChild: "Child", currentParent: "foo", currentChild: "child"},
+		{name: "unicode normalization", oldParent: "é", oldChild: "É", currentParent: "e\u0301", currentChild: "E\u0301"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			inputPath := filepath.Join(directory, "input.d2")
+			outputPath := filepath.Join(directory, "output.svg")
+			first := "root\nlayers: {\n  \"" + test.oldParent + "\": {\n    layers: {\n      \"" + test.oldChild + "\": { old-shape }\n    }\n  }\n}\n"
+			if err := os.WriteFile(inputPath, []byte(first), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+			outputDirectory := filepath.Join(directory, "output")
+			aliasesSameFile := sameBoardOutputPath(outputDirectory, test.oldParent, test.currentParent)
+			second := "root\nlayers: {\n  \"" + test.currentParent + "\": {\n    layers: {\n      \"" + test.currentChild + "\": { new-shape }\n    }\n  }\n}\n"
+			if err := os.WriteFile(inputPath, []byte(second), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runBoardOutputCLI(t, directory, inputPath, outputPath)
+
+			currentDirectory := filepath.Join(outputDirectory, test.currentParent)
+			if info, err := os.Stat(filepath.Join(currentDirectory, test.currentChild+".svg")); err != nil || !info.Mode().IsRegular() {
+				t.Fatalf("new board output missing: %v", err)
+			}
+			oldDirectory := filepath.Join(outputDirectory, test.oldParent)
+			if aliasesSameFile {
+				oldInfo, oldErr := os.Stat(oldDirectory)
+				currentInfo, currentErr := os.Stat(currentDirectory)
+				if oldErr != nil || currentErr != nil || !os.SameFile(oldInfo, currentInfo) {
+					t.Fatalf("filesystem aliases diverged: old=%v/%v current=%v/%v", oldInfo, oldErr, currentInfo, currentErr)
+				}
+			} else if _, err := os.Stat(oldDirectory); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("stale board directory remains on spelling-sensitive filesystem: %v", err)
+			}
+
+			manifest, _, err := readBoardOutputManifest(outputDirectory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, file := range manifest.Files {
+				if strings.Contains(file.Path, test.oldParent) || strings.Contains(file.Path, test.oldChild) {
+					t.Errorf("manifest retained stale spelling %q", file.Path)
+				}
+			}
+			for _, dir := range manifest.Directories {
+				if strings.Contains(dir, test.oldParent) || strings.Contains(dir, test.oldChild) {
+					t.Errorf("manifest retained stale spelling %q", dir)
+				}
+			}
+		})
+	}
+}
+
+func TestBoardOutputPublicationRollsBackWholeTransaction(t *testing.T) {
+	directory := t.TempDir()
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	staleDirectory := filepath.Join(outputDirectory, "stale")
+	if err := os.MkdirAll(staleDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	replacedPath := filepath.Join(outputDirectory, "replaced.svg")
+	stalePath := filepath.Join(staleDirectory, "old.svg")
+	if err := os.WriteFile(replacedPath, []byte("old replacement"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stalePath, []byte("old stale output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	replacedDigest, err := boardOutputFileDigest(replacedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleDigest, err := boardOutputFileDigest(stalePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := boardOutputManifest{
+		Format: boardOutputManifestFormat, Version: boardOutputManifestVersion,
+		Files: []boardOutputManifestFile{
+			{Path: "replaced.svg", SHA256: replacedDigest},
+			{Path: "stale/old.svg", SHA256: staleDigest},
+		},
+		Directories: []string{"stale"},
+	}
+	manifestPath := filepath.Join(outputDirectory, boardOutputManifestName)
+	if err := writeBoardOutputManifest(manifestPath, previous); err != nil {
+		t.Fatal(err)
+	}
+	originalManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workspace, err := newBoardOutputWorkspace(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.stageRoot, "created.svg"), []byte("new file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.stageRoot, "replaced.svg"), []byte("new replacement"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	injected := errors.New("injected publication failure")
+	workspace.beforePublish = func(path string) error {
+		if filepath.Base(path) == boardOutputManifestName {
+			return injected
+		}
+		return nil
+	}
+	touched, err := workspace.publish()
+	if !errors.Is(err, injected) {
+		t.Fatalf("publish() error = %v, want injected failure", err)
+	}
+	if touched {
+		t.Fatal("publish() reported output touched after a successful rollback")
+	}
+
+	for path, want := range map[string]string{
+		replacedPath: "old replacement",
+		stalePath:    "old stale output",
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Errorf("rolled-back file %q = %q, %v; want %q", path, got, err, want)
+		}
+	}
+	if info, err := os.Stat(replacedPath); err != nil {
+		t.Errorf("inspect replacement mode after rollback: %v", err)
+	} else if info.Mode().Perm() != 0o640 {
+		t.Errorf("replacement mode after rollback = %v; want 0640", info.Mode().Perm())
+	}
+	if _, err := os.Stat(filepath.Join(outputDirectory, "created.svg")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("new file survived rollback: %v", err)
+	}
+	if got, err := os.ReadFile(manifestPath); err != nil || string(got) != string(originalManifest) {
+		t.Errorf("manifest after rollback = %q, %v; want original", got, err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(directory, ".d2-board-output-*")); err != nil || len(matches) != 0 {
+		t.Errorf("staging directories after rollback = %v, %v", matches, err)
+	}
+}
+
+func TestBoardOutputPublicationPreservesStaleFileEditedDuringPublish(t *testing.T) {
+	directory := t.TempDir()
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stalePath := filepath.Join(outputDirectory, "stale.svg")
+	if err := os.WriteFile(stalePath, []byte("generated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := boardOutputFileDigest(stalePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := boardOutputManifest{
+		Format: boardOutputManifestFormat, Version: boardOutputManifestVersion,
+		Files: []boardOutputManifestFile{{Path: "stale.svg", SHA256: digest}},
+	}
+	if err := writeBoardOutputManifest(filepath.Join(outputDirectory, boardOutputManifestName), previous); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace, err := newBoardOutputWorkspace(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.stageRoot, "current.svg"), []byte("current"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	edited := false
+	workspace.beforePublish = func(path string) error {
+		if path == stalePath && !edited {
+			edited = true
+			return os.WriteFile(stalePath, []byte("edited during publication"), 0o644)
+		}
+		return nil
+	}
+	if touched, err := workspace.publish(); err != nil || !touched {
+		t.Fatalf("publish() = %v, %v; want successful publication", touched, err)
+	}
+	if got, err := os.ReadFile(stalePath); err != nil || string(got) != "edited during publication" {
+		t.Fatalf("concurrently edited stale output = %q, %v; want preserved", got, err)
+	}
+	manifest, _, err := readBoardOutputManifest(outputDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range manifest.Files {
+		if file.Path == "stale.svg" {
+			t.Fatal("new manifest retained ownership of a user-edited stale file")
+		}
+	}
+}
+
+func TestValidateBoardOutputManifestRejectsUnsafeOwnershipClaims(t *testing.T) {
+	digest := strings.Repeat("0", 2*32)
+	for _, test := range []struct {
+		name     string
+		manifest boardOutputManifest
+	}{
+		{
+			name: "case alias of manifest",
+			manifest: boardOutputManifest{Files: []boardOutputManifestFile{
+				{Path: strings.ToUpper(boardOutputManifestName), SHA256: digest},
+			}},
+		},
+		{
+			name: "file prefix of file",
+			manifest: boardOutputManifest{Files: []boardOutputManifestFile{
+				{Path: "file", SHA256: digest},
+				{Path: "file/child.svg", SHA256: digest},
+			}},
+		},
+		{
+			name: "file prefix of directory",
+			manifest: boardOutputManifest{
+				Files:       []boardOutputManifestFile{{Path: "file", SHA256: digest}},
+				Directories: []string{"file/child"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.manifest.Format = boardOutputManifestFormat
+			test.manifest.Version = boardOutputManifestVersion
+			if err := validateBoardOutputManifest(t.TempDir(), test.manifest); err == nil {
+				t.Fatal("validateBoardOutputManifest() accepted unsafe ownership claims")
+			}
+		})
+	}
+}
+
 func TestMultiboardOutputRejectsPreexistingSymlink(t *testing.T) {
 	directory := t.TempDir()
 	inputPath := filepath.Join(directory, "input.d2")
@@ -266,6 +616,78 @@ layers: {
 	}
 	if _, err := os.Stat(filepath.Join(outputDirectory, "index.svg")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("root output was published before symlink preflight completed: %v", err)
+	}
+}
+
+func TestMultiboardOutputRejectsPreexistingSymlinkAncestor(t *testing.T) {
+	directory := t.TempDir()
+	inputPath := filepath.Join(directory, "input.d2")
+	if err := os.WriteFile(inputPath, []byte(`root
+layers: {
+  parent: {
+    layers: {
+      child: { child-shape }
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	victimDirectory := filepath.Join(directory, "victim")
+	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(victimDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(victimDirectory, "sentinel")
+	if err := os.WriteFile(sentinelPath, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victimDirectory, filepath.Join(outputDirectory, "parent")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := runBoardOutputCLIResult(t, directory, inputPath, outputPath)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Run() error = %v, want symlink ancestor rejection", err)
+	}
+	if got, err := os.ReadFile(sentinelPath); err != nil || string(got) != "keep me" {
+		t.Fatalf("victim sentinel = %q, %v; want unchanged", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(victimDirectory, "child.svg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("board was published through symlink ancestor: %v", err)
+	}
+}
+
+func TestRelinkIncludesConnections(t *testing.T) {
+	diagram := &d2target.Diagram{
+		Shapes:      []d2target.Shape{{Link: "root.layers.child"}},
+		Connections: []d2target.Connection{{Link: "root.layers.child"}},
+	}
+	links := map[string]string{
+		"root":              filepath.Join("output", "index.svg"),
+		"root.layers.child": filepath.Join("output", "child #%.svg"),
+	}
+	if err := relink("root", diagram, links); err != nil {
+		t.Fatal(err)
+	}
+	for kind, link := range map[string]string{
+		"shape":      diagram.Shapes[0].Link,
+		"connection": diagram.Connections[0].Link,
+	} {
+		if link != "child%20%23%25.svg" {
+			t.Errorf("%s board link = %q, want URL-escaped child path", kind, link)
+		}
+		if strings.Contains(link, `\`) {
+			t.Errorf("%s board link %q is not URL-style", kind, link)
+		}
+	}
+	if got := boardOutputLink(filepath.Join("..", "child #%.svg")); got != "../child%20%23%25.svg" {
+		t.Errorf("parent-relative board link = %q, want URL-style escaped path", got)
 	}
 }
 

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -693,13 +693,37 @@ func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, fs
 		var boards [][]byte
 		var outputWritten bool
 		var err error
+		if animateInterval <= 0 && !noChildren {
+			if err := validateBoardOutputPaths(outputPath, diagram); err != nil {
+				return nil, false, err
+			}
+		}
+		outputPaths := newBoardOutputPaths(outputPath)
+		var outputWorkspace *boardOutputWorkspace
+		if animateInterval <= 0 && outputPath != "-" && (len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0) {
+			outputWorkspace, err = newBoardOutputWorkspace(outputPath)
+			if err != nil {
+				return nil, false, err
+			}
+			outputPaths = outputWorkspace.outputPaths(outputPath)
+		}
 		if noChildren {
 			boards, outputWritten, err = renderSingle(ctx, ms, compileDur, plugin, renderOpts, inputPath, outputPath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview)
 		} else {
-			boards, outputWritten, err = render(ctx, ms, compileDur, plugin, renderOpts, inputPath, outputPath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview)
+			boards, outputWritten, err = renderToPaths(ctx, ms, compileDur, plugin, renderOpts, inputPath, outputPaths, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview)
 		}
 		if err != nil {
+			if outputWorkspace != nil {
+				err = errors.Join(err, outputWorkspace.discard())
+				outputWritten = false
+			}
 			return nil, outputWritten, err
+		}
+		if outputWorkspace != nil {
+			outputWritten, err = outputWorkspace.publish()
+			if err != nil {
+				return nil, outputWritten, err
+			}
 		}
 		var out []byte
 		if len(boards) > 0 {
@@ -733,47 +757,15 @@ func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, fs
 }
 
 func resolveLinks(currDiagramPath, outputPath string, diagram *d2target.Diagram) (linkToOutput map[string]string, err error) {
-	if diagram.Name != "" {
-		ext := filepath.Ext(outputPath)
-		outputPath = strings.TrimSuffix(outputPath, ext)
-		outputPath = filepath.Join(outputPath, diagram.Name)
-		outputPath += ext
+	plan, err := planBoardOutput(newBoardOutputPaths(outputPath), diagram)
+	if err != nil {
+		return nil, err
 	}
 
-	boardOutputPath := outputPath
-	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
-		ext := filepath.Ext(boardOutputPath)
-		boardOutputPath = strings.TrimSuffix(boardOutputPath, ext)
-		boardOutputPath = filepath.Join(boardOutputPath, "index")
-		boardOutputPath += ext
-	}
-
-	layersOutputPath := outputPath
-	if len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
-		ext := filepath.Ext(layersOutputPath)
-		layersOutputPath = strings.TrimSuffix(layersOutputPath, ext)
-		layersOutputPath = filepath.Join(layersOutputPath, "layers")
-		layersOutputPath += ext
-	}
-	scenariosOutputPath := outputPath
-	if len(diagram.Layers) > 0 || len(diagram.Steps) > 0 {
-		ext := filepath.Ext(scenariosOutputPath)
-		scenariosOutputPath = strings.TrimSuffix(scenariosOutputPath, ext)
-		scenariosOutputPath = filepath.Join(scenariosOutputPath, "scenarios")
-		scenariosOutputPath += ext
-	}
-	stepsOutputPath := outputPath
-	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 {
-		ext := filepath.Ext(stepsOutputPath)
-		stepsOutputPath = strings.TrimSuffix(stepsOutputPath, ext)
-		stepsOutputPath = filepath.Join(stepsOutputPath, "steps")
-		stepsOutputPath += ext
-	}
-
-	linkToOutput = map[string]string{currDiagramPath: boardOutputPath}
+	linkToOutput = map[string]string{currDiagramPath: plan.board.displayPath}
 
 	for _, dl := range diagram.Layers {
-		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "layers", dl.Name}, "."), layersOutputPath, dl)
+		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "layers", dl.Name}, "."), plan.layers.displayPath, dl)
 		if err != nil {
 			return nil, err
 		}
@@ -782,7 +774,7 @@ func resolveLinks(currDiagramPath, outputPath string, diagram *d2target.Diagram)
 		}
 	}
 	for _, dl := range diagram.Scenarios {
-		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "scenarios", dl.Name}, "."), scenariosOutputPath, dl)
+		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "scenarios", dl.Name}, "."), plan.scenarios.displayPath, dl)
 		if err != nil {
 			return nil, err
 		}
@@ -791,7 +783,7 @@ func resolveLinks(currDiagramPath, outputPath string, diagram *d2target.Diagram)
 		}
 	}
 	for _, dl := range diagram.Steps {
-		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "steps", dl.Name}, "."), stepsOutputPath, dl)
+		m, err := resolveLinks(strings.Join([]string{currDiagramPath, "steps", dl.Name}, "."), plan.steps.displayPath, dl)
 		if err != nil {
 			return nil, err
 		}
@@ -848,62 +840,38 @@ func postProcess(ctx context.Context, plugin d2plugin.Plugin, in []byte) ([]byte
 }
 
 func render(ctx context.Context, ms *xmain.State, compileDur time.Duration, plugin d2plugin.Plugin, opts d2svg.RenderOpts, inputPath, outputPath string, bundle, forceAppendix bool, ruler *textmeasure.Ruler, diagram *d2target.Diagram, ext exportExtension, asciiMode string, wantPreview bool) (_ [][]byte, written bool, _ error) {
+	return renderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, newBoardOutputPaths(outputPath), bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview)
+}
+
+func renderToPaths(ctx context.Context, ms *xmain.State, compileDur time.Duration, plugin d2plugin.Plugin, opts d2svg.RenderOpts, inputPath string, outputPaths boardOutputPaths, bundle, forceAppendix bool, ruler *textmeasure.Ruler, diagram *d2target.Diagram, ext exportExtension, asciiMode string, wantPreview bool) (_ [][]byte, written bool, _ error) {
 	if ext == PNG {
 		var encoder rasterPNGEncoder
 		defer encoder.close()
-		return renderWithPNGEncoder(ctx, ms, compileDur, plugin, opts, inputPath, outputPath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, &encoder)
+		return renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, outputPaths, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, &encoder)
 	}
-	return renderWithPNGEncoder(ctx, ms, compileDur, plugin, opts, inputPath, outputPath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, nil)
+	return renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, outputPaths, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, nil)
 }
 
 func renderWithPNGEncoder(ctx context.Context, ms *xmain.State, compileDur time.Duration, plugin d2plugin.Plugin, opts d2svg.RenderOpts, inputPath, outputPath string, bundle, forceAppendix bool, ruler *textmeasure.Ruler, diagram *d2target.Diagram, ext exportExtension, asciiMode string, wantPreview bool, pngEncoder *rasterPNGEncoder) (_ [][]byte, written bool, _ error) {
-	if diagram.Name != "" {
-		ext := filepath.Ext(outputPath)
-		outputPath = strings.TrimSuffix(outputPath, ext)
-		outputPath = filepath.Join(outputPath, diagram.Name)
-		outputPath += ext
-	}
+	return renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, newBoardOutputPaths(outputPath), bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, pngEncoder)
+}
 
-	boardOutputPath := outputPath
+func renderWithPNGEncoderToPaths(ctx context.Context, ms *xmain.State, compileDur time.Duration, plugin d2plugin.Plugin, opts d2svg.RenderOpts, inputPath string, outputPaths boardOutputPaths, bundle, forceAppendix bool, ruler *textmeasure.Ruler, diagram *d2target.Diagram, ext exportExtension, asciiMode string, wantPreview bool, pngEncoder *rasterPNGEncoder) (_ [][]byte, written bool, _ error) {
+	plan, err := planBoardOutput(outputPaths, diagram)
+	if err != nil {
+		return nil, false, err
+	}
 	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
-		if outputPath == "-" {
+		if plan.base.writePath == "-" {
 			// TODO it can if composed into one
 			return nil, false, fmt.Errorf("multiboard output cannot be written to stdout")
 		}
-		// Boards with subboards must be self-contained folders.
-		ext := filepath.Ext(boardOutputPath)
-		boardOutputPath = strings.TrimSuffix(boardOutputPath, ext)
-		os.RemoveAll(boardOutputPath)
-		boardOutputPath = filepath.Join(boardOutputPath, "index")
-		boardOutputPath += ext
-	}
-
-	layersOutputPath := outputPath
-	if len(diagram.Scenarios) > 0 || len(diagram.Steps) > 0 {
-		ext := filepath.Ext(layersOutputPath)
-		layersOutputPath = strings.TrimSuffix(layersOutputPath, ext)
-		layersOutputPath = filepath.Join(layersOutputPath, "layers")
-		layersOutputPath += ext
-	}
-	scenariosOutputPath := outputPath
-	if len(diagram.Layers) > 0 || len(diagram.Steps) > 0 {
-		ext := filepath.Ext(scenariosOutputPath)
-		scenariosOutputPath = strings.TrimSuffix(scenariosOutputPath, ext)
-		scenariosOutputPath = filepath.Join(scenariosOutputPath, "scenarios")
-		scenariosOutputPath += ext
-	}
-	stepsOutputPath := outputPath
-	if len(diagram.Layers) > 0 || len(diagram.Scenarios) > 0 {
-		ext := filepath.Ext(stepsOutputPath)
-		stepsOutputPath = strings.TrimSuffix(stepsOutputPath, ext)
-		stepsOutputPath = filepath.Join(stepsOutputPath, "steps")
-		stepsOutputPath += ext
 	}
 
 	var boards [][]byte
 	for _, dl := range diagram.Layers {
 		childPreview := wantPreview && diagram.IsFolderOnly && len(boards) == 0
-		childrenBoards, childWritten, err := renderWithPNGEncoder(ctx, ms, compileDur, plugin, opts, inputPath, layersOutputPath, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
+		childrenBoards, childWritten, err := renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, plan.layers, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
 		written = written || childWritten
 		if err != nil {
 			return boards, written, err
@@ -912,7 +880,7 @@ func renderWithPNGEncoder(ctx context.Context, ms *xmain.State, compileDur time.
 	}
 	for _, dl := range diagram.Scenarios {
 		childPreview := wantPreview && diagram.IsFolderOnly && len(boards) == 0
-		childrenBoards, childWritten, err := renderWithPNGEncoder(ctx, ms, compileDur, plugin, opts, inputPath, scenariosOutputPath, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
+		childrenBoards, childWritten, err := renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, plan.scenarios, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
 		written = written || childWritten
 		if err != nil {
 			return boards, written, err
@@ -921,7 +889,7 @@ func renderWithPNGEncoder(ctx context.Context, ms *xmain.State, compileDur time.
 	}
 	for _, dl := range diagram.Steps {
 		childPreview := wantPreview && diagram.IsFolderOnly && len(boards) == 0
-		childrenBoards, childWritten, err := renderWithPNGEncoder(ctx, ms, compileDur, plugin, opts, inputPath, stepsOutputPath, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
+		childrenBoards, childWritten, err := renderWithPNGEncoderToPaths(ctx, ms, compileDur, plugin, opts, inputPath, plan.steps, bundle, forceAppendix, ruler, dl, ext, asciiMode, childPreview, pngEncoder)
 		written = written || childWritten
 		if err != nil {
 			return boards, written, err
@@ -931,14 +899,14 @@ func renderWithPNGEncoder(ctx context.Context, ms *xmain.State, compileDur time.
 
 	if !diagram.IsFolderOnly {
 		start := time.Now()
-		out, boardWritten, err := _renderWithPNGEncoder(ctx, ms, plugin, opts, inputPath, boardOutputPath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, pngEncoder)
+		out, boardWritten, err := _renderWithPNGEncoder(ctx, ms, plugin, opts, inputPath, plan.board.writePath, bundle, forceAppendix, ruler, diagram, ext, asciiMode, wantPreview, pngEncoder)
 		written = written || boardWritten
 		if err != nil {
 			return boards, written, err
 		}
 		dur := compileDur + time.Since(start)
 		if opts.MasterID == "" {
-			ms.Log.Success.Printf("successfully compiled %s to %s in %s", ms.HumanPath(inputPath), ms.HumanPath(boardOutputPath), dur)
+			ms.Log.Success.Printf("successfully compiled %s to %s in %s", ms.HumanPath(inputPath), ms.HumanPath(plan.board.displayPath), dur)
 		}
 		boards = append([][]byte{out}, boards...)
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -804,7 +805,21 @@ func relink(currDiagramPath string, d *d2target.Diagram, linkToOutput map[string
 					if err != nil {
 						return err
 					}
-					d.Shapes[i].Link = rel
+					d.Shapes[i].Link = boardOutputLink(rel)
+					break
+				}
+			}
+		}
+	}
+	for i, connection := range d.Connections {
+		if connection.Link != "" {
+			for k, v := range linkToOutput {
+				if connection.Link == k {
+					rel, err := filepath.Rel(filepath.Dir(linkToOutput[currDiagramPath]), v)
+					if err != nil {
+						return err
+					}
+					d.Connections[i].Link = boardOutputLink(rel)
 					break
 				}
 			}
@@ -829,6 +844,16 @@ func relink(currDiagramPath string, d *d2target.Diagram, linkToOutput map[string
 		}
 	}
 	return nil
+}
+
+func boardOutputLink(path string) string {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	for i, part := range parts {
+		if part != "." && part != ".." {
+			parts[i] = url.PathEscape(part)
+		}
+	}
+	return strings.Join(parts, "/")
 }
 
 func postProcess(ctx context.Context, plugin d2plugin.Plugin, in []byte) ([]byte, error) {

--- a/e2etests-cli/testdata/TestCLI_E2E/layer-link/.d2-board-output-manifest-v1.exp.json
+++ b/e2etests-cli/testdata/TestCLI_E2E/layer-link/.d2-board-output-manifest-v1.exp.json
@@ -1,0 +1,15 @@
+{
+  "format": "d2-board-output",
+  "version": 1,
+  "files": [
+    {
+      "path": "index.svg",
+      "sha256": "d994d6e0c6ea3f5bdaee66026057eee358995aec8398895272b382315781d246"
+    },
+    {
+      "path": "test2.svg",
+      "sha256": "75dafc6c79d4db9c3bb13884a45b3697ace0bcdc707f7e76d4eb5998714ced3d"
+    }
+  ],
+  "directories": []
+}

--- a/e2etests-cli/testdata/TestCLI_E2E/multiboard/life/.d2-board-output-manifest-v1.exp.json
+++ b/e2etests-cli/testdata/TestCLI_E2E/multiboard/life/.d2-board-output-manifest-v1.exp.json
@@ -1,0 +1,30 @@
+{
+  "format": "d2-board-output",
+  "version": 1,
+  "files": [
+    {
+      "path": "index.svg",
+      "sha256": "a86ced1b23dbbf0d00076782cc28b877ec5688b497b48e6767805cc2f78709eb"
+    },
+    {
+      "path": "layers/broker.svg",
+      "sha256": "f7f6713ea138c298f773169207dd721ffa006acf76a8be5255a3cada6e357471"
+    },
+    {
+      "path": "layers/core.svg",
+      "sha256": "da5ab99d2888214b390b10e6b81c1814666a928265aa65a5fa09eb45abbd06d4"
+    },
+    {
+      "path": "layers/stocks.svg",
+      "sha256": "a544e4fda113bdff13817cebf5364453e650e773275a59d4f516863193562c11"
+    },
+    {
+      "path": "scenarios/why.svg",
+      "sha256": "642b138de598279ae8da52d5d2a897b76f94236caea3e6e51453d1925a1cbd6d"
+    }
+  ],
+  "directories": [
+    "layers",
+    "scenarios"
+  ]
+}

--- a/e2etests-cli/testdata/TestCLI_E2E/multiboard/life_index_d2/.d2-board-output-manifest-v1.exp.json
+++ b/e2etests-cli/testdata/TestCLI_E2E/multiboard/life_index_d2/.d2-board-output-manifest-v1.exp.json
@@ -1,0 +1,30 @@
+{
+  "format": "d2-board-output",
+  "version": 1,
+  "files": [
+    {
+      "path": "index.svg",
+      "sha256": "a86ced1b23dbbf0d00076782cc28b877ec5688b497b48e6767805cc2f78709eb"
+    },
+    {
+      "path": "layers/broker.svg",
+      "sha256": "f7f6713ea138c298f773169207dd721ffa006acf76a8be5255a3cada6e357471"
+    },
+    {
+      "path": "layers/core.svg",
+      "sha256": "da5ab99d2888214b390b10e6b81c1814666a928265aa65a5fa09eb45abbd06d4"
+    },
+    {
+      "path": "layers/stocks.svg",
+      "sha256": "a544e4fda113bdff13817cebf5364453e650e773275a59d4f516863193562c11"
+    },
+    {
+      "path": "scenarios/why.svg",
+      "sha256": "642b138de598279ae8da52d5d2a897b76f94236caea3e6e51453d1925a1cbd6d"
+    }
+  ],
+  "directories": [
+    "layers",
+    "scenarios"
+  ]
+}

--- a/e2etests-cli/testdata/TestCLI_E2E/sequence-layer/.d2-board-output-manifest-v1.exp.json
+++ b/e2etests-cli/testdata/TestCLI_E2E/sequence-layer/.d2-board-output-manifest-v1.exp.json
@@ -1,0 +1,15 @@
+{
+  "format": "d2-board-output",
+  "version": 1,
+  "files": [
+    {
+      "path": "index.svg",
+      "sha256": "97c4961a95e15bc605ec47545d0cb27f20bc1416350af3c05ae496813dd3eba2"
+    },
+    {
+      "path": "seq.svg",
+      "sha256": "eb8ab85dabe8730f7d4f2556ccca6a2da8379503be2b9145cc790fa2881bfc69"
+    }
+  ],
+  "directories": []
+}

--- a/e2etests-cli/testdata/TestCLI_E2E/sequence-spread-layer/.d2-board-output-manifest-v1.exp.json
+++ b/e2etests-cli/testdata/TestCLI_E2E/sequence-spread-layer/.d2-board-output-manifest-v1.exp.json
@@ -1,0 +1,15 @@
+{
+  "format": "d2-board-output",
+  "version": 1,
+  "files": [
+    {
+      "path": "index.svg",
+      "sha256": "97c4961a95e15bc605ec47545d0cb27f20bc1416350af3c05ae496813dd3eba2"
+    },
+    {
+      "path": "seq.svg",
+      "sha256": "eb8ab85dabe8730f7d4f2556ccca6a2da8379503be2b9145cc790fa2881bfc69"
+    }
+  ],
+  "directories": []
+}


### PR DESCRIPTION
## Human

---

## AI

Maps every board name to a bounded portable path component, validates the complete output plan for file/directory and normalized-name collisions, and stages multiboard renders in a process-owned directory. Publication is transactional: a versioned ownership manifest removes only unchanged stale generated files, preserves user-modified and unrelated files, and rolls visible mutations back on failure. Publishing no longer recursively removes a content-derived or pre-existing directory. Shape and connection links are rewritten as URL paths.

Tests:

- `go test ./...`
- focused tests with `-count=10`
- focused race tests
- CLI end-to-end golden tests
- Windows amd64 cross-compilation
