### PR TITLE
security: contain board output publication races

### DIFF
--- a/d2cli/board_output.go
+++ b/d2cli/board_output.go
@@ -430,7 +430,7 @@ func (w *boardOutputWorkspace) publish() (touched bool, err error) {
 	return publishBoardOutputWorkspace(w)
 }
 
-func (w *boardOutputWorkspace) preflightMerge() ([]stagedBoardOutput, error) {
+func (w *boardOutputWorkspace) preflightMerge(final *boardOutputRoot) ([]stagedBoardOutput, error) {
 	var entries []stagedBoardOutput
 	err := filepath.WalkDir(w.stageRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -452,7 +452,11 @@ func (w *boardOutputWorkspace) preflightMerge() ([]stagedBoardOutput, error) {
 			return fmt.Errorf("staged board output %q is not a regular file or directory", path)
 		}
 
-		destinationInfo, err := os.Lstat(destination)
+		if final == nil {
+			entries = append(entries, stagedBoardOutput{rel: rel, mode: info.Mode(), dir: info.IsDir()})
+			return nil
+		}
+		destinationInfo, err := final.handle.Lstat(rel)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}

--- a/d2cli/board_output_publish.go
+++ b/d2cli/board_output_publish.go
@@ -2,6 +2,7 @@ package d2cli
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -47,7 +48,14 @@ func publishBoardOutputWorkspace(w *boardOutputWorkspace) (touched bool, err err
 	if err := validateBoardOutputRoot(w.finalRoot); err != nil {
 		return false, err
 	}
-	entries, err := w.preflightMerge()
+	final, err := openExistingBoardOutputRoot(w.finalRoot)
+	if err != nil {
+		return false, err
+	}
+	if final != nil {
+		defer func() { err = errors.Join(err, final.close()) }()
+	}
+	entries, err := w.preflightMerge(final)
 	if err != nil {
 		return false, err
 	}
@@ -63,7 +71,19 @@ func publishBoardOutputWorkspace(w *boardOutputWorkspace) (touched bool, err err
 		return false, err
 	}
 
-	if _, err := os.Lstat(w.finalRoot); errors.Is(err, os.ErrNotExist) {
+	if final == nil {
+		_, statErr := os.Lstat(w.finalRoot)
+		if statErr == nil {
+			final, err = openBoardOutputRoot(w.finalRoot)
+			if err != nil {
+				return false, err
+			}
+			defer func() { err = errors.Join(err, final.close()) }()
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return false, fmt.Errorf("inspect board output root: %w", statErr)
+		}
+	}
+	if final == nil {
 		if w.beforePublish != nil {
 			if err := w.beforePublish(w.finalRoot); err != nil {
 				return false, err
@@ -80,20 +100,73 @@ func publishBoardOutputWorkspace(w *boardOutputWorkspace) (touched bool, err err
 		}
 		w.stageRoot = ""
 		return true, nil
-	} else if err != nil {
-		return false, fmt.Errorf("inspect board output root: %w", err)
 	}
 
-	previous, _, err := readBoardOutputManifest(w.finalRoot)
+	previous, _, err := readBoardOutputManifestRoot(final)
 	if err != nil {
 		return false, err
 	}
-	transaction := boardOutputTransaction{workspace: w}
+	transaction := boardOutputTransaction{workspace: w, root: final}
 	if err := transaction.apply(entries, previous, manifest, manifestSource); err != nil {
 		rollbackErr := transaction.rollback()
 		return rollbackErr != nil, errors.Join(err, rollbackErr)
 	}
 	return transaction.touched(), nil
+}
+
+// boardOutputRoot keeps publication anchored to the directory that was
+// verified when it was opened. On supported platforms, os.Root resolves every
+// later operation relative to that handle and rejects symlinks that escape it.
+// os.Root documents weaker rename and symlink guarantees on plan9 and js; D2's
+// native CLI targets use the descriptor/handle-backed implementations.
+type boardOutputRoot struct {
+	path   string
+	handle *os.Root
+}
+
+func openExistingBoardOutputRoot(path string) (*boardOutputRoot, error) {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect board output root: %w", err)
+	}
+	return openBoardOutputRoot(path)
+}
+
+func openBoardOutputRoot(path string) (*boardOutputRoot, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect board output root: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("board output root %q must be a real directory", path)
+	}
+	handle, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("open board output root %q: %w", path, err)
+	}
+	openedInfo, statErr := handle.Stat(".")
+	if statErr != nil || !os.SameFile(info, openedInfo) {
+		return nil, errors.Join(
+			fmt.Errorf("board output root %q changed while opening it", path),
+			statErr,
+			handle.Close(),
+		)
+	}
+	return &boardOutputRoot{path: path, handle: handle}, nil
+}
+
+func (r *boardOutputRoot) close() error {
+	if err := r.handle.Close(); err != nil {
+		return fmt.Errorf("close board output root %q: %w", r.path, err)
+	}
+	return nil
+}
+
+func (r *boardOutputRoot) display(rel string) string {
+	return filepath.Join(r.path, rel)
 }
 
 func (w *boardOutputWorkspace) buildManifest(entries []stagedBoardOutput) (boardOutputManifest, error) {
@@ -144,9 +217,18 @@ func writeBoardOutputManifest(path string, manifest boardOutputManifest) (err er
 	return nil
 }
 
-func readBoardOutputManifest(root string) (boardOutputManifest, bool, error) {
-	path := filepath.Join(root, boardOutputManifestName)
-	info, err := os.Lstat(path)
+func readBoardOutputManifest(root string) (manifest boardOutputManifest, exists bool, err error) {
+	final, err := openExistingBoardOutputRoot(root)
+	if err != nil || final == nil {
+		return boardOutputManifest{}, false, err
+	}
+	defer func() { err = errors.Join(err, final.close()) }()
+	return readBoardOutputManifestRoot(final)
+}
+
+func readBoardOutputManifestRoot(root *boardOutputRoot) (boardOutputManifest, bool, error) {
+	path := root.display(boardOutputManifestName)
+	info, err := root.handle.Lstat(boardOutputManifestName)
 	if errors.Is(err, os.ErrNotExist) {
 		return boardOutputManifest{}, false, nil
 	}
@@ -159,7 +241,7 @@ func readBoardOutputManifest(root string) (boardOutputManifest, bool, error) {
 	if info.Size() > maxBoardOutputManifestBytes {
 		return boardOutputManifest{}, false, fmt.Errorf("board output manifest exceeds %d bytes", maxBoardOutputManifestBytes)
 	}
-	file, err := os.Open(path)
+	file, err := openBoardOutputRootRegularFile(root, boardOutputManifestName, info)
 	if err != nil {
 		return boardOutputManifest{}, false, fmt.Errorf("open board output manifest: %w", err)
 	}
@@ -181,7 +263,7 @@ func readBoardOutputManifest(root string) (boardOutputManifest, bool, error) {
 	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
 		return boardOutputManifest{}, false, fmt.Errorf("decode board output manifest: trailing data")
 	}
-	if err := validateBoardOutputManifest(root, manifest); err != nil {
+	if err := validateBoardOutputManifest(root.path, manifest); err != nil {
 		return boardOutputManifest{}, false, err
 	}
 	return manifest, true, nil
@@ -252,10 +334,65 @@ func boardOutputFileDigest(path string) (digest string, err error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+func boardOutputRootFileDigest(root *boardOutputRoot, rel string, expected fs.FileInfo) (digest string, err error) {
+	file, err := openBoardOutputRootRegularFile(root, rel, expected)
+	if err != nil {
+		return "", err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func openBoardOutputRootRegularFile(root *boardOutputRoot, rel string, expected fs.FileInfo) (*os.File, error) {
+	file, err := root.handle.Open(rel)
+	if err != nil {
+		return nil, err
+	}
+	info, statErr := file.Stat()
+	if statErr != nil || !info.Mode().IsRegular() || expected != nil && !os.SameFile(expected, info) {
+		if statErr == nil {
+			if !info.Mode().IsRegular() {
+				statErr = fmt.Errorf("not a regular file")
+			} else {
+				statErr = fmt.Errorf("file changed while opening it")
+			}
+		}
+		return nil, errors.Join(
+			fmt.Errorf("open board output %q: %w", root.display(rel), statErr),
+			file.Close(),
+		)
+	}
+	return file, nil
+}
+
+func copyBoardOutputRootFile(root *boardOutputRoot, sourceRel, destination string, sourceInfo fs.FileInfo, mode fs.FileMode, exclusive bool) (err error) {
+	input, err := openBoardOutputRootRegularFile(root, sourceRel, sourceInfo)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, input.Close()) }()
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if exclusive {
+		flags |= os.O_EXCL
+	}
+	output, err := os.OpenFile(destination, flags, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, output.Close()) }()
+	if _, err := io.Copy(output, input); err != nil {
+		return err
+	}
+	return output.Chmod(mode)
+}
+
 type boardOutputFileChange struct {
 	rel            string
 	source         string
-	destination    string
 	remove         bool
 	existed        bool
 	originalInfo   fs.FileInfo
@@ -268,12 +405,13 @@ type boardOutputFileChange struct {
 }
 
 type boardOutputRemovedDirectory struct {
-	path string
+	rel  string
 	mode fs.FileMode
 }
 
 type boardOutputTransaction struct {
 	workspace       *boardOutputWorkspace
+	root            *boardOutputRoot
 	changes         []*boardOutputFileChange
 	appliedChanges  []*boardOutputFileChange
 	createdDirs     []string
@@ -296,7 +434,6 @@ func (t *boardOutputTransaction) apply(entries []stagedBoardOutput, previous, cu
 		}
 		t.changes = append(t.changes, &boardOutputFileChange{
 			rel: entry.rel, source: filepath.Join(t.workspace.stageRoot, entry.rel),
-			destination: filepath.Join(t.workspace.finalRoot, entry.rel),
 		})
 	}
 	staleChanges, err := t.staleFileChanges(previous, currentFiles)
@@ -306,7 +443,6 @@ func (t *boardOutputTransaction) apply(entries []stagedBoardOutput, previous, cu
 	t.changes = append(t.changes, staleChanges...)
 	manifestChange := &boardOutputFileChange{
 		rel: boardOutputManifestName, source: manifestSource,
-		destination: filepath.Join(t.workspace.finalRoot, boardOutputManifestName),
 	}
 
 	allChanges := append(append([]*boardOutputFileChange(nil), t.changes...), manifestChange)
@@ -317,7 +453,7 @@ func (t *boardOutputTransaction) apply(entries []stagedBoardOutput, previous, cu
 		if !entry.dir || entry.rel == "." {
 			continue
 		}
-		if err := t.ensureDirectory(filepath.Join(t.workspace.finalRoot, entry.rel), entry.mode.Perm()); err != nil {
+		if err := t.ensureDirectory(entry.rel, entry.mode.Perm()); err != nil {
 			return err
 		}
 	}
@@ -340,11 +476,11 @@ func (t *boardOutputTransaction) staleFileChanges(previous boardOutputManifest, 
 	for _, file := range previous.Files {
 		rel := filepath.FromSlash(file.Path)
 		if currentRel, ok := currentFiles[boardOutputCollisionKey(rel)]; ok {
-			if currentRel == rel || sameBoardOutputPath(t.workspace.finalRoot, rel, currentRel) {
+			if currentRel == rel || sameBoardOutputPathRoot(t.root, rel, currentRel) {
 				continue
 			}
 		}
-		info, err := lstatBoardOutputPath(t.workspace.finalRoot, rel)
+		info, err := t.root.handle.Lstat(rel)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -354,8 +490,7 @@ func (t *boardOutputTransaction) staleFileChanges(previous boardOutputManifest, 
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 			continue
 		}
-		destination := filepath.Join(t.workspace.finalRoot, rel)
-		digest, err := boardOutputFileDigest(destination)
+		digest, err := boardOutputRootFileDigest(t.root, rel, info)
 		if err != nil {
 			return nil, fmt.Errorf("hash prior board output %q: %w", rel, err)
 		}
@@ -365,7 +500,7 @@ func (t *boardOutputTransaction) staleFileChanges(previous boardOutputManifest, 
 			continue
 		}
 		changes = append(changes, &boardOutputFileChange{
-			rel: rel, destination: destination, remove: true,
+			rel: rel, remove: true,
 			expectedSHA256: strings.ToLower(file.SHA256),
 		})
 	}
@@ -375,7 +510,7 @@ func (t *boardOutputTransaction) staleFileChanges(previous boardOutputManifest, 
 func (t *boardOutputTransaction) prepareBackups(changes []*boardOutputFileChange) error {
 	var backupRoot string
 	for index, change := range changes {
-		info, err := lstatBoardOutputPath(t.workspace.finalRoot, change.rel)
+		info, err := t.root.handle.Lstat(change.rel)
 		if errors.Is(err, os.ErrNotExist) {
 			if change.remove {
 				continue
@@ -387,7 +522,7 @@ func (t *boardOutputTransaction) prepareBackups(changes []*boardOutputFileChange
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			return fmt.Errorf("board output path %q is not a regular file", change.destination)
+			return fmt.Errorf("board output path %q is not a regular file", t.root.display(change.rel))
 		}
 		change.existed = true
 		change.originalInfo = info
@@ -399,13 +534,13 @@ func (t *boardOutputTransaction) prepareBackups(changes []*boardOutputFileChange
 			}
 		}
 		change.backup = filepath.Join(backupRoot, fmt.Sprintf("%06d", index))
-		if err := copyBoardOutputFile(change.destination, change.backup, change.originalMode, true); err != nil {
-			return fmt.Errorf("back up board output %q: %w", change.destination, err)
+		if err := copyBoardOutputRootFile(t.root, change.rel, change.backup, change.originalInfo, change.originalMode, true); err != nil {
+			return fmt.Errorf("back up board output %q: %w", t.root.display(change.rel), err)
 		}
 		if change.remove {
 			digest, err := boardOutputFileDigest(change.backup)
 			if err != nil {
-				return fmt.Errorf("verify board output backup %q: %w", change.destination, err)
+				return fmt.Errorf("verify board output backup %q: %w", t.root.display(change.rel), err)
 			}
 			if digest != change.expectedSHA256 {
 				// The file was edited while publication was being prepared. Keep it
@@ -417,16 +552,17 @@ func (t *boardOutputTransaction) prepareBackups(changes []*boardOutputFileChange
 	return nil
 }
 
-func (t *boardOutputTransaction) ensureDirectory(path string, mode fs.FileMode) error {
-	info, err := os.Lstat(path)
+func (t *boardOutputTransaction) ensureDirectory(rel string, mode fs.FileMode) error {
+	path := t.root.display(rel)
+	info, err := t.root.handle.Lstat(rel)
 	if errors.Is(err, os.ErrNotExist) {
-		if err := t.beforeMutation(path); err != nil {
+		if err := t.beforeMutation(rel); err != nil {
 			return err
 		}
-		if err := os.Mkdir(path, mode); err != nil {
+		if err := t.root.handle.Mkdir(rel, mode); err != nil {
 			return fmt.Errorf("create board output directory %q: %w", path, err)
 		}
-		t.createdDirs = append(t.createdDirs, path)
+		t.createdDirs = append(t.createdDirs, rel)
 		t.visibleMutation = true
 		return nil
 	}
@@ -443,16 +579,16 @@ func (t *boardOutputTransaction) applyChange(change *boardOutputFileChange) erro
 	if change.skip || change.remove && !change.existed {
 		return nil
 	}
-	if err := t.beforeMutation(change.destination); err != nil {
+	if err := t.beforeMutation(change.rel); err != nil {
 		return err
 	}
-	if err := verifyBoardOutputFileState(change); err != nil {
+	if err := t.verifyBoardOutputFileState(change); err != nil {
 		return err
 	}
 	if change.remove {
-		digest, err := boardOutputFileDigest(change.destination)
+		digest, err := boardOutputRootFileDigest(t.root, change.rel, change.originalInfo)
 		if err != nil {
-			return fmt.Errorf("verify stale board output %q: %w", change.destination, err)
+			return fmt.Errorf("verify stale board output %q: %w", t.root.display(change.rel), err)
 		}
 		if digest != change.expectedSHA256 {
 			// The user changed the file after it was backed up. Preserve it and
@@ -460,8 +596,8 @@ func (t *boardOutputTransaction) applyChange(change *boardOutputFileChange) erro
 			change.skip = true
 			return nil
 		}
-		if err := os.Remove(change.destination); err != nil {
-			return fmt.Errorf("remove stale board output %q: %w", change.destination, err)
+		if err := t.root.handle.Remove(change.rel); err != nil {
+			return fmt.Errorf("remove stale board output %q: %w", t.root.display(change.rel), err)
 		}
 		change.applied = true
 		t.appliedChanges = append(t.appliedChanges, change)
@@ -469,7 +605,7 @@ func (t *boardOutputTransaction) applyChange(change *boardOutputFileChange) erro
 		return nil
 	}
 
-	applied, installedInfo, err := installBoardOutputFile(change.source, change.destination, change.existed)
+	applied, installedInfo, err := installBoardOutputFile(t.root, change.source, change.rel, change.existed)
 	change.applied = applied
 	change.installedInfo = installedInfo
 	if applied {
@@ -482,8 +618,9 @@ func (t *boardOutputTransaction) applyChange(change *boardOutputFileChange) erro
 	return nil
 }
 
-func verifyBoardOutputFileState(change *boardOutputFileChange) error {
-	info, err := os.Lstat(change.destination)
+func (t *boardOutputTransaction) verifyBoardOutputFileState(change *boardOutputFileChange) error {
+	path := t.root.display(change.rel)
+	info, err := t.root.handle.Lstat(change.rel)
 	if !change.existed {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -491,68 +628,69 @@ func verifyBoardOutputFileState(change *boardOutputFileChange) error {
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("board output path %q appeared during publication", change.destination)
+		return fmt.Errorf("board output path %q appeared during publication", path)
 	}
 	if err != nil {
-		return fmt.Errorf("inspect board output %q before publication: %w", change.destination, err)
+		return fmt.Errorf("inspect board output %q before publication: %w", path, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !os.SameFile(change.originalInfo, info) {
-		return fmt.Errorf("board output path %q changed during publication", change.destination)
+		return fmt.Errorf("board output path %q changed during publication", path)
 	}
 	return nil
 }
 
-func installBoardOutputFile(source, destination string, replacing bool) (applied bool, installedInfo fs.FileInfo, err error) {
-	temporary, err := prepareBoardOutputFile(source, filepath.Dir(destination))
+func installBoardOutputFile(root *boardOutputRoot, source, destinationRel string, replacing bool) (applied bool, installedInfo fs.FileInfo, err error) {
+	destination := root.display(destinationRel)
+	temporaryRel, temporaryInfo, err := prepareBoardOutputFile(root, source, filepath.Dir(destinationRel))
 	if err != nil {
 		return false, nil, fmt.Errorf("prepare board output %q: %w", destination, err)
 	}
 	defer func() {
-		if removeErr := os.Remove(temporary); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		if removeErr := removeBoardOutputFileIfSame(root, temporaryRel, temporaryInfo); removeErr != nil {
 			err = errors.Join(err, removeErr)
 		}
 	}()
 
 	if !replacing {
-		if linkErr := os.Link(temporary, destination); linkErr == nil {
-			installedInfo, err := os.Lstat(destination)
+		if linkErr := root.handle.Link(temporaryRel, destinationRel); linkErr == nil {
+			installedInfo, err := root.handle.Lstat(destinationRel)
 			if err != nil {
 				return true, nil, fmt.Errorf("inspect published board output %q: %w", destination, err)
 			}
 			return true, installedInfo, nil
-		} else if _, statErr := os.Lstat(destination); statErr == nil {
+		} else if _, statErr := root.handle.Lstat(destinationRel); statErr == nil {
 			return false, nil, fmt.Errorf("publish board output %q: destination appeared during publication", destination)
 		} else if !errors.Is(statErr, os.ErrNotExist) {
 			return false, nil, fmt.Errorf("inspect board output %q after link failure: %w", destination, statErr)
 		}
 
-		applied, installedInfo, err := copyBoardOutputFileExclusive(temporary, destination)
+		applied, installedInfo, err := copyBoardOutputFileExclusive(root, temporaryRel, temporaryInfo, destinationRel)
 		if err != nil {
 			return applied, installedInfo, fmt.Errorf("publish board output %q: %w", destination, err)
 		}
 		return applied, installedInfo, nil
 	}
 
-	if err := os.Rename(temporary, destination); err != nil {
-		if removeErr := os.Remove(destination); removeErr != nil {
+	if err := root.handle.Rename(temporaryRel, destinationRel); err != nil {
+		if removeErr := root.handle.Remove(destinationRel); removeErr != nil {
 			return false, nil, fmt.Errorf("prepare board output %q for Windows replacement: %w", destination, removeErr)
 		}
 		applied = true
-		if err := os.Rename(temporary, destination); err != nil {
+		if err := root.handle.Rename(temporaryRel, destinationRel); err != nil {
 			return true, nil, fmt.Errorf("publish board output %q: %w", destination, err)
 		}
 	} else {
 		applied = true
 	}
-	installedInfo, err = os.Lstat(destination)
+	installedInfo, err = root.handle.Lstat(destinationRel)
 	if err != nil {
 		return true, nil, fmt.Errorf("inspect published board output %q: %w", destination, err)
 	}
 	return true, installedInfo, nil
 }
 
-func copyBoardOutputFileExclusive(source, destination string) (applied bool, installedInfo fs.FileInfo, err error) {
-	input, err := os.Open(source)
+func copyBoardOutputFileExclusive(root *boardOutputRoot, sourceRel string, sourceInfo fs.FileInfo, destinationRel string) (applied bool, installedInfo fs.FileInfo, err error) {
+	input, err := openBoardOutputRootRegularFile(root, sourceRel, sourceInfo)
 	if err != nil {
 		return false, nil, err
 	}
@@ -561,7 +699,7 @@ func copyBoardOutputFileExclusive(source, destination string) (applied bool, ins
 	if err != nil {
 		return false, nil, err
 	}
-	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	output, err := root.handle.OpenFile(destinationRel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
 	if err != nil {
 		return false, nil, err
 	}
@@ -582,24 +720,27 @@ func copyBoardOutputFileExclusive(source, destination string) (applied bool, ins
 	return true, installedInfo, nil
 }
 
-func prepareBoardOutputFile(source, destinationDir string) (temporaryPath string, err error) {
+func prepareBoardOutputFile(root *boardOutputRoot, source, destinationDirRel string) (temporaryRel string, temporaryInfo fs.FileInfo, err error) {
 	input, err := os.Open(source)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	defer func() { err = errors.Join(err, input.Close()) }()
 	info, err := input.Stat()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("source is not a regular file")
+		return "", nil, fmt.Errorf("source is not a regular file")
 	}
-	temporary, err := os.CreateTemp(destinationDir, ".d2-board-file-")
+	temporaryRel, temporary, err := createBoardOutputTempFile(root, destinationDirRel)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	temporaryPath = temporary.Name()
+	createdInfo, err := temporary.Stat()
+	if err != nil {
+		return "", nil, errors.Join(err, temporary.Close(), root.handle.Remove(temporaryRel))
+	}
 	remove := true
 	closed := false
 	defer func() {
@@ -612,44 +753,63 @@ func prepareBoardOutputFile(source, destinationDir string) (temporaryPath string
 			}
 		}
 		if remove {
-			if removeErr := os.Remove(temporaryPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			if removeErr := removeBoardOutputFileIfSame(root, temporaryRel, createdInfo); removeErr != nil {
 				err = errors.Join(err, removeErr)
 			}
 		}
 	}()
 	if _, err := io.Copy(temporary, input); err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if err := temporary.Chmod(info.Mode().Perm()); err != nil {
-		return "", err
+		return "", nil, err
+	}
+	temporaryInfo, err = temporary.Stat()
+	if err != nil {
+		return "", nil, err
 	}
 	if err := temporary.Close(); err != nil {
-		return "", err
+		return "", nil, err
 	}
 	closed = true
 	remove = false
-	return temporaryPath, nil
+	return temporaryRel, temporaryInfo, nil
 }
 
-func copyBoardOutputFile(source, destination string, mode fs.FileMode, exclusive bool) (err error) {
-	input, err := os.Open(source)
+func createBoardOutputTempFile(root *boardOutputRoot, directoryRel string) (string, *os.File, error) {
+	for range 100 {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", nil, fmt.Errorf("generate temporary board output name: %w", err)
+		}
+		rel := filepath.Join(directoryRel, ".d2-board-file-"+hex.EncodeToString(random[:]))
+		file, err := root.handle.OpenFile(rel, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return "", nil, err
+		}
+		return rel, file, nil
+	}
+	return "", nil, fmt.Errorf("create unique temporary board output file")
+}
+
+func removeBoardOutputFileIfSame(root *boardOutputRoot, rel string, expected fs.FileInfo) error {
+	info, err := root.handle.Lstat(rel)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("inspect temporary board output %q: %w", root.display(rel), err)
 	}
-	defer func() { err = errors.Join(err, input.Close()) }()
-	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
-	if exclusive {
-		flags |= os.O_EXCL
+	if !os.SameFile(expected, info) {
+		return fmt.Errorf("refusing to remove changed temporary board output %q", root.display(rel))
 	}
-	output, err := os.OpenFile(destination, flags, mode)
-	if err != nil {
-		return err
+	if err := root.handle.Remove(rel); err != nil {
+		return fmt.Errorf("remove temporary board output %q: %w", root.display(rel), err)
 	}
-	defer func() { err = errors.Join(err, output.Close()) }()
-	if _, err := io.Copy(output, input); err != nil {
-		return err
-	}
-	return output.Chmod(mode)
+	return nil
 }
 
 func (t *boardOutputTransaction) removeStaleDirectories(previous, current boardOutputManifest) error {
@@ -662,7 +822,7 @@ func (t *boardOutputTransaction) removeStaleDirectories(previous, current boardO
 	for _, dir := range previous.Directories {
 		rel := filepath.FromSlash(dir)
 		if currentRel, ok := currentDirs[boardOutputCollisionKey(rel)]; ok {
-			if currentRel == rel || sameBoardOutputPath(t.workspace.finalRoot, rel, currentRel) {
+			if currentRel == rel || sameBoardOutputPathRoot(t.root, rel, currentRel) {
 				continue
 			}
 		}
@@ -672,7 +832,7 @@ func (t *boardOutputTransaction) removeStaleDirectories(previous, current boardO
 		return strings.Count(filepath.Clean(stale[i]), string(filepath.Separator)) > strings.Count(filepath.Clean(stale[j]), string(filepath.Separator))
 	})
 	for _, rel := range stale {
-		info, err := lstatBoardOutputPath(t.workspace.finalRoot, rel)
+		info, err := t.root.handle.Lstat(rel)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -682,41 +842,73 @@ func (t *boardOutputTransaction) removeStaleDirectories(previous, current boardO
 		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 			continue
 		}
-		path := filepath.Join(t.workspace.finalRoot, rel)
-		children, err := os.ReadDir(path)
+		path := t.root.display(rel)
+		children, err := readBoardOutputDirectory(t.root, rel, info)
 		if err != nil {
 			return err
 		}
 		if len(children) != 0 {
 			continue
 		}
-		if err := t.beforeMutation(path); err != nil {
+		if err := t.beforeMutation(rel); err != nil {
 			return err
 		}
-		if err := os.Remove(path); err != nil {
+		currentInfo, statErr := t.root.handle.Lstat(rel)
+		if statErr != nil || !os.SameFile(info, currentInfo) {
+			return errors.Join(fmt.Errorf("board output directory %q changed during publication", path), statErr)
+		}
+		if err := t.root.handle.Remove(rel); err != nil {
 			// A concurrent creator wins; preserve the directory rather than
 			// recursively removing anything D2 does not own.
-			if children, readErr := os.ReadDir(path); readErr == nil && len(children) != 0 {
-				continue
+			if currentInfo, statErr := t.root.handle.Lstat(rel); statErr == nil {
+				if children, readErr := readBoardOutputDirectory(t.root, rel, currentInfo); readErr == nil && len(children) != 0 {
+					continue
+				}
 			}
 			return fmt.Errorf("remove stale board output directory %q: %w", path, err)
 		}
-		t.removedDirs = append(t.removedDirs, boardOutputRemovedDirectory{path: path, mode: info.Mode().Perm()})
+		t.removedDirs = append(t.removedDirs, boardOutputRemovedDirectory{rel: rel, mode: info.Mode().Perm()})
 		t.visibleMutation = true
 	}
 	return nil
 }
 
 func sameBoardOutputPath(root, first, second string) bool {
-	firstInfo, firstErr := lstatBoardOutputPath(root, first)
-	secondInfo, secondErr := lstatBoardOutputPath(root, second)
+	opened, err := openExistingBoardOutputRoot(root)
+	if err != nil || opened == nil {
+		return false
+	}
+	defer opened.close()
+	return sameBoardOutputPathRoot(opened, first, second)
+}
+
+func sameBoardOutputPathRoot(root *boardOutputRoot, first, second string) bool {
+	firstInfo, firstErr := root.handle.Lstat(first)
+	secondInfo, secondErr := root.handle.Lstat(second)
 	return firstErr == nil && secondErr == nil && os.SameFile(firstInfo, secondInfo)
 }
 
-func (t *boardOutputTransaction) beforeMutation(path string) error {
+func readBoardOutputDirectory(root *boardOutputRoot, rel string, expected fs.FileInfo) (entries []fs.DirEntry, err error) {
+	directory, err := root.handle.Open(rel)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Join(err, directory.Close()) }()
+	info, err := directory.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || !os.SameFile(expected, info) {
+		return nil, fmt.Errorf("board output directory %q changed while opening it", root.display(rel))
+	}
+	return directory.ReadDir(-1)
+}
+
+func (t *boardOutputTransaction) beforeMutation(rel string) error {
 	if t.workspace.beforePublish == nil {
 		return nil
 	}
+	path := t.root.display(rel)
 	if err := t.workspace.beforePublish(path); err != nil {
 		return fmt.Errorf("publish board output %q: %w", path, err)
 	}
@@ -727,24 +919,27 @@ func (t *boardOutputTransaction) rollback() error {
 	var rollbackErr error
 	for index := len(t.removedDirs) - 1; index >= 0; index-- {
 		dir := t.removedDirs[index]
-		if err := os.Mkdir(dir.path, dir.mode); err != nil && !errors.Is(err, os.ErrExist) {
-			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore board output directory %q: %w", dir.path, err))
+		if err := t.root.handle.Mkdir(dir.rel, dir.mode); err != nil && !errors.Is(err, os.ErrExist) {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore board output directory %q: %w", t.root.display(dir.rel), err))
 		}
 	}
 	for index := len(t.appliedChanges) - 1; index >= 0; index-- {
 		change := t.appliedChanges[index]
-		if err := rollbackBoardOutputFile(change); err != nil {
+		if err := t.rollbackBoardOutputFile(change); err != nil {
 			rollbackErr = errors.Join(rollbackErr, err)
 		}
 	}
 	for index := len(t.createdDirs) - 1; index >= 0; index-- {
-		path := t.createdDirs[index]
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			if children, readErr := os.ReadDir(path); readErr == nil && len(children) != 0 {
-				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("refusing to remove non-empty transaction directory %q", path))
-			} else {
-				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove transaction directory %q: %w", path, err))
+		rel := t.createdDirs[index]
+		path := t.root.display(rel)
+		if err := t.root.handle.Remove(rel); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if info, statErr := t.root.handle.Lstat(rel); statErr == nil {
+				if children, readErr := readBoardOutputDirectory(t.root, rel, info); readErr == nil && len(children) != 0 {
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("refusing to remove non-empty transaction directory %q", path))
+					continue
+				}
 			}
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove transaction directory %q: %w", path, err))
 		}
 	}
 	if rollbackErr == nil {
@@ -753,67 +948,33 @@ func (t *boardOutputTransaction) rollback() error {
 	return rollbackErr
 }
 
-func rollbackBoardOutputFile(change *boardOutputFileChange) error {
+func (t *boardOutputTransaction) rollbackBoardOutputFile(change *boardOutputFileChange) error {
 	if !change.applied {
 		return nil
 	}
-	info, err := os.Lstat(change.destination)
+	path := t.root.display(change.rel)
+	info, err := t.root.handle.Lstat(change.rel)
 	if change.installedInfo != nil {
 		if err != nil || !os.SameFile(change.installedInfo, info) {
-			return fmt.Errorf("refusing to roll back changed board output %q", change.destination)
+			return fmt.Errorf("refusing to roll back changed board output %q", path)
 		}
 	} else if err == nil {
-		return fmt.Errorf("refusing to roll back recreated board output %q", change.destination)
+		return fmt.Errorf("refusing to roll back recreated board output %q", path)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	if change.existed {
-		_, _, err := installBoardOutputFile(change.backup, change.destination, change.installedInfo != nil)
+		_, _, err := installBoardOutputFile(t.root, change.backup, change.rel, change.installedInfo != nil)
 		if err != nil {
-			return fmt.Errorf("restore board output %q: %w", change.destination, err)
+			return fmt.Errorf("restore board output %q: %w", path, err)
 		}
 		return nil
 	}
 	if change.installedInfo == nil {
 		return nil
 	}
-	if err := os.Remove(change.destination); err != nil {
-		return fmt.Errorf("remove newly published board output %q: %w", change.destination, err)
+	if err := t.root.handle.Remove(change.rel); err != nil {
+		return fmt.Errorf("remove newly published board output %q: %w", path, err)
 	}
 	return nil
-}
-
-// lstatBoardOutputPath rejects symlinks in every existing ancestor. It is not
-// a substitute for handle-relative operations, but it prevents deterministic
-// publication through a pre-existing symlink.
-func lstatBoardOutputPath(root, rel string) (fs.FileInfo, error) {
-	rootInfo, err := os.Lstat(root)
-	if err != nil {
-		return nil, err
-	}
-	if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
-		return nil, fmt.Errorf("board output root %q is not a real directory", root)
-	}
-	if rel == "." {
-		return rootInfo, nil
-	}
-	current := root
-	parts := strings.Split(filepath.Clean(rel), string(filepath.Separator))
-	for index, part := range parts {
-		current = filepath.Join(current, part)
-		info, err := os.Lstat(current)
-		if err != nil {
-			return nil, err
-		}
-		if info.Mode()&os.ModeSymlink != 0 && index != len(parts)-1 {
-			return nil, fmt.Errorf("refusing to access board output through symlink %q", current)
-		}
-		if index != len(parts)-1 && !info.IsDir() {
-			return nil, fmt.Errorf("board output ancestor %q is not a directory", current)
-		}
-		if index == len(parts)-1 {
-			return info, nil
-		}
-	}
-	return nil, os.ErrNotExist
 }

--- a/d2cli/board_output_test.go
+++ b/d2cli/board_output_test.go
@@ -489,6 +489,82 @@ func TestBoardOutputPublicationRollsBackWholeTransaction(t *testing.T) {
 	}
 }
 
+func TestBoardOutputPublicationRejectsAncestorSwapWithoutEscapingRoot(t *testing.T) {
+	directory := t.TempDir()
+	outputPath := filepath.Join(directory, "output.svg")
+	outputDirectory := filepath.Join(directory, "output")
+	nestedDirectory := filepath.Join(outputDirectory, "nested")
+	movedDirectory := filepath.Join(directory, "moved-nested")
+	victimDirectory := filepath.Join(directory, "victim")
+	if err := os.MkdirAll(nestedDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(victimDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDirectory, "sentinel"), []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	probe := filepath.Join(directory, "symlink-probe")
+	if err := os.Symlink(victimDirectory, probe); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace, err := newBoardOutputWorkspace(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(workspace.stageRoot, "a-created"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace.stageRoot, "nested", "leaf"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.stageRoot, "nested", "leaf", "board.svg"), []byte("new board"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	swapped := false
+	workspace.beforePublish = func(path string) error {
+		if path != filepath.Join(nestedDirectory, "leaf") {
+			return nil
+		}
+		swapped = true
+		if err := os.Rename(nestedDirectory, movedDirectory); err != nil {
+			return err
+		}
+		return os.Symlink(victimDirectory, nestedDirectory)
+	}
+	touched, err := workspace.publish()
+	if err == nil {
+		t.Fatal("publish() accepted a symlink ancestor installed during publication")
+	}
+	if touched {
+		t.Fatal("publish() reported output touched after rolling back the transaction")
+	}
+	if !swapped {
+		t.Fatal("publication did not reach the injected ancestor swap")
+	}
+	if _, err := os.Stat(filepath.Join(victimDirectory, "leaf")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("publication created a directory outside its root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(victimDirectory, "leaf", "board.svg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("publication created a file outside its root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDirectory, "a-created")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("transaction directory survived rollback: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(movedDirectory, "sentinel")); err != nil || string(got) != "keep me" {
+		t.Fatalf("preexisting nested output = %q, %v; want unchanged", got, err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(directory, ".d2-board-output-*")); err != nil || len(matches) != 0 {
+		t.Fatalf("staging directories after rollback = %v, %v", matches, err)
+	}
+}
+
 func TestBoardOutputPublicationPreservesStaleFileEditedDuringPublish(t *testing.T) {
 	directory := t.TempDir()
 	outputPath := filepath.Join(directory, "output.svg")


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

Board publication previously checked destination paths with `Lstat` and then performed later reads, creates, renames, and removals through ordinary pathnames. A local attacker who can modify the output tree concurrently could rename a checked directory and replace it with a symlink during that gap. D2 could then create, replace, or remove files outside the requested output root with the D2 process's filesystem permissions.

This is a filesystem time-of-check/time-of-use vulnerability. It requires concurrent write access to an ancestor inside an existing board-output tree; a D2 source file alone cannot trigger it. The relevant boundary is a shared workspace, build agent, or service where the renderer has more filesystem authority than another local actor.

### What changed

- Open and identity-check an existing output directory once as `os.Root`.
- Perform destination preflight, manifest reads, stale-file hashing, backups, directory reads, creates, renames, removals, cleanup, and rollback relative to that retained root handle.
- Identity-check opened files and directories against their earlier metadata before sensitive reads or mutations.
- Create transaction temp files with cryptographically random `O_EXCL` names inside the rooted directory.
- Keep the existing atomic whole-stage rename path when the output root does not yet exist.
- Add a deterministic regression that swaps a checked nested directory for an absolute symlink immediately before file creation and verifies no victim file is created and all earlier transaction changes roll back.

On supported native platforms, renaming the root itself may change where it appears by pathname, but operations remain confined to the originally opened directory object. `os.Root` documents weaker guarantees on js and Plan 9; the native CLI uses descriptor/handle-backed implementations.

### Verification

- Focused board-output publication suite
- `go test ./d2cli`
- `go test ./...`
- `go vet ./...`
- Focused `go test -race`
- Windows amd64 `d2cli` test cross-build
