### PR TITLE
security: bound URL decoder expansion

### DIFF
--- a/lib/urlenc/urlenc.go
+++ b/lib/urlenc/urlenc.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/d2lang/util-go/xdefer"
 )
+
+const maxDecodedScriptSize int64 = 16 << 20
 
 // Encode takes a D2 script and encodes it as a compressed base64 string for embedding in URLs.
 func Encode(raw string) (_ string, err error) {
@@ -41,12 +45,18 @@ func Decode(encoded string) (_ string, err error) {
 	}
 
 	zr := flate.NewReaderDict(bytes.NewReader(b64Decoded), nil)
-	var b bytes.Buffer
-	if _, err := io.Copy(&b, zr); err != nil {
+	defer func() {
+		if closeErr := zr.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	decoded, err := io.ReadAll(io.LimitReader(zr, maxDecodedScriptSize+1))
+	if err != nil {
 		return "", err
 	}
-	if err := zr.Close(); err != nil {
-		return "", nil
+	if int64(len(decoded)) > maxDecodedScriptSize {
+		return "", fmt.Errorf("decoded D2 script exceeds maximum size of %d bytes", maxDecodedScriptSize)
 	}
-	return b.String(), nil
+	return string(decoded), nil
 }

--- a/lib/urlenc/urlenc_test.go
+++ b/lib/urlenc/urlenc_test.go
@@ -1,6 +1,7 @@
 package urlenc
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/d2lang/util-go/assert"
@@ -20,6 +21,23 @@ I just forgot my whole philosophy of life!!!: {
 	assert.Success(t, err)
 
 	assert.String(t, script, decoded)
+}
+
+func TestDecodeRejectsOversizedScript(t *testing.T) {
+	script := strings.Repeat("x", int(maxDecodedScriptSize)+1)
+	encoded, err := Encode(script)
+	assert.Success(t, err)
+	if len(encoded) >= 1<<20 {
+		t.Fatalf("expected a compact decompression-bomb fixture, got %d encoded bytes", len(encoded))
+	}
+
+	decoded, err := Decode(encoded)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("Decode() error = %v, want decoded-size limit", err)
+	}
+	if decoded != "" {
+		t.Fatalf("Decode() returned %d bytes after exceeding the limit", len(decoded))
+	}
 }
 
 // TestChanges makes it explicit in PRs when encoding changes


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

`urlenc.Decode` accepts compressed, base64-encoded input and previously copied the decompressed stream into an unbounded memory buffer. The public JavaScript/WASM `decode` API exposes this function directly, so an application that decodes an attacker-controlled diagram URL could be given a small DEFLATE payload that expands until the browser tab, worker, or server process runs out of memory.

This is decompression amplification (CWE-409). It affects availability; it does not by itself allow code execution or data disclosure. The regression fixture demonstrates that an encoded input under 1 MiB can expand past 16 MiB.

### What changed

- Stop decompression after 16 MiB plus one byte.
- Return a clear error when the decoded D2 script exceeds the limit.
- Always close the DEFLATE reader and preserve any close error.
- Add a regression test using a highly compressible oversized script.

Normal URL-encoded diagrams are unchanged. The 16 MiB decoded limit is intentionally far above practical browser URL sizes while making the decoder's worst-case allocation finite.

### Verification

- `go test ./...`
- `go vet ./...`
- WASM consumer compile check with `GOOS=js GOARCH=wasm go test -c ./d2js/d2wasm`
