### PR TITLE
security: escape SQL-table constraint text in SVG

### DIFF
--- a/d2renderers/d2sketch/sketch.go
+++ b/d2renderers/d2sketch/sketch.go
@@ -504,7 +504,7 @@ func Table(shape d2target.Shape) (string, error) {
 		textEl.Y = constraintTR.Y + float64(shape.FontSize)*3/4
 		textEl.Fill = shape.SecondaryAccentColor
 		textEl.Style = fmt.Sprintf("text-anchor:%s;font-size:%vpx;letter-spacing:2px", "end", float64(shape.FontSize))
-		textEl.Content = f.ConstraintAbbr()
+		textEl.Content = svg.EscapeText(f.ConstraintAbbr())
 		output += textEl.Render()
 
 		rowBox.TopLeft.Y += rowHeight

--- a/d2renderers/d2svg/sql_table_constraint_escaping_test.go
+++ b/d2renderers/d2svg/sql_table_constraint_escaping_test.go
@@ -1,0 +1,102 @@
+package d2svg_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestRenderEscapesSQLTableConstraints(t *testing.T) {
+	t.Parallel()
+
+	const constraint = `</text><script onload="document.documentElement.dataset.pwned='yes'">void 0</script><text>& preserved`
+	for _, sketch := range []bool{false, true} {
+		sketch := sketch
+		name := "normal"
+		if sketch {
+			name = "sketch"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diagram := sqlConstraintEscapingDiagram(constraint)
+			out, err := d2svg.Render(diagram, &d2svg.RenderOpts{Sketch: &sketch})
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			assertSafeSQLConstraint(t, out, constraint)
+		})
+	}
+}
+
+func sqlConstraintEscapingDiagram(constraint string) *d2target.Diagram {
+	diagram := d2target.NewDiagram()
+	fontFamily, monoFontFamily := d2fonts.SourceSansPro, d2fonts.SourceCodePro
+	diagram.FontFamily = &fontFamily
+	diagram.MonoFontFamily = &monoFontFamily
+
+	shape := *d2target.BaseShape()
+	shape.ID = "table"
+	shape.Type = d2target.ShapeSQLTable
+	shape.Width = 420
+	shape.Height = 120
+	shape.Fill = "#ffffff"
+	shape.Stroke = "#000000"
+	shape.Color = "#000000"
+	shape.FontSize = 16
+	shape.PrimaryAccentColor = "#000000"
+	shape.SecondaryAccentColor = "#000000"
+	shape.NeutralAccentColor = "#000000"
+	shape.Columns = []d2target.SQLColumn{
+		{
+			Name:       d2target.Text{Label: "column", LabelWidth: 48},
+			Type:       d2target.Text{Label: "string", LabelWidth: 40},
+			Constraint: []string{constraint},
+		},
+	}
+	diagram.Shapes = []d2target.Shape{shape}
+	return diagram
+}
+
+func assertSafeSQLConstraint(t *testing.T, source []byte, constraint string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(bytes.NewReader(source))
+	decoder.Strict = true
+	var decodedText strings.Builder
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Render() emitted invalid XML: %v\n%s", err, source)
+		}
+		switch token := token.(type) {
+		case xml.StartElement:
+			if strings.EqualFold(token.Name.Local, "script") {
+				t.Fatalf("Render() emitted an injected script element: %s", source)
+			}
+			for _, attr := range token.Attr {
+				if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+					t.Fatalf("Render() emitted an event-handler attribute %q: %s", attr.Name.Local, source)
+				}
+			}
+		case xml.CharData:
+			decodedText.Write(token)
+		}
+	}
+
+	if !strings.Contains(decodedText.String(), constraint) {
+		t.Fatalf("Render() did not preserve constraint %q as text after XML decoding: %s", constraint, source)
+	}
+	if !bytes.Contains(source, []byte(`&lt;/text&gt;&lt;script`)) {
+		t.Fatalf("Render() did not XML-escape the constraint markup: %s", source)
+	}
+}

--- a/d2renderers/d2svg/table.go
+++ b/d2renderers/d2svg/table.go
@@ -102,7 +102,7 @@ func tableRow(shape d2target.Shape, box *geo.Box, nameText, typeText, constraint
 	textEl.X = box.TopLeft.X + (box.Width - d2target.NamePadding)
 	textEl.Fill = shape.SecondaryAccentColor
 	textEl.Style = fmt.Sprintf("text-anchor:%s;font-size:%vpx", "end", fontSize)
-	textEl.Content = constraintText
+	textEl.Content = svg.EscapeText(constraintText)
 	out += textEl.Render()
 
 	return out


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

Arbitrary SQL-table constraint strings were inserted directly between SVG `<text>` tags in both the normal and sketch renderers. A D2 author could close the text element and inject a `<script>` element or event-handler attribute. If a victim opens the generated SVG directly or embeds it in an active same-origin SVG/HTML context, that markup can execute with the embedding origin's privileges.

This is stored/content-driven SVG XSS. It affects SVG output; raster, PDF, and PPTX rendering already treat the constraint as text rather than markup.

### What changed

- XML-escape SQL constraint abbreviations before assigning SVG text content.
- Apply the same fix to the normal and sketch renderers.
- Add a regression that renders a hostile constraint through both paths, strict-parses the XML, rejects script/event-handler nodes, and verifies the original value survives as decoded text.

Ordinary constraints such as `PK`, `FK`, and `UNQ` render identically.

### Verification

- `go test ./d2renderers/d2svg ./d2renderers/d2sketch`
- `go test ./...`
- `go vet ./...`
