### PR TITLE
security: require explicit local file access

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/d2lang/d2/d2themes/d2themescatalog"
 	"github.com/d2lang/d2/lib/background"
 	"github.com/d2lang/d2/lib/imgbundler"
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/log"
 	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/pdf"
@@ -418,7 +419,9 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		ms.Log.Debug.Printf("GIF export: animate-interval not specified, defaulting to 1000ms")
 	}
 
-	_, written, err := compile(ctx, ms, plugins, nil, layoutFlag, renderOpts, fontFamily, monoFontFamily, animateInterval, inputPath, outputPath, boardPath, noChildren, *bundleFlag, *forceAppendixFlag, outputFormat, *asciiModeFlag, false)
+	// The CLI is a trusted local application and intentionally preserves its
+	// historical ability to import arbitrary host files.
+	_, written, err := compile(ctx, ms, plugins, localfile.Unrestricted(), layoutFlag, renderOpts, fontFamily, monoFontFamily, animateInterval, inputPath, outputPath, boardPath, noChildren, *bundleFlag, *forceAppendixFlag, outputFormat, *asciiModeFlag, false)
 	if err != nil {
 		if written {
 			return fmt.Errorf("failed to fully compile (partial render written) %s: %w", ms.HumanPath(inputPath), err)
@@ -1223,7 +1226,7 @@ func _renderWithPNGEncoder(ctx context.Context, ms *xmain.State, plugin d2plugin
 
 	cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
 	l := simplelog.FromCmdLog(ms.Log)
-	svg, bundleErr := imgbundler.BundleLocal(ctx, l, inputPath, svg, cacheImages)
+	svg, bundleErr := imgbundler.BundleLocalWithPolicy(ctx, l, inputPath, svg, localfile.Unrestricted(), cacheImages)
 	if bundle {
 		var bundleErr2 error
 		svg, bundleErr2 = imgbundler.BundleRemoteWithPolicy(ctx, l, svg, cacheImages, netpolicy.FromContext(ctx))

--- a/d2cli/raster.go
+++ b/d2cli/raster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/d2lang/d2/d2renderers/d2svgimport"
 	"github.com/d2lang/d2/d2target"
 	"github.com/d2lang/d2/lib/imageasset"
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/xgif"
 )
@@ -1031,6 +1032,7 @@ func newSceneAssetOptions(ctx context.Context, inputPath string, cacheImages boo
 	}
 	resolver, err := imageasset.New(imageasset.Options{
 		BaseDir:        baseDir,
+		LocalFiles:     localfile.Unrestricted(),
 		HTTPClient:     assetHTTPClient,
 		NetworkPolicy:  netpolicy.FromContext(ctx),
 		Cache:          cache,

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -30,6 +30,7 @@ import (
 	"github.com/d2lang/d2/d2plugin"
 	"github.com/d2lang/d2/d2renderers/d2fonts"
 	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/lib/localfile"
 )
 
 // Enabled with the build tag "dev".
@@ -422,7 +423,10 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 			recompiledPrefix = "re"
 		}
 
-		fs := trackedFS{}
+		// Watch mode is a trusted local CLI workflow, so it may follow imports
+		// anywhere on the host filesystem. Keep that opt-in explicit while using
+		// localfile.Policy to reject directories and other special files.
+		fs := trackedFS{localFiles: localfile.Unrestricted()}
 		w.boardpathMu.Lock()
 		var boardPath []string
 		if w.boardPath != "" {
@@ -658,11 +662,12 @@ func wsHeartbeat(ctx context.Context, c *websocket.Conn) {
 
 // trackedFS is OS's FS with the addition that it tracks which files are opened successfully
 type trackedFS struct {
-	opened []string
+	localFiles localfile.Policy
+	opened     []string
 }
 
 func (tfs *trackedFS) Open(name string) (fs.File, error) {
-	f, err := os.Open(name)
+	f, err := tfs.localFiles.Open(name)
 	if err == nil {
 		tfs.opened = append(tfs.opened, name)
 	}

--- a/d2cli/watch_test.go
+++ b/d2cli/watch_test.go
@@ -1,0 +1,66 @@
+package d2cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/d2lang/d2/lib/localfile"
+)
+
+func TestTrackedFSHonorsLocalFilePolicy(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "inside.d2")
+	if err := os.WriteFile(inside, []byte("inside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outsideRoot := t.TempDir()
+	outside := filepath.Join(outsideRoot, "outside.d2")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rooted, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked := trackedFS{localFiles: rooted}
+	file, err := tracked.Open(inside)
+	if err != nil {
+		t.Fatalf("open rooted regular file: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(tracked.opened) != 1 || tracked.opened[0] != inside {
+		t.Fatalf("tracked opens = %q, want [%q]", tracked.opened, inside)
+	}
+
+	if _, err := tracked.Open(outside); !errors.Is(err, localfile.ErrDenied) {
+		t.Fatalf("outside-root Open error = %v, want localfile.ErrDenied", err)
+	}
+	if _, err := tracked.Open(root); err == nil {
+		t.Fatal("trackedFS accepted a directory")
+	}
+	if len(tracked.opened) != 1 {
+		t.Fatalf("failed opens were tracked: %q", tracked.opened)
+	}
+
+	var denied trackedFS
+	if _, err := denied.Open(inside); !errors.Is(err, localfile.ErrDenied) {
+		t.Fatalf("zero-policy Open error = %v, want localfile.ErrDenied", err)
+	}
+
+	trusted := trackedFS{localFiles: localfile.Unrestricted()}
+	file, err = trusted.Open(outside)
+	if err != nil {
+		t.Fatalf("trusted CLI Open error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(trusted.opened) != 1 || trusted.opened[0] != outside {
+		t.Fatalf("trusted tracked opens = %q, want [%q]", trusted.opened, outside)
+	}
+}

--- a/d2cli/watch_unix_test.go
+++ b/d2cli/watch_unix_test.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+package d2cli
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/d2lang/d2/lib/localfile"
+)
+
+func TestTrackedFSRejectsFIFOWithoutBlocking(t *testing.T) {
+	fifoPath := filepath.Join(t.TempDir(), "import.d2")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tracked := trackedFS{localFiles: localfile.Unrestricted()}
+	done := make(chan error, 1)
+	go func() {
+		file, err := tracked.Open(fifoPath)
+		if file != nil {
+			err = file.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("trackedFS accepted a FIFO")
+		}
+		if len(tracked.opened) != 0 {
+			t.Fatalf("FIFO was tracked as opened: %q", tracked.opened)
+		}
+	case <-time.After(2 * time.Second):
+		writer, _ := os.OpenFile(fifoPath, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if writer != nil {
+			_ = writer.Close()
+		}
+		t.Fatal("trackedFS blocked on a FIFO")
+	}
+}

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -30,8 +30,10 @@ type CompileOptions struct {
 	// context.Background().
 	Context  context.Context
 	UTF16Pos bool
-	// FS is the file system used for resolving imports in the d2 text.
-	// It should correspond to the root path.
+	// FS is the file system used for resolving imports in the D2 text. Nil
+	// disables imports. Callers that accept untrusted input should prefer a
+	// filesystem constrained to the intended import root; lib/localfile provides
+	// rooted and explicit unrestricted host-filesystem policies.
 	FS fs.FS
 }
 

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2,6 +2,7 @@ package d2compiler_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +18,17 @@ import (
 	"github.com/d2lang/d2/d2graph"
 	"github.com/d2lang/d2/d2target"
 )
+
+func TestNilFSDeniesImports(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "secret.d2"), []byte("disclosed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := d2compiler.Compile(filepath.Join(directory, "index.d2"), strings.NewReader("...@secret"), nil)
+	if err == nil || !strings.Contains(err.Error(), "imports are disabled") {
+		t.Fatalf("Compile error = %v, want imports-disabled error", err)
+	}
+}
 
 func TestOpacityValidation(t *testing.T) {
 	t.Parallel()

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -70,7 +70,8 @@ type CompileOptions struct {
 	// treated as context.Background().
 	Context  context.Context
 	UTF16Pos bool
-	// Pass nil to disable imports.
+	// FS resolves imports. Nil disables imports. The lib/localfile package
+	// provides rooted and explicit unrestricted host-filesystem policies.
 	FS fs.FS
 }
 

--- a/d2ir/import.go
+++ b/d2ir/import.go
@@ -1,8 +1,7 @@
 package d2ir
 
 import (
-	"io/fs"
-	"os"
+	"errors"
 	"path"
 	"path/filepath"
 	"strings"
@@ -10,6 +9,10 @@ import (
 	"github.com/d2lang/d2/d2ast"
 	"github.com/d2lang/d2/d2parser"
 )
+
+// ErrImportsDisabled is returned when D2 source requests an import but the
+// caller did not provide CompileOptions.FS.
+var ErrImportsDisabled = errors.New("d2ir: imports are disabled; provide CompileOptions.FS to enable them")
 
 func (c *compiler) pushImportStack(imp *d2ast.Import) (string, bool) {
 	impPath := imp.PathWithPre()
@@ -195,13 +198,10 @@ func (c *compiler) loadImportAST(impPath string, parseErr *d2parser.ParseError) 
 		return cloneASTMap(ast), nil, true
 	}
 
-	var f fs.File
-	var err error
 	if c.fs == nil {
-		f, err = os.Open(impPath)
-	} else {
-		f, err = c.fs.Open(impPath)
+		return nil, ErrImportsDisabled, false
 	}
+	f, err := c.fs.Open(impPath)
 	if err != nil {
 		return nil, err, false
 	}

--- a/d2ir/import_test.go
+++ b/d2ir/import_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -46,6 +48,22 @@ func TestCanceledContextPropagatesFromImportedParse(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Compile error = %v, want context.Canceled", err)
+	}
+}
+
+func TestNilFSDeniesImports(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "secret.d2"), []byte("disclosed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inputPath := filepath.Join(directory, "index.d2")
+	ast, err := d2parser.Parse(inputPath, strings.NewReader("...@secret"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = d2ir.Compile(ast, nil)
+	if err == nil || !strings.Contains(err.Error(), "imports are disabled") {
+		t.Fatalf("Compile error = %v, want imports-disabled error", err)
 	}
 }
 

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -22,7 +22,11 @@ import (
 )
 
 type CompileOptions struct {
-	UTF16Pos       bool
+	UTF16Pos bool
+	// FS is the file system used for resolving imports in the D2 text. Nil
+	// disables imports. Callers that accept untrusted input should prefer a
+	// filesystem constrained to the intended import root; lib/localfile provides
+	// rooted and explicit unrestricted host-filesystem policies.
 	FS             fs.FS
 	MeasuredTexts  []*d2target.MText
 	Ruler          *textmeasure.Ruler

--- a/d2lib/d2_test.go
+++ b/d2lib/d2_test.go
@@ -3,7 +3,10 @@ package d2lib
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/d2lang/d2/d2graph"
@@ -22,6 +25,19 @@ func TestParseAndCompileHonorCanceledContext(t *testing.T) {
 	}
 	if _, _, err := Compile(ctx, "x", nil, nil); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Compile() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestNilFSDeniesImports(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "secret.d2"), []byte("disclosed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := Compile(context.Background(), "...@secret", &CompileOptions{
+		InputPath: filepath.Join(directory, "index.d2"),
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "imports are disabled") {
+		t.Fatalf("Compile error = %v, want imports-disabled error", err)
 	}
 }
 

--- a/lib/imageasset/imageasset.go
+++ b/lib/imageasset/imageasset.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/netpolicy"
 )
 
@@ -248,9 +249,14 @@ func (c *MemoryCache) Put(key string, resource *Resource) {
 
 // Options configures one independent resolver.
 type Options struct {
-	// BaseDir resolves relative local paths. New makes it absolute; an empty
-	// value freezes the current working directory at construction time.
-	BaseDir    string
+	// BaseDir resolves relative local paths. New makes it absolute. When it is
+	// empty, rooted local-file policies use their configured root and other
+	// policies freeze the current working directory at construction time.
+	BaseDir string
+	// LocalFiles controls local-file access. Its zero value denies local files.
+	// Use localfile.Rooted for untrusted input. localfile.Unrestricted is an
+	// explicit opt-in intended only for trusted local applications.
+	LocalFiles localfile.Policy
 	HTTPClient *http.Client
 	// NetworkPolicy defaults to public addresses only. Trusted callers can
 	// explicitly allow private-network assets.
@@ -268,6 +274,7 @@ type Options struct {
 // owns no global state and is safe for concurrent use.
 type Resolver struct {
 	baseDir     string
+	localFiles  localfile.Policy
 	client      *http.Client
 	cache       Cache
 	cachePrefix string
@@ -291,7 +298,11 @@ func New(options Options) (*Resolver, error) {
 	}
 	baseDir := options.BaseDir
 	if baseDir == "" {
-		baseDir = "."
+		if root, ok := options.LocalFiles.RootPath(); ok {
+			baseDir = root
+		} else {
+			baseDir = "."
+		}
 	}
 	absolute, err := filepath.Abs(baseDir)
 	if err != nil {
@@ -326,6 +337,7 @@ func New(options Options) (*Resolver, error) {
 	}
 	return &Resolver{
 		baseDir:         baseDir,
+		localFiles:      options.LocalFiles,
 		client:          client,
 		cache:           options.Cache,
 		cachePrefix:     cachePrefix,

--- a/lib/imageasset/imageasset_test.go
+++ b/lib/imageasset/imageasset_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/andybalholm/brotli"
 
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/netpolicy"
 )
 
@@ -833,6 +834,9 @@ func newTestResolver(t *testing.T, options Options) *Resolver {
 	// transports. Tests of the default public-only policy construct a Resolver
 	// directly instead.
 	options.NetworkPolicy = netpolicy.Policy{AllowPrivateNetworks: true}
+	// Existing format, cache, and limit tests model a trusted local caller.
+	// Policy-denial and rooted behavior are covered with direct New calls.
+	options.LocalFiles = localfile.Unrestricted()
 	if options.Limits == (Limits{}) {
 		options.Limits = generousLimits()
 	}

--- a/lib/imageasset/local_policy_test.go
+++ b/lib/imageasset/local_policy_test.go
@@ -1,0 +1,152 @@
+package imageasset
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/d2lang/d2/lib/localfile"
+)
+
+func TestLocalFilesDeniedByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "image.png")
+	if err := os.WriteFile(path, encodePNG(t, 1, 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := New(Options{Limits: generousLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), path)
+	if !errors.Is(err, localfile.ErrDenied) {
+		t.Fatalf("Resolve error = %v, want localfile.ErrDenied", err)
+	}
+}
+
+func TestRootedLocalFilesContainResolution(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	insidePath := filepath.Join(root, "inside.png")
+	outsidePath := filepath.Join(parent, "outside.png")
+	if err := os.WriteFile(insidePath, encodePNG(t, 2, 3), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsidePath, encodePNG(t, 4, 5), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := New(Options{LocalFiles: policy, Limits: generousLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range []string{"inside.png", insidePath} {
+		resource, err := resolver.Resolve(context.Background(), source)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", source, err)
+		}
+		assertResource(t, resource, KindRaster, "image/png", 2, 3)
+	}
+	for _, source := range []string{"../outside.png", outsidePath} {
+		if _, err := resolver.Resolve(context.Background(), source); !errors.Is(err, localfile.ErrDenied) {
+			t.Fatalf("Resolve(%q) error = %v, want localfile.ErrDenied", source, err)
+		}
+	}
+}
+
+func TestRootedLocalFilesRejectSymlinkEscapeAndOversize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks commonly requires elevated Windows privileges")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(parent, "outside.png")
+	if err := os.WriteFile(outsidePath, encodePNG(t, 1, 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(root, "escape.png")); err != nil {
+		t.Fatal(err)
+	}
+	oversizedPath := filepath.Join(root, "oversized.png")
+	if err := os.WriteFile(oversizedPath, encodePNG(t, 1, 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	limits := generousLimits()
+	limits.MaxFetchedBytes = 1
+	resolver, err := New(Options{LocalFiles: policy, Limits: limits})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), "escape.png"); err == nil {
+		t.Fatal("resolver followed a symlink outside the configured root")
+	}
+	_, err = resolver.Resolve(context.Background(), "oversized.png")
+	var limitErr *LimitError
+	if !errors.As(err, &limitErr) || limitErr.Name != "fetched bytes" {
+		t.Fatalf("oversized local error = %v, want fetched-byte LimitError", err)
+	}
+}
+
+func TestLocalCacheCannotCrossPolicyBoundary(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(parent, "outside.png")
+	if err := os.WriteFile(outsidePath, encodePNG(t, 1, 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache, err := NewMemoryCache(4, 1<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	limits := generousLimits()
+	prime, err := New(Options{
+		BaseDir:        root,
+		LocalFiles:     localfile.Unrestricted(),
+		Cache:          cache,
+		CacheNamespace: "policy-boundary",
+		Limits:         limits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prime.Resolve(context.Background(), outsidePath); err != nil {
+		t.Fatal(err)
+	}
+	rootedPolicy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rooted, err := New(Options{
+		LocalFiles:     rootedPolicy,
+		Cache:          cache,
+		CacheNamespace: "policy-boundary",
+		Limits:         limits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rooted.Resolve(context.Background(), outsidePath); !errors.Is(err, localfile.ErrDenied) {
+		t.Fatalf("rooted resolver reused unrestricted cache entry: %v", err)
+	}
+	if len(cache.entries) != 1 {
+		t.Fatalf("denied resolve changed cache size to %d", len(cache.entries))
+	}
+}

--- a/lib/imageasset/resolve.go
+++ b/lib/imageasset/resolve.go
@@ -246,7 +246,11 @@ func (r *Resolver) classifySource(ctx context.Context, source string) (sourceSpe
 		return sourceSpec{}, err
 	}
 	absolute = filepath.Clean(absolute)
-	return sourceSpec{kind: sourceLocal, raw: raw, label: raw, key: "file:" + absolute, path: absolute}, nil
+	cacheKey, err := r.localFiles.CacheKey(absolute)
+	if err != nil {
+		return sourceSpec{}, err
+	}
+	return sourceSpec{kind: sourceLocal, raw: raw, label: raw, key: "file:" + cacheKey, path: absolute}, nil
 }
 
 func displaySource(source string) string {
@@ -361,26 +365,11 @@ func (r *Resolver) load(ctx context.Context, spec sourceSpec) (loadedSource, err
 	}
 }
 
-func (r *Resolver) loadLocal(ctx context.Context, spec sourceSpec) (loadedSource, error) {
+func (r *Resolver) loadLocal(ctx context.Context, spec sourceSpec) (_ loadedSource, err error) {
 	if err := checkContext(ctx); err != nil {
 		return loadedSource{}, err
 	}
-	info, err := os.Stat(spec.path)
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			err = ctxErr
-		} else if errors.Is(err, os.ErrNotExist) {
-			err = unavailable(err)
-		}
-		return loadedSource{}, fmt.Errorf("stat local file %q: %w", spec.path, err)
-	}
-	if !info.Mode().IsRegular() {
-		return loadedSource{}, fmt.Errorf("local path %q is not a regular file", spec.path)
-	}
-	if info.Size() > r.limits.MaxFetchedBytes {
-		return loadedSource{}, &LimitError{Name: "fetched bytes", Actual: info.Size(), Limit: r.limits.MaxFetchedBytes}
-	}
-	file, err := os.Open(spec.path)
+	file, err := r.localFiles.Open(spec.path)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			err = ctxErr
@@ -389,7 +378,11 @@ func (r *Resolver) loadLocal(ctx context.Context, spec sourceSpec) (loadedSource
 		}
 		return loadedSource{}, fmt.Errorf("open local file %q: %w", spec.path, err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close local file %q: %w", spec.path, closeErr))
+		}
+	}()
 	openedInfo, err := file.Stat()
 	if err != nil {
 		return loadedSource{}, fmt.Errorf("stat opened local file %q: %w", spec.path, err)

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -7,13 +7,13 @@ import (
 	"compress/zlib"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"html"
 	"io"
 	"mime"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -23,6 +23,7 @@ import (
 
 	"github.com/andybalholm/brotli"
 
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/simplelog"
 	"github.com/d2lang/d2/lib/svg"
@@ -35,8 +36,17 @@ const maxImageSize int64 = 1 << 25 // 33_554_432
 
 var imageRegex = regexp.MustCompile(`<image href="([^"]+)"`)
 
+// BundleLocal bundles local image references using the deny-by-default local
+// file policy. Call BundleLocalWithPolicy to deliberately permit local files.
 func BundleLocal(ctx context.Context, l simplelog.Logger, inputPath string, in []byte, cacheImages bool) ([]byte, error) {
-	return bundle(ctx, l, inputPath, in, false, cacheImages, netpolicy.Policy{})
+	return BundleLocalWithPolicy(ctx, l, inputPath, in, localfile.Policy{}, cacheImages)
+}
+
+// BundleLocalWithPolicy bundles local image references allowed by localFiles.
+// Use localfile.Rooted for untrusted input. localfile.Unrestricted is intended
+// only for trusted local applications such as the D2 command-line interface.
+func BundleLocalWithPolicy(ctx context.Context, l simplelog.Logger, inputPath string, in []byte, localFiles localfile.Policy, cacheImages bool) ([]byte, error) {
+	return bundle(ctx, l, inputPath, in, localFiles, false, cacheImages, netpolicy.Policy{})
 }
 
 func BundleRemote(ctx context.Context, l simplelog.Logger, in []byte, cacheImages bool) ([]byte, error) {
@@ -47,7 +57,7 @@ func BundleRemote(ctx context.Context, l simplelog.Logger, in []byte, cacheImage
 // permits public destinations only; trusted callers may explicitly opt into
 // private-network assets.
 func BundleRemoteWithPolicy(ctx context.Context, l simplelog.Logger, in []byte, cacheImages bool, policy netpolicy.Policy) ([]byte, error) {
-	return bundle(ctx, l, "", in, true, cacheImages, policy)
+	return bundle(ctx, l, "", in, localfile.Policy{}, true, cacheImages, policy)
 }
 
 type repl struct {
@@ -55,7 +65,7 @@ type repl struct {
 	to   []byte
 }
 
-func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, isRemote, cacheImages bool, policy netpolicy.Policy) (_ []byte, err error) {
+func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, localFiles localfile.Policy, isRemote, cacheImages bool, policy netpolicy.Policy) (_ []byte, err error) {
 	if isRemote {
 		defer xdefer.Errorf(&err, "failed to bundle remote images")
 	} else {
@@ -78,7 +88,7 @@ func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byt
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 
-	return runWorkers(ctx, l, inputPath, svg, imgs, isRemote, cacheImages, client, policy)
+	return runWorkers(ctx, l, inputPath, svg, imgs, localFiles, isRemote, cacheImages, client, policy)
 }
 
 // filterImageElements finds all unique image elements in imgs that are
@@ -108,7 +118,7 @@ func filterImageElements(imgs [][][]byte, isRemote bool) [][][]byte {
 	return imgs2
 }
 
-func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, imgs [][][]byte, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) (_ []byte, err error) {
+func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, imgs [][][]byte, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) (_ []byte, err error) {
 	var wg sync.WaitGroup
 	replc := make(chan repl)
 
@@ -135,7 +145,7 @@ func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg [
 					<-sema
 				}()
 
-				bundledImage, err := worker(ctx, l, inputPath, img[1], isRemote, cacheImages, client, policy)
+				bundledImage, err := worker(ctx, l, inputPath, img[1], localFiles, isRemote, cacheImages, client, policy)
 				if err != nil {
 					l.Error(fmt.Sprintf("failed to bundle %s: %v", img[1], err))
 					errhrefsMu.Lock()
@@ -178,10 +188,23 @@ type imageCacheKey struct {
 	href                 string
 	isRemote             bool
 	allowPrivateNetworks bool
+	localPolicyKey       string
 }
 
-func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []byte, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) ([]byte, error) {
+func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []byte, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) ([]byte, error) {
 	cacheKey := imageCacheKey{href: string(href), isRemote: isRemote, allowPrivateNetworks: policy.AllowPrivateNetworks}
+	localPath := ""
+	if !isRemote {
+		localPath = html.UnescapeString(string(href))
+		if inputPath != "-" && !filepath.IsAbs(localPath) {
+			localPath = filepath.Join(filepath.Dir(inputPath), localPath)
+		}
+		policyKey, err := localFiles.CacheKey(localPath)
+		if err != nil {
+			return nil, err
+		}
+		cacheKey.localPolicyKey = policyKey
+	}
 	if cacheImages {
 		if hit, ok := imgCache.Load(cacheKey); ok {
 			return hit.([]byte), nil
@@ -195,11 +218,7 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 		buf, mimeType, err = httpGet(ctx, l, client, html.UnescapeString(string(href)))
 	} else {
 		l.Debug(fmt.Sprintf("reading %s from disk", string(href)))
-		path := html.UnescapeString(string(href))
-		if inputPath != "-" && !filepath.IsAbs(path) {
-			path = filepath.Join(filepath.Dir(inputPath), path)
-		}
-		buf, err = os.ReadFile(path)
+		buf, err = readLocal(ctx, localFiles, localPath)
 	}
 	if err != nil {
 		return nil, err
@@ -224,6 +243,42 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 		imgCache.Store(cacheKey, out)
 	}
 	return out, nil
+}
+
+func readLocal(ctx context.Context, localFiles localfile.Policy, filePath string) (_ []byte, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	file, err := localFiles.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close local image %q: %w", filePath, closeErr))
+		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat local image %q: %w", filePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("local image %q is not a regular file", filePath)
+	}
+	if info.Size() > maxImageSize {
+		return nil, fmt.Errorf("local image exceeds maximum size of %d bytes", maxImageSize)
+	}
+	buf, err := io.ReadAll(io.LimitReader(file, maxImageSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(buf)) > maxImageSize {
+		return nil, fmt.Errorf("local image exceeds maximum size of %d bytes", maxImageSize)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 var httpClient = &http.Client{}

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -463,7 +463,7 @@ func TestInlineRemoteContentTypeIsSafeAndCanonical(t *testing.T) {
 				return respRecorder.Result()
 			})
 
-			out, err := BundleRemote(ctx, simplelog.FromLibLog(ctx), sampleSVG, false)
+			out, err := bundleRemoteForTest(ctx, simplelog.FromLibLog(ctx), sampleSVG, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -22,6 +22,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/d2lang/d2/internal/testlog"
+	"github.com/d2lang/d2/lib/localfile"
 	"github.com/d2lang/d2/lib/log"
 	"github.com/d2lang/d2/lib/netpolicy"
 	"github.com/d2lang/d2/lib/simplelog"
@@ -209,7 +210,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 	l := simplelog.FromLibLog(ctx)
 	// It doesn't matter what the inputPath is for absolute paths
-	out, err := BundleLocal(ctx, l, "asdf", []byte(sampleSVG), false)
+	out, err := BundleLocalWithPolicy(ctx, l, "asdf", []byte(sampleSVG), localfile.Unrestricted(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +242,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	)
 
 	// Bogus directory not found
-	_, err = BundleLocal(ctx, l, "asdf/asdf/asdf", []byte(sampleSVG), false)
+	_, err = BundleLocalWithPolicy(ctx, l, "asdf/asdf/asdf", []byte(sampleSVG), localfile.Unrestricted(), false)
 	if err == nil {
 		t.Fatal("Expected error for invalid input path")
 	}
@@ -250,7 +251,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	}
 
 	// - is ignored
-	_, err = BundleLocal(ctx, l, "-", []byte(sampleSVG), false)
+	_, err = BundleLocalWithPolicy(ctx, l, "-", []byte(sampleSVG), localfile.Unrestricted(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +260,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	sampleSVG = fmt.Sprintf(template, svgURL, pngURL)
 
 	// correct relative path
-	_, err = BundleLocal(ctx, l, "./nested/a.d2", []byte(sampleSVG), false)
+	_, err = BundleLocalWithPolicy(ctx, l, "./nested/a.d2", []byte(sampleSVG), localfile.Unrestricted(), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/imgbundler/local_policy_test.go
+++ b/lib/imgbundler/local_policy_test.go
@@ -1,0 +1,119 @@
+package imgbundler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/d2lang/d2/internal/testlog"
+	"github.com/d2lang/d2/lib/localfile"
+	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/simplelog"
+)
+
+func TestBundleLocalDeniesByDefault(t *testing.T) {
+	path := writeLocalPolicyImage(t, t.TempDir(), "image.svg", `<svg xmlns="http://www.w3.org/2000/svg"/>`)
+	_, err := BundleLocal(localPolicyContext(t), localPolicyLogger(t), "-", localPolicySVG(path), false)
+	if err == nil {
+		t.Fatal("BundleLocal read a local file without an explicit policy")
+	}
+}
+
+func TestBundleLocalRootedPolicy(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalPolicyImage(t, root, "inside.svg", `<svg xmlns="http://www.w3.org/2000/svg"/>`)
+	outside := writeLocalPolicyImage(t, parent, "outside.svg", `<svg xmlns="http://www.w3.org/2000/svg"/>`)
+	policy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := localPolicyContext(t)
+	logger := localPolicyLogger(t)
+	output, err := BundleLocalWithPolicy(ctx, logger, filepath.Join(root, "input.d2"), localPolicySVG("inside.svg"), policy, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), `data:image/svg+xml;base64,`) {
+		t.Fatalf("in-root image was not bundled: %s", output)
+	}
+	for _, href := range []string{"../outside.svg", outside} {
+		if _, err := BundleLocalWithPolicy(ctx, logger, filepath.Join(root, "input.d2"), localPolicySVG(href), policy, false); err == nil {
+			t.Fatalf("rooted policy bundled outside path %q", href)
+		}
+	}
+}
+
+func TestBundleLocalRootedPolicyRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks commonly requires elevated Windows privileges")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := writeLocalPolicyImage(t, parent, "outside.svg", `<svg xmlns="http://www.w3.org/2000/svg"/>`)
+	if err := os.Symlink(outside, filepath.Join(root, "escape.svg")); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = BundleLocalWithPolicy(localPolicyContext(t), localPolicyLogger(t), filepath.Join(root, "input.d2"), localPolicySVG("escape.svg"), policy, false)
+	if err == nil {
+		t.Fatal("rooted policy followed an escaping symlink")
+	}
+}
+
+func TestBundleLocalCapsLocalFileBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized.png")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxImageSize + 1); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = BundleLocalWithPolicy(localPolicyContext(t), localPolicyLogger(t), "-", localPolicySVG(path), localfile.Unrestricted(), false)
+	if err == nil {
+		t.Fatal("BundleLocal accepted an oversized local image")
+	}
+}
+
+func localPolicySVG(href string) []byte {
+	return []byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg"><image href="%s"/></svg>`, href))
+}
+
+func writeLocalPolicyImage(t *testing.T, directory, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func localPolicyContext(t *testing.T) context.Context {
+	t.Helper()
+	imgCache = sync.Map{}
+	return log.With(context.Background(), testlog.New(t))
+}
+
+func localPolicyLogger(t *testing.T) simplelog.Logger {
+	t.Helper()
+	return simplelog.FromLibLog(localPolicyContext(t))
+}

--- a/lib/imgbundler/local_policy_test.go
+++ b/lib/imgbundler/local_policy_test.go
@@ -2,6 +2,7 @@ package imgbundler
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,6 +73,51 @@ func TestBundleLocalRootedPolicyRejectsSymlinkEscape(t *testing.T) {
 	_, err = BundleLocalWithPolicy(localPolicyContext(t), localPolicyLogger(t), filepath.Join(root, "input.d2"), localPolicySVG("escape.svg"), policy, false)
 	if err == nil {
 		t.Fatal("rooted policy followed an escaping symlink")
+	}
+}
+
+func TestBundleLocalCacheDoesNotCrossRootReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" || runtime.GOOS == "plan9" {
+		t.Skip("directory identity across renames is not portable to this platform")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	movedRoot := filepath.Join(parent, "moved-root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const original = `<svg xmlns="http://www.w3.org/2000/svg"><title>original</title></svg>`
+	const replacement = `<svg xmlns="http://www.w3.org/2000/svg"><title>replacement</title></svg>`
+	writeLocalPolicyImage(t, root, "asset.svg", original)
+	firstPolicy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := localPolicyContext(t)
+	logger := simplelog.FromLibLog(ctx)
+	inputPath := filepath.Join(root, "input.d2")
+	if _, err := BundleLocalWithPolicy(ctx, logger, inputPath, localPolicySVG("asset.svg"), firstPolicy, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(root, movedRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalPolicyImage(t, root, "asset.svg", replacement)
+	secondPolicy, err := localfile.Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := BundleLocalWithPolicy(ctx, logger, inputPath, localPolicySVG("asset.svg"), secondPolicy, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := base64.StdEncoding.EncodeToString([]byte(replacement))
+	if !strings.Contains(string(output), want) {
+		t.Fatal("replacement root reused the previous root's cached asset")
 	}
 }
 

--- a/lib/localfile/localfile.go
+++ b/lib/localfile/localfile.go
@@ -1,0 +1,160 @@
+// Package localfile provides explicit policies for opening local files.
+// The zero value denies access. Callers must deliberately choose either a
+// symlink-safe filesystem root or unrestricted host-filesystem access.
+package localfile
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ErrDenied reports that a policy does not permit a local-file path.
+var ErrDenied = errors.New("localfile: access denied")
+
+type policyMode uint8
+
+const (
+	modeDenied policyMode = iota
+	modeRooted
+	modeUnrestricted
+)
+
+// Policy controls access to local files. Its zero value denies all local-file
+// access and is safe for untrusted input.
+//
+// Policy implements fs.FS so it can also be supplied explicitly to D2's
+// compiler APIs when imports are desired.
+type Policy struct {
+	mode policyMode
+	root string
+}
+
+// Rooted returns a policy that permits files at or beneath root. Opens use
+// os.Root, so symbolic links cannot escape root on supported platforms.
+func Rooted(root string) (Policy, error) {
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return Policy{}, fmt.Errorf("localfile: resolve root %q: %w", root, err)
+	}
+	absolute = filepath.Clean(absolute)
+	handle, err := os.OpenRoot(absolute)
+	if err != nil {
+		return Policy{}, fmt.Errorf("localfile: open root %q: %w", root, err)
+	}
+	if err := handle.Close(); err != nil {
+		return Policy{}, fmt.Errorf("localfile: close root %q: %w", root, err)
+	}
+	return Policy{mode: modeRooted, root: absolute}, nil
+}
+
+// Unrestricted returns a policy that permits arbitrary host-filesystem reads.
+// Use it only for trusted local input, such as the D2 command-line interface.
+func Unrestricted() Policy {
+	return Policy{mode: modeUnrestricted}
+}
+
+// RootPath returns the absolute configured root and true for a rooted policy.
+// It returns an empty string and false for denied and unrestricted policies.
+func (p Policy) RootPath() (string, bool) {
+	return p.root, p.mode == modeRooted
+}
+
+// CacheKey returns a policy-scoped, canonical key for name. It rejects names
+// outside the policy's lexical scope; Open additionally enforces the rooted
+// symbolic-link boundary. The key prevents a cache filled under an unrestricted
+// policy from bypassing a rooted or denied policy.
+func (p Policy) CacheKey(name string) (string, error) {
+	resolved, err := p.resolve(name)
+	if err != nil {
+		return "", err
+	}
+	switch p.mode {
+	case modeRooted:
+		rootHash := sha256.Sum256([]byte(p.root))
+		return fmt.Sprintf("root:%x:%s", rootHash, filepath.ToSlash(resolved.relative)), nil
+	case modeUnrestricted:
+		return "unrestricted:" + filepath.ToSlash(resolved.absolute), nil
+	default:
+		panic("localfile: resolved path under invalid policy mode")
+	}
+}
+
+// Open opens name according to the policy. For rooted policies, relative names
+// are interpreted relative to the configured root. Absolute names are accepted
+// only when they are lexically beneath that root, and os.Root enforces the same
+// boundary while following symbolic links.
+func (p Policy) Open(name string) (fs.File, error) {
+	resolved, err := p.resolve(name)
+	if err != nil {
+		return nil, err
+	}
+	if p.mode == modeUnrestricted {
+		return os.Open(resolved.absolute)
+	}
+
+	root, err := os.OpenRoot(p.root)
+	if err != nil {
+		return nil, fmt.Errorf("localfile: open root %q: %w", p.root, err)
+	}
+	file, openErr := root.Open(resolved.relative)
+	closeErr := root.Close()
+	if openErr != nil {
+		var closeRootErr error
+		if closeErr != nil {
+			closeRootErr = fmt.Errorf("localfile: close root %q: %w", p.root, closeErr)
+		}
+		return nil, errors.Join(
+			fmt.Errorf("localfile: open %q beneath root %q: %w", name, p.root, openErr),
+			closeRootErr,
+		)
+	}
+	if closeErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("localfile: close root %q: %w", p.root, closeErr),
+			file.Close(),
+		)
+	}
+	return file, nil
+}
+
+type resolvedPath struct {
+	absolute string
+	relative string
+}
+
+func (p Policy) resolve(name string) (resolvedPath, error) {
+	switch p.mode {
+	case modeDenied:
+		return resolvedPath{}, fmt.Errorf("%w: local-file access is disabled", ErrDenied)
+	case modeUnrestricted:
+		absolute, err := filepath.Abs(name)
+		if err != nil {
+			return resolvedPath{}, fmt.Errorf("localfile: resolve %q: %w", name, err)
+		}
+		return resolvedPath{absolute: filepath.Clean(absolute)}, nil
+	case modeRooted:
+		var relative string
+		if filepath.IsAbs(name) {
+			var err error
+			relative, err = filepath.Rel(p.root, filepath.Clean(name))
+			if err != nil {
+				return resolvedPath{}, fmt.Errorf("localfile: resolve %q beneath root %q: %w", name, p.root, err)
+			}
+		} else {
+			relative = filepath.Clean(name)
+		}
+		if !filepath.IsLocal(relative) {
+			return resolvedPath{}, fmt.Errorf("%w: %q is outside configured root %q", ErrDenied, name, p.root)
+		}
+		return resolvedPath{
+			absolute: filepath.Join(p.root, relative),
+			relative: relative,
+		}, nil
+	default:
+		return resolvedPath{}, errors.New("localfile: invalid policy")
+	}
+}

--- a/lib/localfile/localfile.go
+++ b/lib/localfile/localfile.go
@@ -1,10 +1,19 @@
-// Package localfile provides explicit policies for opening local files.
+// Package localfile provides explicit policies for opening regular local files.
 // The zero value denies access. Callers must deliberately choose either a
 // symlink-safe filesystem root or unrestricted host-filesystem access.
+//
+// On Unix, files are opened nonblocking and verified from the opened descriptor
+// before Open returns, preventing ordinary FIFO open waits. Device-specific
+// open behavior can still vary. Other platforms have no portable nonblocking
+// open flag, so a hostile special file may block before it can be rejected. In
+// addition, os.Root cannot provide a symlink security boundary on GOOS=js and
+// does not retain directory identity across renames on GOOS=js or GOOS=plan9.
+// Callers on those platforms must not treat Rooted as a complete boundary for
+// hostile filesystems.
 package localfile
 
 import (
-	"crypto/sha256"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -26,15 +35,19 @@ const (
 // Policy controls access to local files. Its zero value denies all local-file
 // access and is safe for untrusted input.
 //
-// Policy implements fs.FS so it can also be supplied explicitly to D2's
-// compiler APIs when imports are desired.
+// Policy implements the part of fs.FS needed by D2's compiler imports. Open
+// intentionally rejects directories and other non-regular files, so Policy is
+// not a general-purpose directory-browsing filesystem.
 type Policy struct {
-	mode policyMode
-	root string
+	mode       policyMode
+	rootPath   string
+	root       *os.Root
+	cacheScope [32]byte
 }
 
 // Rooted returns a policy that permits files at or beneath root. Opens use
-// os.Root, so symbolic links cannot escape root on supported platforms.
+// one retained os.Root, so symbolic links cannot escape root and replacing the
+// configured path cannot retarget the policy on supported platforms.
 func Rooted(root string) (Policy, error) {
 	absolute, err := filepath.Abs(root)
 	if err != nil {
@@ -45,10 +58,14 @@ func Rooted(root string) (Policy, error) {
 	if err != nil {
 		return Policy{}, fmt.Errorf("localfile: open root %q: %w", root, err)
 	}
-	if err := handle.Close(); err != nil {
-		return Policy{}, fmt.Errorf("localfile: close root %q: %w", root, err)
+	var cacheScope [32]byte
+	if _, err := rand.Read(cacheScope[:]); err != nil {
+		return Policy{}, errors.Join(
+			fmt.Errorf("localfile: create cache scope for root %q: %w", root, err),
+			closeRoot(handle, root),
+		)
 	}
-	return Policy{mode: modeRooted, root: absolute}, nil
+	return Policy{mode: modeRooted, rootPath: absolute, root: handle, cacheScope: cacheScope}, nil
 }
 
 // Unrestricted returns a policy that permits arbitrary host-filesystem reads.
@@ -60,7 +77,7 @@ func Unrestricted() Policy {
 // RootPath returns the absolute configured root and true for a rooted policy.
 // It returns an empty string and false for denied and unrestricted policies.
 func (p Policy) RootPath() (string, bool) {
-	return p.root, p.mode == modeRooted
+	return p.rootPath, p.mode == modeRooted
 }
 
 // CacheKey returns a policy-scoped, canonical key for name. It rejects names
@@ -74,8 +91,9 @@ func (p Policy) CacheKey(name string) (string, error) {
 	}
 	switch p.mode {
 	case modeRooted:
-		rootHash := sha256.Sum256([]byte(p.root))
-		return fmt.Sprintf("root:%x:%s", rootHash, filepath.ToSlash(resolved.relative)), nil
+		// The random per-policy scope prevents a cache entry produced through an
+		// older directory at the same path from crossing into a replacement root.
+		return fmt.Sprintf("root:%x:%s", p.cacheScope, filepath.ToSlash(resolved.relative)), nil
 	case modeUnrestricted:
 		return "unrestricted:" + filepath.ToSlash(resolved.absolute), nil
 	default:
@@ -83,42 +101,62 @@ func (p Policy) CacheKey(name string) (string, error) {
 	}
 }
 
-// Open opens name according to the policy. For rooted policies, relative names
-// are interpreted relative to the configured root. Absolute names are accepted
-// only when they are lexically beneath that root, and os.Root enforces the same
-// boundary while following symbolic links.
+// Open opens a regular file according to the policy. For rooted policies,
+// relative names are interpreted relative to the configured root. Absolute
+// names are accepted only when they are lexically beneath that root, and the
+// retained os.Root enforces the same boundary while following symbolic links.
 func (p Policy) Open(name string) (fs.File, error) {
 	resolved, err := p.resolve(name)
 	if err != nil {
 		return nil, err
 	}
 	if p.mode == modeUnrestricted {
-		return os.Open(resolved.absolute)
+		file, err := openFile(resolved.absolute)
+		if err != nil {
+			return nil, err
+		}
+		return requireRegular(name, file)
 	}
 
-	root, err := os.OpenRoot(p.root)
-	if err != nil {
-		return nil, fmt.Errorf("localfile: open root %q: %w", p.root, err)
+	if p.root == nil {
+		return nil, errors.New("localfile: invalid rooted policy")
 	}
-	file, openErr := root.Open(resolved.relative)
-	closeErr := root.Close()
-	if openErr != nil {
-		var closeRootErr error
-		if closeErr != nil {
-			closeRootErr = fmt.Errorf("localfile: close root %q: %w", p.root, closeErr)
-		}
+	file, err := openFileInRoot(p.root, resolved.relative)
+	if err != nil {
+		return nil, fmt.Errorf("localfile: open %q beneath root %q: %w", name, p.rootPath, err)
+	}
+	return requireRegular(name, file)
+}
+
+func requireRegular(name string, file *os.File) (fs.File, error) {
+	info, err := file.Stat()
+	if err != nil {
 		return nil, errors.Join(
-			fmt.Errorf("localfile: open %q beneath root %q: %w", name, p.root, openErr),
-			closeRootErr,
+			fmt.Errorf("localfile: stat opened file %q: %w", name, err),
+			closeFile(file, name),
 		)
 	}
-	if closeErr != nil {
+	if !info.Mode().IsRegular() {
 		return nil, errors.Join(
-			fmt.Errorf("localfile: close root %q: %w", p.root, closeErr),
-			file.Close(),
+			fmt.Errorf("localfile: %q is not a regular file", name),
+			closeFile(file, name),
 		)
 	}
 	return file, nil
+}
+
+func closeFile(file *os.File, name string) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("localfile: close %q: %w", name, err)
+	}
+	return nil
+}
+
+func closeRoot(root *os.Root, name string) error {
+	if err := root.Close(); err != nil {
+		return fmt.Errorf("localfile: close root %q: %w", name, err)
+	}
+	return nil
 }
 
 type resolvedPath struct {
@@ -140,18 +178,18 @@ func (p Policy) resolve(name string) (resolvedPath, error) {
 		var relative string
 		if filepath.IsAbs(name) {
 			var err error
-			relative, err = filepath.Rel(p.root, filepath.Clean(name))
+			relative, err = filepath.Rel(p.rootPath, filepath.Clean(name))
 			if err != nil {
-				return resolvedPath{}, fmt.Errorf("localfile: resolve %q beneath root %q: %w", name, p.root, err)
+				return resolvedPath{}, fmt.Errorf("localfile: resolve %q beneath root %q: %w", name, p.rootPath, err)
 			}
 		} else {
 			relative = filepath.Clean(name)
 		}
 		if !filepath.IsLocal(relative) {
-			return resolvedPath{}, fmt.Errorf("%w: %q is outside configured root %q", ErrDenied, name, p.root)
+			return resolvedPath{}, fmt.Errorf("%w: %q is outside configured root %q", ErrDenied, name, p.rootPath)
 		}
 		return resolvedPath{
-			absolute: filepath.Join(p.root, relative),
+			absolute: filepath.Join(p.rootPath, relative),
 			relative: relative,
 		}, nil
 	default:

--- a/lib/localfile/localfile_test.go
+++ b/lib/localfile/localfile_test.go
@@ -1,0 +1,120 @@
+package localfile
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestZeroPolicyDeniesLocalFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var policy Policy
+	if _, err := policy.Open(path); !errors.Is(err, ErrDenied) {
+		t.Fatalf("Open error = %v, want ErrDenied", err)
+	}
+	if _, err := policy.CacheKey(path); !errors.Is(err, ErrDenied) {
+		t.Fatalf("CacheKey error = %v, want ErrDenied", err)
+	}
+}
+
+func TestRootedPolicyContainsOpens(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(root, "inside.txt")
+	outside := filepath.Join(parent, "outside.txt")
+	if err := os.WriteFile(inside, []byte("inside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"inside.txt", inside} {
+		file, err := policy.Open(name)
+		if err != nil {
+			t.Fatalf("Open(%q): %v", name, err)
+		}
+		data, readErr := io.ReadAll(file)
+		closeErr := file.Close()
+		if readErr != nil || closeErr != nil {
+			t.Fatalf("read/close %q: %v / %v", name, readErr, closeErr)
+		}
+		if string(data) != "inside" {
+			t.Fatalf("Open(%q) = %q", name, data)
+		}
+	}
+	for _, name := range []string{"../outside.txt", outside} {
+		if _, err := policy.Open(name); !errors.Is(err, ErrDenied) {
+			t.Fatalf("Open(%q) error = %v, want ErrDenied", name, err)
+		}
+	}
+}
+
+func TestRootedPolicyRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks commonly requires elevated Windows privileges")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := policy.Open("escape"); err == nil {
+		t.Fatal("Open followed a symlink outside the configured root")
+	}
+}
+
+func TestUnrestrictedPolicyIsExplicitAndCacheScoped(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file")
+	if err := os.WriteFile(path, []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rooted, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrestricted := Unrestricted()
+	rootedKey, err := rooted.CacheKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrestrictedKey, err := unrestricted.CacheKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rootedKey == unrestrictedKey {
+		t.Fatal("rooted and unrestricted cache keys collide")
+	}
+	file, err := unrestricted.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/lib/localfile/localfile_test.go
+++ b/lib/localfile/localfile_test.go
@@ -88,6 +88,74 @@ func TestRootedPolicyRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestRootedPolicyPinsDirectoryAcrossPathReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" || runtime.GOOS == "plan9" {
+		t.Skip("directory identity across renames is not portable to this platform")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	movedRoot := filepath.Join(parent, "moved-root")
+	replacement := filepath.Join(parent, "replacement")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(replacement, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "value"), []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(replacement, "value"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(root, movedRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, root); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := policy.Open("value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("read/close pinned file: %v / %v", readErr, closeErr)
+	}
+	if string(data) != "original" {
+		t.Fatalf("Open after root replacement = %q, want original directory", data)
+	}
+}
+
+func TestRootedPolicyCacheScopeIsPerInstance(t *testing.T) {
+	root := t.TempDir()
+	first, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstKey, err := first.CacheKey("value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondKey, err := second.CacheKey("value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstKey == secondKey {
+		t.Fatal("distinct rooted policy instances share a cache scope")
+	}
+}
+
 func TestUnrestrictedPolicyIsExplicitAndCacheScoped(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "file")

--- a/lib/localfile/localfile_unix_test.go
+++ b/lib/localfile/localfile_unix_test.go
@@ -1,0 +1,61 @@
+//go:build unix
+
+package localfile
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestPolicyRejectsFIFOWithoutBlocking(t *testing.T) {
+	root := t.TempDir()
+	rooted, err := Rooted(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		policy Policy
+		path   string
+	}{
+		{name: "rooted", policy: rooted, path: "fifo-rooted"},
+		{name: "unrestricted", policy: Unrestricted(), path: filepath.Join(root, "fifo-unrestricted")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fifoPath := tc.path
+			if !filepath.IsAbs(fifoPath) {
+				fifoPath = filepath.Join(root, fifoPath)
+			}
+			if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				file, err := tc.policy.Open(tc.path)
+				if file != nil {
+					err = file.Close()
+				}
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("Open accepted a FIFO")
+				}
+			case <-time.After(2 * time.Second):
+				// Release a blocking reader so a regression does not strand a
+				// goroutine for the remainder of the test process.
+				writer, _ := os.OpenFile(fifoPath, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+				if writer != nil {
+					_ = writer.Close()
+				}
+				t.Fatal("Open blocked on a FIFO")
+			}
+		})
+	}
+}

--- a/lib/localfile/open_portable.go
+++ b/lib/localfile/open_portable.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package localfile
+
+import "os"
+
+// There is no portable os.OpenFile flag corresponding to Unix O_NONBLOCK.
+// requireRegular still rejects special files after these calls return.
+func openFile(name string) (*os.File, error) {
+	return os.Open(name)
+}
+
+func openFileInRoot(root *os.Root, name string) (*os.File, error) {
+	return root.Open(name)
+}

--- a/lib/localfile/open_unix.go
+++ b/lib/localfile/open_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package localfile
+
+import (
+	"os"
+	"syscall"
+)
+
+func openFile(name string) (*os.File, error) {
+	return os.OpenFile(name, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}
+
+func openFileInRoot(root *os.Root, name string) (*os.File, error) {
+	return root.OpenFile(name, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}


### PR DESCRIPTION
## Human

---

## AI

Makes local imports and image assets deny-by-default for library callers, adds symlink-safe rooted access for untrusted workspaces, and keeps trusted CLI and watch-mode behavior behind an explicit unrestricted policy. Rooted policies retain their opened root across path replacement, use per-instance cache identities, and reject non-regular files without blocking on FIFOs, including watch-mode import recompiles. Legacy local asset bundling now enforces a byte limit.

Integration note: merge #2894 and #2899 first, then rebase this PR so the parser context, public-network, and local-file policy changes are combined in the shared asset APIs.

Tests:

- `go test ./...`
- `go vet ./...`
- focused race tests
- JS/WASM runtime tests
- Windows, Plan 9, WASI, and JS cross-compilation
