### PR TITLE
security: reject cyclic composite variables

### DIFF
--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -70,6 +70,194 @@ func TestClassReferenceCycle(t *testing.T) {
 class-cycle.d2:1:17: class "x" forms a reference cycle`)
 }
 
+func TestCompositeVariableCycles(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		dsl  string
+		want string
+	}{
+		{
+			name: "self_descendant",
+			dsl: `vars: {
+  x: {
+    y: ${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:3:8: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "indirect",
+			dsl: `vars: {
+  x: {
+    through-y: ${y}
+  }
+  y: {
+    through-x: ${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:6:16: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "edge",
+			dsl: `vars: {
+  x: {
+    a -> b: ${x}
+  }
+}`,
+			want: `variable-cycle.d2:3:13: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "map_self_spread",
+			dsl: `vars: {
+  x: {
+    ...${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:3:5: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "map_indirect_spread",
+			dsl: `vars: {
+  x: {
+    ...${y}
+  }
+  y: {
+    ...${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:3:5: cyclic composite variable reference "y"
+variable-cycle.d2:6:5: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "map_nested_indirect_spread",
+			dsl: `vars: {
+  x: {
+    nested: {
+      ...${y}
+    }
+  }
+  y: {
+    ...${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:4:7: cyclic composite variable reference "y"
+variable-cycle.d2:8:5: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "edge_map_nested_indirect_spread",
+			dsl: `vars: {
+  x: {
+    a -> b: {
+      ...${y}
+    }
+  }
+  y: {
+    ...${x}
+  }
+}
+a: ${x}`,
+			want: `variable-cycle.d2:4:7: cyclic composite variable reference "y"
+variable-cycle.d2:8:5: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "array_self_spread",
+			dsl: `vars: {
+  x: [...${x}]
+}
+a.class: ${x}`,
+			want: `variable-cycle.d2:2:7: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "array_indirect_spread",
+			dsl: `vars: {
+  x: [...${y}]
+  y: [...${x}]
+}
+a.class: ${x}`,
+			want: `variable-cycle.d2:2:7: cyclic composite variable reference "y"
+variable-cycle.d2:3:7: cyclic composite variable reference "x"`,
+		},
+		{
+			name: "array_nested_indirect_spread",
+			dsl: `vars: {
+  x: [[...${y}]]
+  y: [...${x}]
+}
+a.class: ${x}`,
+			want: `variable-cycle.d2:3:7: cyclic composite variable reference "x"`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := d2compiler.Compile("variable-cycle.d2", strings.NewReader(tc.dsl), nil)
+			assert.ErrorString(t, err, tc.want)
+		})
+	}
+}
+
+func TestCompositeVariableAliasingRemainsValid(t *testing.T) {
+	t.Parallel()
+
+	g, _, err := d2compiler.Compile("variable-alias.d2", strings.NewReader(`vars: {
+  x: {
+    child
+  }
+}
+a: ${x}
+b: ${x}`), nil)
+	assert.Success(t, err)
+	assert.Equal(t, 4, len(g.Objects))
+	assert.String(t, "a.child", g.Objects[1].AbsID())
+	assert.String(t, "b.child", g.Objects[3].AbsID())
+}
+
+func TestCompositeVariableSpreadsRemainValid(t *testing.T) {
+	t.Parallel()
+
+	g, _, err := d2compiler.Compile("variable-spread.d2", strings.NewReader(`vars: {
+  children: {
+    child
+  }
+  tags: [one; two]
+}
+a: {
+  ...${children}
+  class: [...${tags}]
+}`), nil)
+	assert.Success(t, err)
+	assert.Equal(t, 2, len(g.Objects))
+	assert.String(t, "a.child", g.Objects[1].AbsID())
+	assert.Equal(t, 2, len(g.Objects[0].Attributes.Classes))
+	assert.String(t, "one", g.Objects[0].Attributes.Classes[0])
+	assert.String(t, "two", g.Objects[0].Attributes.Classes[1])
+}
+
+func TestCompositeVariableForwardSpreadFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := d2compiler.Compile("variable-forward-spread.d2", strings.NewReader(`vars: {
+  x: {
+    ...${y}
+  }
+  y: {
+    ...${z}
+  }
+  z: {
+    leaf
+  }
+}
+a: ${x}`), nil)
+	assert.ErrorString(t, err, `variable-forward-spread.d2:3:5: cannot spread composite variable "y" before its spread substitutions are resolved`)
+}
+
 func TestEdgeLinkBecomesLabel(t *testing.T) {
 	t.Parallel()
 

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -43,7 +43,10 @@ type compiler struct {
 	// and glob state cannot leak between import sites.
 	parsedImports   map[string]*d2ast.Map
 	importTemplates map[string]*importTemplate
-	utf16Pos        bool
+	// Composite maps may be revisited through valid variable aliases. Report a
+	// rejected cycle once at its source substitution rather than once per alias.
+	reportedCompositeCycles map[*d2ast.Substitution]struct{}
+	utf16Pos                bool
 
 	// Stack of globs that must be recomputed at each new object in and below the current scope.
 	globContextStack [][]*globContext
@@ -95,10 +98,11 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 		ctx: ctx,
 		fs:  opts.FS,
 
-		seenImports:     make(map[string]struct{}),
-		parsedImports:   make(map[string]*d2ast.Map),
-		importTemplates: make(map[string]*importTemplate),
-		utf16Pos:        opts.UTF16Pos,
+		seenImports:             make(map[string]struct{}),
+		parsedImports:           make(map[string]*d2ast.Map),
+		importTemplates:         make(map[string]*importTemplate),
+		reportedCompositeCycles: make(map[*d2ast.Substitution]struct{}),
+		utf16Pos:                opts.UTF16Pos,
 	}
 	m := &Map{}
 	m.initRoot()
@@ -283,6 +287,13 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 					c.errorf(node.LastRef().AST(), `could not resolve variable "%s"`, strings.Join(box.Substitution.IDA(), "."))
 					return
 				}
+				if resolvedField.Composite != nil && substitutionUsesComposite(node, box.Substitution.Spread) {
+					if compositeContainsNode(resolvedField.Composite, node) ||
+						(box.Substitution.Spread && c.spreadCompositeReferencesNode(resolvedField.Composite, node, varsStack)) {
+						c.reportCompositeCycle(box.Substitution)
+						return
+					}
+				}
 				if box.Substitution.Spread {
 					if resolvedField.Composite == nil {
 						c.errorf(box.Substitution, "cannot spread non-composite")
@@ -305,6 +316,10 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 					case *Field:
 						m := ParentMap(n)
 						if resolvedField.Map() != nil {
+							if hasUnresolvedMapSpread(resolvedField.Map()) {
+								c.errorf(box.Substitution, `cannot spread composite variable "%s" before its spread substitutions are resolved`, strings.Join(box.Substitution.IDA(), "."))
+								return
+							}
 							expandSubstitutionIndexed(m, resolvedField.Map(), n)
 						}
 						// Remove the placeholder field
@@ -405,6 +420,162 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 		s.Value = preprocessedValue
 	}
 	return removedField
+}
+
+func (c *compiler) reportCompositeCycle(substitution *d2ast.Substitution) {
+	if _, reported := c.reportedCompositeCycles[substitution]; reported {
+		return
+	}
+	if c.reportedCompositeCycles == nil {
+		c.reportedCompositeCycles = make(map[*d2ast.Substitution]struct{})
+	}
+	c.reportedCompositeCycles[substitution] = struct{}{}
+	c.errorf(substitution, `cyclic composite variable reference "%s"`, strings.Join(substitution.IDA(), "."))
+}
+
+func substitutionUsesComposite(node Node, spread bool) bool {
+	switch node.(type) {
+	case *Field, *Edge:
+		return true
+	case *Scalar:
+		return spread
+	default:
+		return false
+	}
+}
+
+// spreadCompositeReferencesNode follows unresolved spread substitutions
+// anywhere below composite without mutating it. Map spread expansion copies
+// fields, while array spread expansion shares values, so a pointer-only
+// containment check cannot see an indirect cycle until after the first
+// expansion. Following the spread dependencies first keeps cycle rejection
+// ahead of every mutation.
+func (c *compiler) spreadCompositeReferencesNode(composite Composite, target Node, varsStack []*Map) bool {
+	stack := []Composite{composite}
+	seen := make(map[Composite]struct{})
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := seen[current]; ok {
+			continue
+		}
+		seen[current] = struct{}{}
+		if compositeContainsNode(current, target) {
+			return true
+		}
+
+		for _, candidate := range compositeSpreadNodes(current) {
+			primary := candidate.Primary()
+			if primary == nil {
+				continue
+			}
+			unquoted, ok := primary.Value.(*d2ast.UnquotedString)
+			if !ok {
+				continue
+			}
+			for _, box := range unquoted.Value {
+				if box.Substitution == nil || !box.Substitution.Spread {
+					continue
+				}
+				for i, vars := range varsStack {
+					resolved := c.resolveSubstitution(vars, candidate, box.Substitution, i == 0)
+					if resolved == nil {
+						continue
+					}
+					if resolved.Composite != nil {
+						stack = append(stack, resolved.Composite)
+					}
+					break
+				}
+			}
+		}
+	}
+	return false
+}
+
+func compositeSpreadNodes(composite Composite) (nodes []Node) {
+	walkComposite(composite, func(n Node) bool {
+		switch n := n.(type) {
+		case *Field:
+			if n != nil && n.Name == nil {
+				nodes = append(nodes, n)
+			}
+		case *Scalar:
+			if n != nil {
+				if _, ok := n.Parent().(*Array); ok {
+					nodes = append(nodes, n)
+				}
+			}
+		}
+		return false
+	})
+	return nodes
+}
+
+func hasUnresolvedMapSpread(m *Map) bool {
+	for _, field := range m.Fields {
+		if field == nil || field.Name == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// compositeContainsNode reports whether target is reachable through a
+// composite's child structure. Composite substitutions deliberately share the
+// resolved value, so attaching a composite below one of its own descendants
+// would turn the IR tree into a cycle. Use an iterative walk with a visited set
+// because earlier valid substitutions can make the structure a DAG, and the
+// check must also terminate defensively if handed an already-cyclic IR.
+func compositeContainsNode(composite Composite, target Node) bool {
+	return walkComposite(composite, func(n Node) bool {
+		return n == target
+	})
+}
+
+func walkComposite(composite Composite, visit func(Node) bool) bool {
+	stack := []Node{composite}
+	seen := make(map[Node]struct{})
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		if visit(n) {
+			return true
+		}
+
+		switch n := n.(type) {
+		case *Map:
+			if n == nil {
+				continue
+			}
+			for _, f := range n.Fields {
+				stack = append(stack, f)
+			}
+			for _, e := range n.Edges {
+				stack = append(stack, e)
+			}
+		case *Field:
+			if n != nil && n.Composite != nil {
+				stack = append(stack, n.Composite)
+			}
+		case *Edge:
+			if n != nil && n.Map_ != nil {
+				stack = append(stack, n.Map_)
+			}
+		case *Array:
+			if n == nil {
+				continue
+			}
+			for _, value := range n.Values {
+				stack = append(stack, value)
+			}
+		}
+	}
+	return false
 }
 
 func (c *compiler) collectVariables(vars *Map, variables map[string]string) {

--- a/d2ir/substitution_cycle_test.go
+++ b/d2ir/substitution_cycle_test.go
@@ -1,0 +1,16 @@
+package d2ir
+
+import "testing"
+
+func TestCompositeContainsNodeHandlesExistingCycle(t *testing.T) {
+	root := &Map{}
+	child := &Field{Composite: root}
+	root.Fields = []*Field{child}
+
+	if !compositeContainsNode(root, child) {
+		t.Fatal("compositeContainsNode did not find child in cyclic structure")
+	}
+	if compositeContainsNode(root, &Field{}) {
+		t.Fatal("compositeContainsNode found unrelated node in cyclic structure")
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

Composite variable substitution could attach a map or array beneath one of its own descendants, creating a cyclic IR graph. Later compiler and merge passes assume that graph is a tree and recurse through it indefinitely. A tiny attacker-controlled diagram such as a map containing `${x}` inside `x` therefore grows the Go stack until the runtime terminates the process; nested map, edge, and array spreads provided additional paths to the same result.

This is an availability vulnerability for servers, editor workers, and other long-lived processes that compile untrusted D2. Go's fatal stack-overflow path cannot be converted into an ordinary compile error with `recover`.

### What changed

- Check whether a resolved composite can reach the substitution target before attaching or spreading it.
- Walk the full composite subtree iteratively with a visited set, including named-field composites, edge maps, and nested arrays.
- Follow unresolved spread dependencies before mutation so direct, indirect, and nested spread cycles are rejected.
- Deduplicate diagnostics when valid aliases revisit the same rejected substitution.
- Fail closed with a diagnostic for a forward map-spread case that previously panicked during merge.
- Add direct, indirect, edge, map-spread, array-spread, and nested-carrier regressions, plus positive tests for ordinary aliasing and spreads.

The pre-fix nested repro accumulated tens of thousands of recursive merge frames. It now exits normally with a source-located `cyclic composite variable reference` error.

### Verification

- Focused composite-cycle and existing-cycle tests
- Direct CLI subprocess repro of the former runaway merge
- `go test ./...`
- `go vet ./...`
