### PR TITLE
security: validate SVG gradient stop positions

### DIFF
--- a/d2compiler/gradient_security_test.go
+++ b/d2compiler/gradient_security_test.go
@@ -1,0 +1,24 @@
+package d2compiler_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2compiler"
+)
+
+func TestCompileRejectsGradientStopMarkup(t *testing.T) {
+	t.Parallel()
+
+	for _, gradientType := range []string{"linear", "radial"} {
+		gradientType := gradientType
+		t.Run(gradientType, func(t *testing.T) {
+			t.Parallel()
+			dsl := `x.style.fill: '` + gradientType + `-gradient(red 0%"/><script>document.documentElement.dataset.pwned=1</script><!--, blue --><stop/>)'`
+			_, _, err := d2compiler.Compile("gradient-security.d2", strings.NewReader(dsl), nil)
+			if err == nil || !strings.Contains(err.Error(), `expected "fill" to be a valid named color`) {
+				t.Fatalf("Compile() error = %v, want invalid-color diagnostic", err)
+			}
+		})
+	}
+}

--- a/lib/color/gradient.go
+++ b/lib/color/gradient.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"html"
 	"math"
 	"regexp"
 	"strconv"
@@ -46,6 +47,7 @@ func ParseGradient(cssGradient string) (Gradient, error) {
 	}
 
 	firstParam := strings.TrimSpace(paramList[0])
+	var err error
 
 	if gradient.Type == "linear" && (strings.HasSuffix(firstParam, "deg") || strings.HasPrefix(firstParam, "to ")) {
 		gradient.Direction = firstParam
@@ -53,16 +55,19 @@ func ParseGradient(cssGradient string) (Gradient, error) {
 		if len(colorStops) == 0 {
 			return Gradient{}, errors.New("no color stops in gradient")
 		}
-		gradient.ColorStops = parseColorStops(colorStops)
+		gradient.ColorStops, err = parseColorStops(colorStops)
 	} else if gradient.Type == "radial" && (firstParam == "circle" || firstParam == "ellipse") {
 		gradient.Direction = firstParam
 		colorStops := paramList[1:]
 		if len(colorStops) == 0 {
 			return Gradient{}, errors.New("no color stops in gradient")
 		}
-		gradient.ColorStops = parseColorStops(colorStops)
+		gradient.ColorStops, err = parseColorStops(colorStops)
 	} else {
-		gradient.ColorStops = parseColorStops(paramList)
+		gradient.ColorStops, err = parseColorStops(paramList)
+	}
+	if err != nil {
+		return Gradient{}, err
 	}
 	gradient.ID = UniqueGradientID(cssGradient)
 
@@ -97,9 +102,9 @@ func splitParams(params string) []string {
 	return parts
 }
 
-func parseColorStops(params []string) []ColorStop {
+func parseColorStops(params []string) ([]ColorStop, error) {
 	var colorStops []ColorStop
-	for _, p := range params {
+	for i, p := range params {
 		p = strings.TrimSpace(p)
 		parts := strings.Fields(p)
 
@@ -107,12 +112,30 @@ func parseColorStops(params []string) []ColorStop {
 		case 1:
 			colorStops = append(colorStops, ColorStop{Color: parts[0]})
 		case 2:
-			colorStops = append(colorStops, ColorStop{Color: parts[0], Position: parts[1]})
+			position, err := canonicalGradientStopPosition(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("color stop %d position %q: %w", i, parts[1], err)
+			}
+			colorStops = append(colorStops, ColorStop{Color: parts[0], Position: position})
 		default:
-			continue
+			return nil, fmt.Errorf("invalid color stop %d %q", i, p)
 		}
 	}
-	return colorStops
+	return colorStops, nil
+}
+
+func canonicalGradientStopPosition(position string) (string, error) {
+	percentage := strings.HasSuffix(position, "%")
+	number := strings.TrimSuffix(position, "%")
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return "", errors.New("must be a finite number or percentage")
+	}
+	canonical := strconv.FormatFloat(value, 'g', -1, 64)
+	if percentage {
+		canonical += "%"
+	}
+	return canonical, nil
 }
 
 func GradientToSVG(gradient Gradient) string {
@@ -130,14 +153,14 @@ func LinearGradientToSVG(gradient Gradient) string {
 	x1, y1, x2, y2 := parseLinearGradientDirection(gradient.Direction)
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`<linearGradient id="%s" `, gradient.ID))
-	sb.WriteString(fmt.Sprintf(`x1="%s" y1="%s" x2="%s" y2="%s">`, x1, y1, x2, y2))
+	sb.WriteString(fmt.Sprintf(`<linearGradient id="%s" `, html.EscapeString(gradient.ID)))
+	sb.WriteString(fmt.Sprintf(`x1="%s" y1="%s" x2="%s" y2="%s">`, html.EscapeString(x1), html.EscapeString(y1), html.EscapeString(x2), html.EscapeString(y2)))
 	sb.WriteString("\n")
 
 	totalStops := len(gradient.ColorStops)
 	for i, cs := range gradient.ColorStops {
 		offset := gradientStopOffset(cs.Position, i, totalStops)
-		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, offset, cs.Color))
+		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, html.EscapeString(offset), html.EscapeString(cs.Color)))
 		sb.WriteString("\n")
 	}
 	sb.WriteString(`</linearGradient>`)
