### PR TITLE
security: bound recursive import depth

### DIFF
--- a/d2ir/import.go
+++ b/d2ir/import.go
@@ -14,6 +14,10 @@ import (
 // caller did not provide CompileOptions.FS.
 var ErrImportsDisabled = errors.New("d2ir: imports are disabled; provide CompileOptions.FS to enable them")
 
+// MaxImportDepth is the maximum number of imported files permitted in one
+// active import chain. The root source file is not counted.
+const MaxImportDepth = 128
+
 func (c *compiler) pushImportStack(imp *d2ast.Import) (string, bool) {
 	impPath := imp.PathWithPre()
 	if impPath == "" && imp.Range != (d2ast.Range{}) {
@@ -28,6 +32,11 @@ func (c *compiler) pushImportStack(imp *d2ast.Import) (string, bool) {
 		if !filepath.IsAbs(impPath) {
 			impPath = path.Join(path.Dir(c.importStack[len(c.importStack)-1]), impPath)
 		}
+	}
+
+	if len(c.importStack) > 0 && len(c.importStack)-1 >= MaxImportDepth {
+		c.errorf(imp, "maximum import depth of %d exceeded", MaxImportDepth)
+		return "", false
 	}
 
 	for i, p := range c.importStack {

--- a/d2ir/import_depth_test.go
+++ b/d2ir/import_depth_test.go
@@ -1,0 +1,68 @@
+package d2ir_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/d2lang/d2/d2ir"
+	"github.com/d2lang/d2/d2parser"
+)
+
+const importDepthHelperEnv = "D2_TEST_IMPORT_DEPTH_HELPER"
+
+func TestImportDepthLimit(t *testing.T) {
+	if os.Getenv(importDepthHelperEnv) == "1" {
+		compileImportChain(t, 10_000, true)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestImportDepthLimit$")
+	cmd.Env = append(os.Environ(), importDepthHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("deep import subprocess did not stop safely: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("deep import subprocess failed: %v\n%s", err, output)
+	}
+}
+
+func TestImportDepthBoundary(t *testing.T) {
+	compileImportChain(t, d2ir.MaxImportDepth, false)
+	compileImportChain(t, d2ir.MaxImportDepth+1, true)
+}
+
+func compileImportChain(t *testing.T, depth int, wantLimitError bool) {
+	t.Helper()
+	files := make(fstest.MapFS, depth)
+	for index := 0; index < depth; index++ {
+		contents := "leaf"
+		if index+1 < depth {
+			contents = fmt.Sprintf("...@level-%05d", index+1)
+		}
+		files[fmt.Sprintf("level-%05d.d2", index)] = &fstest.MapFile{Data: []byte(contents)}
+	}
+
+	ast, err := d2parser.Parse("index.d2", strings.NewReader("...@level-00000"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = d2ir.Compile(ast, &d2ir.CompileOptions{FS: files})
+	if wantLimitError {
+		if err == nil || !strings.Contains(err.Error(), "maximum import depth") {
+			t.Fatalf("Compile error = %v, want maximum import depth error", err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("Compile error at supported import depth %d: %v", depth, err)
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

The parser's nesting limit applies to each source file independently, but imports recurse through files without a depth bound. An attacker who controls a diagram and its import filesystem can therefore use thousands of individually shallow files to bypass the parser limit and grow the compiler's call stack. Import-cycle detection also scans the active chain at every level, adding quadratic work.

This is an availability issue for services, editor workers, and CLI workflows that compile untrusted D2 projects. A pre-fix subprocess compiled a 10,000-file chain without any normal limit; sufficiently deeper chains depend only on the Go runtime's stack growth and process resources.

### What changed

- Limit one active import chain to 128 imported files, excluding the root source.
- Reject the next import before path-cycle scanning or opening another file.
- Add boundary tests proving 128 imports succeed and 129 fail with a clear diagnostic.
- Add a 10,000-file subprocess regression proving hostile depth now terminates safely rather than consuming an unbounded stack in the test process.

Independent import trees are unaffected; only the depth of a single active chain is bounded.

### Verification

- `go test ./d2ir`
- `go test ./...`
- `go vet ./...`
