### PR TITLE
security: escape SVG color attributes

### DIFF
--- a/d2renderers/d2svg/color_attribute_escaping_test.go
+++ b/d2renderers/d2svg/color_attribute_escaping_test.go
@@ -1,0 +1,196 @@
+package d2svg_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+	"github.com/d2lang/d2/lib/geo"
+)
+
+func TestRenderEscapesTargetColorAttributes(t *testing.T) {
+	t.Parallel()
+
+	const payload = `red" onload="alert(1)`
+	tests := []struct {
+		name      string
+		attribute string
+		configure func(*d2target.Diagram)
+	}{
+		{name: "root-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Root.Fill = payload }},
+		{name: "root-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Root.Stroke = payload }},
+		{name: "shape-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].Fill = payload }},
+		{name: "shape-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Shapes[0].Stroke = payload }},
+		{name: "shape-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].Color = payload }},
+		{name: "shape-label-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].LabelFill = payload }},
+		{
+			name: "shape-primary-accent", attribute: "fill",
+			configure: func(d *d2target.Diagram) {
+				setClassShape(&d.Shapes[0])
+				d.Shapes[0].PrimaryAccentColor = payload
+			},
+		},
+		{
+			name: "shape-secondary-accent", attribute: "fill",
+			configure: func(d *d2target.Diagram) {
+				setClassShape(&d.Shapes[0])
+				d.Shapes[0].SecondaryAccentColor = payload
+			},
+		},
+		{
+			name: "shape-neutral-accent", attribute: "fill",
+			configure: func(d *d2target.Diagram) {
+				setSQLTableShape(&d.Shapes[0])
+				d.Shapes[0].NeutralAccentColor = payload
+			},
+		},
+		{name: "connection-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Connections[0].Stroke = payload }},
+		{name: "connection-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].Fill = payload }},
+		{name: "connection-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].Color = payload }},
+		{name: "connection-source-label-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].SrcLabel.Color = payload }},
+		{name: "connection-destination-label-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].DstLabel.Color = payload }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagram := colorAttributeDiagram()
+			test.configure(diagram)
+
+			// The public JavaScript renderer receives this target structure as JSON.
+			encoded, err := json.Marshal(diagram)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			var decoded d2target.Diagram
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			out, err := d2svg.Render(&decoded, nil)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			assertSafeColorAttribute(t, out, test.attribute, payload)
+		})
+	}
+}
+
+func colorAttributeDiagram() *d2target.Diagram {
+	diagram := d2target.NewDiagram()
+	diagram.Root.Fill = "#ffffff"
+	fontFamily, monoFontFamily := d2fonts.SourceSansPro, d2fonts.SourceCodePro
+	diagram.FontFamily = &fontFamily
+	diagram.MonoFontFamily = &monoFontFamily
+
+	shape := *d2target.BaseShape()
+	shape.ID = "shape"
+	shape.Type = d2target.ShapeRectangle
+	shape.Width = 100
+	shape.Height = 66
+	shape.Fill = "#ffffff"
+	shape.Stroke = "#000000"
+	shape.Color = "#000000"
+	shape.Label = "shape"
+	shape.FontSize = 16
+	shape.LabelWidth = 40
+	shape.LabelHeight = 20
+
+	destination := *d2target.BaseShape()
+	destination.ID = "destination"
+	destination.Type = d2target.ShapeRectangle
+	destination.Pos.X = 200
+	destination.Width = 100
+	destination.Height = 66
+	destination.Fill = "#ffffff"
+	destination.Stroke = "#000000"
+
+	connection := *d2target.BaseConnection()
+	connection.ID = "connection"
+	connection.Src = shape.ID
+	connection.Dst = destination.ID
+	connection.Route = []*geo.Point{{X: 100, Y: 33}, {X: 200, Y: 33}}
+	connection.Stroke = "#000000"
+	connection.Color = "#000000"
+	connection.Fill = "#ffffff"
+	connection.Label = "connection"
+	connection.FontSize = 16
+	connection.LabelWidth = 80
+	connection.LabelHeight = 20
+	connection.LabelPosition = "INSIDE_MIDDLE_CENTER"
+	connection.SrcLabel = &d2target.Text{Label: "source", Color: "#000000", LabelWidth: 48, LabelHeight: 20}
+	connection.DstLabel = &d2target.Text{Label: "destination", Color: "#000000", LabelWidth: 80, LabelHeight: 20}
+
+	diagram.Shapes = []d2target.Shape{shape, destination}
+	diagram.Connections = []d2target.Connection{connection}
+	return diagram
+}
+
+func setClassShape(shape *d2target.Shape) {
+	shape.Type = d2target.ShapeClass
+	shape.Height = 120
+	shape.PrimaryAccentColor = "#000000"
+	shape.SecondaryAccentColor = "#000000"
+	shape.Fields = []d2target.ClassField{{Name: "field", Type: "string"}}
+}
+
+func setSQLTableShape(shape *d2target.Shape) {
+	shape.Type = d2target.ShapeSQLTable
+	shape.Height = 120
+	shape.PrimaryAccentColor = "#000000"
+	shape.SecondaryAccentColor = "#000000"
+	shape.NeutralAccentColor = "#000000"
+	shape.Columns = []d2target.SQLColumn{
+		{
+			Name:       d2target.Text{Label: "column", LabelWidth: 48},
+			Type:       d2target.Text{Label: "string", LabelWidth: 40},
+			Constraint: []string{"primary_key"},
+		},
+	}
+}
+
+func assertSafeColorAttribute(t *testing.T, source []byte, attribute, value string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(bytes.NewReader(source))
+	decoder.Strict = true
+	found := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Render() emitted invalid XML: %v\n%s", err, source)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(start.Name.Local, "script") {
+			t.Fatalf("Render() emitted an injected script element: %s", source)
+		}
+		for _, attr := range start.Attr {
+			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+				t.Fatalf("Render() emitted an event-handler attribute %q: %s", attr.Name.Local, source)
+			}
+			if attr.Name.Local == attribute && attr.Value == value {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("Render() did not preserve %s value %q after XML decoding: %s", attribute, value, source)
+	}
+	if !bytes.Contains(source, []byte(`&#34; onload=&#34;`)) {
+		t.Fatalf("Render() did not XML-escape the color attribute: %s", source)
+	}
+}

--- a/d2themes/element.go
+++ b/d2themes/element.go
@@ -182,40 +182,40 @@ func (el *ThemableElement) Render() string {
 	if color.IsThemeColor(el.Stroke) {
 		class += fmt.Sprintf(" stroke-%s", el.Stroke)
 		if el.inlineTheme != nil {
-			out += fmt.Sprintf(` stroke="%s"`, ResolveThemeColor(*el.inlineTheme, el.Stroke))
+			out += fmt.Sprintf(` stroke="%s"`, svg.EscapeAttribute(ResolveThemeColor(*el.inlineTheme, el.Stroke)))
 		}
 	} else if len(el.Stroke) > 0 {
 		if color.IsGradient(el.Stroke) {
 			el.Stroke = fmt.Sprintf("url('#%s')", color.UniqueGradientID(el.Stroke))
 		}
-		out += fmt.Sprintf(` stroke="%s"`, el.Stroke)
+		out += fmt.Sprintf(` stroke="%s"`, svg.EscapeAttribute(el.Stroke))
 	}
 	if color.IsThemeColor(el.Fill) {
 		class += fmt.Sprintf(" fill-%s", el.Fill)
 		if el.inlineTheme != nil {
-			out += fmt.Sprintf(` fill="%s"`, ResolveThemeColor(*el.inlineTheme, el.Fill))
+			out += fmt.Sprintf(` fill="%s"`, svg.EscapeAttribute(ResolveThemeColor(*el.inlineTheme, el.Fill)))
 		}
 	} else if len(el.Fill) > 0 {
 		if color.IsGradient(el.Fill) {
 			el.Fill = fmt.Sprintf("url('#%s')", color.UniqueGradientID(el.Fill))
 		}
-		out += fmt.Sprintf(` fill="%s"`, el.Fill)
+		out += fmt.Sprintf(` fill="%s"`, svg.EscapeAttribute(el.Fill))
 	}
 	if color.IsThemeColor(el.BackgroundColor) {
 		class += fmt.Sprintf(" background-color-%s", el.BackgroundColor)
 		if el.inlineTheme != nil {
-			out += fmt.Sprintf(` background-color="%s"`, ResolveThemeColor(*el.inlineTheme, el.BackgroundColor))
+			out += fmt.Sprintf(` background-color="%s"`, svg.EscapeAttribute(ResolveThemeColor(*el.inlineTheme, el.BackgroundColor)))
 		}
 	} else if len(el.BackgroundColor) > 0 {
-		out += fmt.Sprintf(` background-color="%s"`, el.BackgroundColor)
+		out += fmt.Sprintf(` background-color="%s"`, svg.EscapeAttribute(el.BackgroundColor))
 	}
 	if color.IsThemeColor(el.Color) {
 		class += fmt.Sprintf(" color-%s", el.Color)
 		if el.inlineTheme != nil {
-			out += fmt.Sprintf(` color="%s"`, ResolveThemeColor(*el.inlineTheme, el.Color))
+			out += fmt.Sprintf(` color="%s"`, svg.EscapeAttribute(ResolveThemeColor(*el.inlineTheme, el.Color)))
 		}
 	} else if len(el.Color) > 0 {
-		out += fmt.Sprintf(` color="%s"`, el.Color)
+		out += fmt.Sprintf(` color="%s"`, svg.EscapeAttribute(el.Color))
 	}
 
 	if len(class) > 0 {

--- a/d2themes/element_test.go
+++ b/d2themes/element_test.go
@@ -1,0 +1,55 @@
+package d2themes
+
+import (
+	"encoding/xml"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestThemableElementEscapesPaintAttributes(t *testing.T) {
+	t.Parallel()
+
+	const value = `red" onload="alert(1)`
+	element := NewThemableElement("rect", nil)
+	element.Fill = value
+	element.Stroke = value
+	element.BackgroundColor = value
+	element.Color = value
+	source := "<svg>" + element.Render() + "</svg>"
+
+	want := map[string]bool{
+		"fill":             false,
+		"stroke":           false,
+		"background-color": false,
+		"color":            false,
+	}
+	decoder := xml.NewDecoder(strings.NewReader(source))
+	decoder.Strict = true
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Render() emitted invalid XML: %v\n%s", err, source)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		for _, attr := range start.Attr {
+			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+				t.Fatalf("Render() emitted an event-handler attribute %q: %s", attr.Name.Local, source)
+			}
+			if _, ok := want[attr.Name.Local]; ok && attr.Value == value {
+				want[attr.Name.Local] = true
+			}
+		}
+	}
+	for attribute, found := range want {
+		if !found {
+			t.Errorf("Render() did not preserve %s value %q after XML decoding: %s", attribute, value, source)
+		}
+	}
+}

--- a/lib/svg/text.go
+++ b/lib/svg/text.go
@@ -7,10 +7,23 @@ import (
 	"strings"
 )
 
+var xmlDoubleQuotedAttributeEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	`"`, "&#34;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
 func EscapeText(text string) string {
 	buf := new(bytes.Buffer)
 	_ = xml.EscapeText(buf, []byte(text))
 	return buf.String()
+}
+
+// EscapeAttribute escapes a value for use in a double-quoted XML attribute.
+// Single quotes are left unchanged because they cannot terminate that context.
+func EscapeAttribute(attribute string) string {
+	return xmlDoubleQuotedAttributeEscaper.Replace(attribute)
 }
 
 func SVGID(text string) string {

--- a/lib/svg/text_test.go
+++ b/lib/svg/text_test.go
@@ -1,0 +1,13 @@
+package svg
+
+import "testing"
+
+func TestEscapeAttribute(t *testing.T) {
+	t.Parallel()
+
+	const value = `url('#gradient') & " < > '`
+	const want = `url('#gradient') &amp; &#34; &lt; &gt; '`
+	if got := EscapeAttribute(value); got != want {
+		t.Fatalf("EscapeAttribute(%q) = %q, want %q", value, got, want)
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

The SVG renderer wrote non-theme fill, stroke, text color, background color, and accent values directly into double-quoted XML attributes. The D2 compiler normally validates colors, but the public JavaScript/WASM `D2.render(diagram)` API accepts a serialized `d2target.Diagram` directly. An attacker who controls that JSON could include a quote in any affected color field, terminate the attribute, and add an `onload` or other event-handler attribute.

This is active SVG XSS. If the generated SVG is opened directly or embedded in an active same-origin SVG/HTML context, the injected handler can execute with that origin's privileges. Compiler-side color validation does not protect callers of the lower-level render API.

### What changed

- Add an XML escaper specifically for double-quoted attribute values.
- Escape all shared `stroke`, `fill`, `background-color`, and `color` serialization paths, including inline-theme resolution.
- Preserve single quotes so existing gradient values such as `url('#gradient')` remain byte-for-byte stable.
- Round-trip hostile root, shape, connection, label, and accent fields through JSON before rendering.
- Strict-parse every regression output, reject script/event-handler markup, and verify the hostile value survives only as decoded attribute data.

Normal compiled diagrams and gradient snapshots render identically.

### Verification

- Focused SVG, theme-element, and escape-helper tests
- Renderer snapshot tests
- `go test ./...`
- `go vet ./...`