@@ -214,12 +237,12 @@ func parseLinearGradientDirection(direction string) (x1, y1, x2, y2 string) {
 
 func RadialGradientToSVG(gradient Gradient) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`<radialGradient id="%s">`, gradient.ID))
+	sb.WriteString(fmt.Sprintf(`<radialGradient id="%s">`, html.EscapeString(gradient.ID)))
 	sb.WriteString("\n")
 	totalStops := len(gradient.ColorStops)
 	for i, cs := range gradient.ColorStops {
 		offset := gradientStopOffset(cs.Position, i, totalStops)
-		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, offset, cs.Color))
+		sb.WriteString(fmt.Sprintf(`<stop offset="%s" stop-color="%s" />`, html.EscapeString(offset), html.EscapeString(cs.Color)))
 		sb.WriteString("\n")
 	}
 	sb.WriteString(`</radialGradient>`)

--- a/lib/color/gradient_test.go
+++ b/lib/color/gradient_test.go
@@ -2,6 +2,7 @@ package color
 
 import (
 	"encoding/xml"
+	"io"
 	"strings"
 	"testing"
 )
@@ -39,5 +40,84 @@ func TestOneStopGradientToSVG(t *testing.T) {
 				t.Fatalf("stop offset = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestParseGradientValidatesStopPositions(t *testing.T) {
+	t.Parallel()
+
+	for _, gradient := range []string{
+		`linear-gradient(red 0%"/><script>document.documentElement.dataset.pwned=1</script><!--, blue --><stop/>)`,
+		`radial-gradient(red calc(1%), blue)`,
+		`linear-gradient(red NaN, blue)`,
+		`linear-gradient(red +Inf%, blue)`,
+		`linear-gradient(red 20px, blue)`,
+	} {
+		gradient := gradient
+		t.Run(gradient, func(t *testing.T) {
+			t.Parallel()
+			if parsed, err := ParseGradient(gradient); err == nil {
+				t.Fatalf("ParseGradient(%q) = %#v, want an invalid-position error", gradient, parsed)
+			}
+			if ValidColor(gradient) {
+				t.Fatalf("ValidColor(%q) = true", gradient)
+			}
+		})
+	}
+
+	parsed, err := ParseGradient(`linear-gradient(red +.5%, blue 1e2)`)
+	if err != nil {
+		t.Fatalf("ParseGradient() error = %v", err)
+	}
+	if got, want := parsed.ColorStops[0].Position, "0.5%"; got != want {
+		t.Fatalf("first canonical position = %q, want %q", got, want)
+	}
+	if got, want := parsed.ColorStops[1].Position, "100"; got != want {
+		t.Fatalf("second canonical position = %q, want %q", got, want)
+	}
+}
+
+func TestGradientToSVGEscapesConstructedAttributes(t *testing.T) {
+	t.Parallel()
+
+	wantOffset := `0%"/><script onload="alert(1)">x</script><!--`
+	source := GradientToSVG(Gradient{
+		Type: "linear",
+		ID:   `gradient" onload="alert(1)`,
+		ColorStops: []ColorStop{{
+			Color:    `red" onload="alert(1)`,
+			Position: wantOffset,
+		}},
+	})
+
+	decoder := xml.NewDecoder(strings.NewReader(source))
+	decoder.Strict = true
+	foundOffset := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("GradientToSVG() emitted invalid XML: %v\n%s", err, source)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(start.Name.Local, "script") {
+			t.Fatalf("GradientToSVG() emitted an injected script element: %s", source)
+		}
+		for _, attr := range start.Attr {
+			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+				t.Fatalf("GradientToSVG() emitted an event-handler attribute %q: %s", attr.Name.Local, source)
+			}
+			if start.Name.Local == "stop" && attr.Name.Local == "offset" && attr.Value == wantOffset {
+				foundOffset = true
+			}
+		}
+	}
+	if !foundOffset {
+		t.Fatalf("GradientToSVG() did not preserve the escaped offset as data: %s", source)
 	}
 }


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

Gradient colors were validated, but the optional position after each color was copied verbatim into an SVG `<stop offset="...">` attribute. A D2 author could use a quoted gradient value whose position closes that attribute and inserts a real `<script>` element or event-handler attribute. The compiler accepted the value as a color, and the SVG serializer emitted the injected markup.

This is content-driven SVG XSS. It can execute when a generated SVG is opened directly or embedded in an active same-origin SVG/HTML context. It affects SVG generation; it is not merely malformed output or a visual-only CSS trick.

### What changed

- Require every explicit gradient stop position to be a finite number or percentage.
- Canonicalize accepted positions before storing them, so the serializer never reuses attacker-controlled syntax.
- XML-escape gradient IDs, vectors, offsets, and colors as defense in depth for callers that construct `Gradient` values directly.
- Add parser, serializer, and end-to-end compiler regressions for linear and radial gradients, including strict XML parsing and checks for script/event-handler injection.

Normal numeric and percentage stops remain supported. Values such as `NaN`, infinities, CSS units, functions, or markup are rejected with an invalid-color diagnostic.

### Verification

- `go test ./lib/color ./d2compiler ./d2renderers/d2scenebuild ./d2renderers/d2svg`
- `go test ./...`
- `go vet ./...`
