### PR TITLE
security: authenticate watch server access

### DIFF
--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -2,8 +2,11 @@ package d2cli
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
 	"embed"
 	_ "embed"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -86,7 +89,12 @@ type watcher struct {
 
 	resMu sync.Mutex
 	res   *compileResult
+
+	accessToken      string
+	accessCookieName string
 }
+
+const watchAccessTokenBytes = 32
 
 type compileResult struct {
 	SVG   string   `json:"svg"`
@@ -96,6 +104,11 @@ type compileResult struct {
 
 func newWatcher(ctx context.Context, ms *xmain.State, opts watcherOpts) (*watcher, error) {
 	ctx, cancel := context.WithCancel(ctx)
+	accessToken, err := newWatchAccessToken()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to generate watch access token: %w", err)
+	}
 
 	w := &watcher{
 		ctx:     ctx,
@@ -107,12 +120,22 @@ func newWatcher(ctx context.Context, ms *xmain.State, opts watcherOpts) (*watche
 
 		compileCh: make(chan struct{}, 1),
 		wsclients: make(map[*wsclient]struct{}),
+
+		accessToken: accessToken,
 	}
-	err := w.init()
+	err = w.init()
 	if err != nil {
 		return nil, err
 	}
 	return w, nil
+}
+
+func newWatchAccessToken() (string, error) {
+	b := make([]byte, watchAccessTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func (w *watcher) init() error {
@@ -457,7 +480,7 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 
 		if firstCompile {
 			firstCompile = false
-			url := fmt.Sprintf("http://%s", w.l.Addr())
+			url := w.accessURL("/")
 			err = xbrowser.Open(ctx, w.ms.Env, url)
 			if err != nil {
 				w.ms.Log.Warn.Printf("failed to open browser to %v: %v", url, err)
@@ -472,8 +495,18 @@ func (w *watcher) listen() error {
 		return err
 	}
 	w.l = l
-	w.ms.Log.Success.Printf("listening on http://%v", w.l.Addr())
+	_, port, err := net.SplitHostPort(w.l.Addr().String())
+	if err != nil {
+		_ = w.l.Close()
+		return fmt.Errorf("failed to determine watch listener port: %w", err)
+	}
+	w.accessCookieName = "d2-watch-" + port
+	w.ms.Log.Success.Printf("listening on %s", w.accessURL("/"))
 	return nil
+}
+
+func (w *watcher) accessURL(path string) string {
+	return fmt.Sprintf("http://%s%s?token=%s", w.l.Addr(), path, w.accessToken)
 }
 
 func (w *watcher) goServe() error {
@@ -484,12 +517,58 @@ func (w *watcher) goServe() error {
 	m.Handle("/static/", http.StripPrefix("/static", w.staticFileServer))
 	m.Handle("/watch", xhttp.HandlerFuncAdapter{Log: w.ms.Log, Func: w.handleWatch})
 
-	s := xhttp.NewServer(w.ms.Log.Warn, xhttp.Log(w.ms.Log, m))
+	logged := xhttp.Log(w.ms.Log, m)
+	authenticated := http.HandlerFunc(func(hw http.ResponseWriter, r *http.Request) {
+		if w.authorizeRequest(hw, r) {
+			logged.ServeHTTP(hw, r)
+		}
+	})
+	s := xhttp.NewServer(w.ms.Log.Warn, authenticated)
 	w.goFunc(func(ctx context.Context) error {
 		return xhttp.Serve(ctx, time.Second*30, s, w.l)
 	})
 
 	return nil
+}
+
+func (w *watcher) authorizeRequest(hw http.ResponseWriter, r *http.Request) bool {
+	query := r.URL.Query()
+	if query.Has("token") {
+		if !constantTimeTokenEqual(query.Get("token"), w.accessToken) {
+			http.Error(hw, "watch access denied", http.StatusForbidden)
+			return false
+		}
+
+		hw.Header().Set("Cache-Control", "no-store")
+		hw.Header().Set("Referrer-Policy", "no-referrer")
+		http.SetCookie(hw, &http.Cookie{
+			Name:     w.accessCookieName,
+			Value:    w.accessToken,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		})
+		query.Del("token")
+		redirect := *r.URL
+		redirect.Scheme = ""
+		redirect.Host = ""
+		redirect.RawPath = ""
+		redirect.Path = "/" + strings.TrimLeft(redirect.Path, "/")
+		redirect.RawQuery = query.Encode()
+		http.Redirect(hw, r, redirect.String(), http.StatusSeeOther)
+		return false
+	}
+
+	if cookie, err := r.Cookie(w.accessCookieName); err == nil &&
+		constantTimeTokenEqual(cookie.Value, w.accessToken) {
+		return true
+	}
+	http.Error(hw, "watch access denied", http.StatusForbidden)
+	return false
+}
+
+func constantTimeTokenEqual(provided, expected string) bool {
+	return len(provided) == len(expected) && subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
 }
 
 func (w *watcher) getRes() *compileResult {

--- a/d2cli/watch_security_test.go
+++ b/d2cli/watch_security_test.go
@@ -1,0 +1,110 @@
+package d2cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewWatchAccessToken(t *testing.T) {
+	t.Parallel()
+
+	first, err := newWatchAccessToken()
+	if err != nil {
+		t.Fatalf("newWatchAccessToken() error = %v", err)
+	}
+	second, err := newWatchAccessToken()
+	if err != nil {
+		t.Fatalf("newWatchAccessToken() error = %v", err)
+	}
+	if first == second {
+		t.Fatal("two watch access tokens unexpectedly matched")
+	}
+	if strings.ContainsAny(first, "+/=") {
+		t.Fatalf("watch access token %q is not URL-safe", first)
+	}
+}
+
+func TestWatcherAuthorizeRequest(t *testing.T) {
+	t.Parallel()
+
+	const (
+		token      = "correct-token"
+		cookieName = "d2-watch-12345"
+	)
+	w := &watcher{accessToken: token, accessCookieName: cookieName}
+
+	t.Run("rejects unauthenticated request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://attacker.example/private-board", nil)
+		recorder := httptest.NewRecorder()
+		if w.authorizeRequest(recorder, req) {
+			t.Fatal("authorizeRequest() accepted an unauthenticated request")
+		}
+		if got := recorder.Code; got != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", got, http.StatusForbidden)
+		}
+	})
+
+	t.Run("rejects invalid cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/private-board", nil)
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: "wrong-token"})
+		recorder := httptest.NewRecorder()
+		if w.authorizeRequest(recorder, req) {
+			t.Fatal("authorizeRequest() accepted an invalid cookie")
+		}
+		if got := recorder.Code; got != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", got, http.StatusForbidden)
+		}
+	})
+
+	t.Run("exchanges token for strict HTTP-only cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/private-board?keep=1&token="+url.QueryEscape(token), nil)
+		recorder := httptest.NewRecorder()
+		if w.authorizeRequest(recorder, req) {
+			t.Fatal("authorizeRequest() served the token-bearing URL without redirecting")
+		}
+		if got := recorder.Code; got != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", got, http.StatusSeeOther)
+		}
+		if got := recorder.Header().Get("Location"); got != "/private-board?keep=1" {
+			t.Fatalf("Location = %q, want token-free board URL", got)
+		}
+		if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+			t.Fatalf("Cache-Control = %q, want no-store", got)
+		}
+		if got := recorder.Header().Get("Referrer-Policy"); got != "no-referrer" {
+			t.Fatalf("Referrer-Policy = %q, want no-referrer", got)
+		}
+		cookies := recorder.Result().Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("Set-Cookie count = %d, want 1", len(cookies))
+		}
+		cookie := cookies[0]
+		if cookie.Name != cookieName || cookie.Value != token || !cookie.HttpOnly || cookie.SameSite != http.SameSiteStrictMode || cookie.Path != "/" {
+			t.Fatalf("access cookie = %#v", cookie)
+		}
+
+		followup := httptest.NewRequest(http.MethodGet, "http://localhost/private-board", nil)
+		followup.AddCookie(cookie)
+		if !w.authorizeRequest(httptest.NewRecorder(), followup) {
+			t.Fatal("authorizeRequest() rejected the exchanged access cookie")
+		}
+	})
+
+	t.Run("strips repeated token URL despite valid cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/private-board?token="+url.QueryEscape(token), nil)
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: token})
+		recorder := httptest.NewRecorder()
+		if w.authorizeRequest(recorder, req) {
+			t.Fatal("authorizeRequest() served a token-bearing URL through the existing cookie")
+		}
+		if got := recorder.Code; got != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", got, http.StatusSeeOther)
+		}
+		if got := recorder.Header().Get("Location"); got != "/private-board" {
+			t.Fatalf("Location = %q, want token-free board URL", got)
+		}
+	})
+}

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -9,6 +9,8 @@ import (
 	"image/png"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1417,15 +1419,8 @@ layers: {
 				tms.Start(t, ctx)
 				defer stopWatch(t, tms)
 
-				// Wait for watch server to spin up and listen
-				urlRE := regexp.MustCompile(`127.0.0.1:([0-9]+)`)
-				watchURL, err := waitLogs(ctx, stderr, urlRE)
-				assert.Success(t, err)
+				watchURL, httpClient, c := connectWatchClient(ctx, t, stderr)
 				stderr.Reset()
-
-				// Start a client
-				c, _, err := websocket.Dial(ctx, fmt.Sprintf("ws://%s/watch", watchURL), nil)
-				assert.Success(t, err)
 				defer c.CloseNow()
 
 				// Get the link
@@ -1436,7 +1431,7 @@ layers: {
 				assert.Equal(t, 2, len(match))
 				linkedPath := match[1]
 
-				err = getWatchPage(ctx, t, fmt.Sprintf("http://%s/%s", watchURL, linkedPath))
+				err = getWatchPage(ctx, t, httpClient, fmt.Sprintf("http://%s/%s", watchURL, linkedPath))
 				assert.Success(t, err)
 
 				successRE := regexp.MustCompile(`broadcasting update to 1 client`)
@@ -1464,16 +1459,8 @@ layers: {
 				tms.Start(t, ctx)
 				defer stopWatch(t, tms)
 
-				// Wait for watch server to spin up and listen
-				urlRE := regexp.MustCompile(`127.0.0.1:([0-9]+)`)
-				watchURL, err := waitLogs(ctx, stderr, urlRE)
-				assert.Success(t, err)
-
+				watchURL, httpClient, c := connectWatchClient(ctx, t, stderr)
 				stderr.Reset()
-
-				// Start a client
-				c, _, err := websocket.Dial(ctx, fmt.Sprintf("ws://%s/watch", watchURL), nil)
-				assert.Success(t, err)
 				defer c.CloseNow()
 
 				// Get the link
@@ -1484,7 +1471,7 @@ layers: {
 				assert.Equal(t, 2, len(match))
 				linkedPath := match[1]
 
-				err = getWatchPage(ctx, t, fmt.Sprintf("http://%s/%s", watchURL, linkedPath))
+				err = getWatchPage(ctx, t, httpClient, fmt.Sprintf("http://%s/%s", watchURL, linkedPath))
 				assert.Success(t, err)
 
 				successRE := regexp.MustCompile(`broadcasting update to 1 client`)
@@ -1511,22 +1498,14 @@ layers: {
 				tms.Start(t, ctx)
 				defer stopWatch(t, tms)
 
-				// Wait for watch server to spin up and listen
-				urlRE := regexp.MustCompile(`127.0.0.1:([0-9]+)`)
-				watchURL, err := waitLogs(ctx, stderr, urlRE)
-				assert.Success(t, err)
-
+				watchURL, httpClient, c := connectWatchClient(ctx, t, stderr)
 				stderr.Reset()
-
-				// Start a client
-				c, _, err := websocket.Dial(ctx, fmt.Sprintf("ws://%s/watch", watchURL), nil)
-				assert.Success(t, err)
 				defer c.CloseNow()
 
-				_, _, err = c.Read(ctx)
+				_, _, err := c.Read(ctx)
 				assert.Success(t, err)
 
-				err = getWatchPage(ctx, t, fmt.Sprintf("http://%s/%s", watchURL, "cream"))
+				err = getWatchPage(ctx, t, httpClient, fmt.Sprintf("http://%s/%s", watchURL, "cream"))
 				assert.Success(t, err)
 
 				// Get the link
@@ -1537,7 +1516,7 @@ layers: {
 
 				link := string(match[1])
 
-				err = getWatchPage(ctx, t, fmt.Sprintf("http://%s/%s", watchURL, link))
+				err = getWatchPage(ctx, t, httpClient, fmt.Sprintf("http://%s/%s", watchURL, link))
 				assert.Success(t, err)
 				_, _, err = c.Read(ctx)
 				assert.Success(t, err)
@@ -1573,16 +1552,8 @@ layers: {
 				tms.Start(t, ctx)
 				defer stopWatch(t, tms)
 
-				// Wait for watch server to spin up and listen
-				urlRE := regexp.MustCompile(`127.0.0.1:([0-9]+)`)
-				watchURL, err := waitLogs(ctx, stderr, urlRE)
-				assert.Success(t, err)
-
+				watchURL, httpClient, c := connectWatchClient(ctx, t, stderr)
 				stderr.Reset()
-
-				// Start a client
-				c, _, err := websocket.Dial(ctx, fmt.Sprintf("ws://%s/watch", watchURL), nil)
-				assert.Success(t, err)
 				defer c.CloseNow()
 
 				// Get the link
@@ -1592,7 +1563,7 @@ layers: {
 				assert.Equal(t, 2, len(match))
 				link := string(match[1])
 
-				err = getWatchPage(ctx, t, fmt.Sprintf("http://%s/%s", watchURL, link))
+				err = getWatchPage(ctx, t, httpClient, fmt.Sprintf("http://%s/%s", watchURL, link))
 				assert.Success(t, err)
 				_, _, err = c.Read(ctx)
 				assert.Success(t, err)
@@ -1618,11 +1589,8 @@ x
 				tms.Start(t, ctx)
 				defer stopWatch(t, tms)
 
-				urlRE := regexp.MustCompile(`127.0.0.1:([0-9]+)`)
-				watchURL, err := waitLogs(ctx, stderr, urlRE)
-				assert.Success(t, err)
-				c, _, err := websocket.Dial(ctx, fmt.Sprintf("ws://%s/watch", watchURL), nil)
-				assert.Success(t, err)
+				_, _, c := connectWatchClient(ctx, t, stderr)
+				var err error
 				defer c.CloseNow()
 
 				// Results are broadcast after the dependency watch list is updated.
@@ -1972,13 +1940,33 @@ func waitLogs(ctx context.Context, stream *stderrWrapper, pattern *regexp.Regexp
 	return match, nil
 }
 
-func getWatchPage(ctx context.Context, t *testing.T, page string) error {
+func connectWatchClient(ctx context.Context, t *testing.T, stderr *stderrWrapper) (string, *http.Client, *websocket.Conn) {
+	t.Helper()
+
+	accessURL, err := waitLogs(ctx, stderr, regexp.MustCompile(`http://127\.0\.0\.1:[0-9]+/\?token=[A-Za-z0-9_-]+`))
+	assert.Success(t, err)
+	parsed, err := url.Parse(accessURL)
+	assert.Success(t, err)
+	jar, err := cookiejar.New(nil)
+	assert.Success(t, err)
+	httpClient := &http.Client{Jar: jar}
+	assert.Success(t, getWatchPage(ctx, t, httpClient, accessURL))
+
+	websocketURL := *parsed
+	websocketURL.Scheme = "ws"
+	websocketURL.Path = "/watch"
+	websocketURL.RawQuery = ""
+	c, _, err := websocket.Dial(ctx, websocketURL.String(), &websocket.DialOptions{HTTPClient: httpClient})
+	assert.Success(t, err)
+	return parsed.Host, httpClient, c
+}
+
+func getWatchPage(ctx context.Context, t *testing.T, httpClient *http.Client, page string) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", page, nil)
 	if err != nil {
 		return err
 	}
 
-	var httpClient = &http.Client{}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

`d2 --watch` previously exposed its board routes and WebSocket without authenticating the requester. The default `localhost:0` listener limits ordinary network reach, but it does not make an HTTP service safe from browser-originated requests: a malicious site can use DNS rebinding to make its hostname resolve to the watch listener, and the WebSocket library accepts an Origin when its host matches the attacker-controlled Host header. A successful connection can read every rendered SVG or compiler error broadcast by the watcher. Any unauthenticated GET can also select a board and trigger compilation, allowing repeated CPU and memory consumption.

The impact is disclosure of locally rendered diagram content and denial of service while watch mode is running. A deliberately remote listener configured with `$HOST`/`$PORT` was directly exposed as well. This does not make the watch server safe against a malicious local process or an on-path observer when plain HTTP is used; the new token is a capability delivered through the terminal and initial browser URL.

### What changed

- Generate a fresh 256-bit random access token for every watcher.
- Include the capability URL in the listener message and automatic browser launch.
- Require authentication before every board, static asset, and WebSocket route.
- Exchange a valid query token for a port-specific, HTTP-only, `SameSite=Strict` session cookie, then redirect to the same local path without the token.
- Mark the exchange response `no-store` and `no-referrer`, and keep the authentication layer outside request logging so the query token is not copied into ordinary access logs.
- Construct the redirect as a local absolute path, discarding any supplied scheme, host, or raw path.
- Update watch end-to-end tests to perform the same token exchange before loading boards or opening the WebSocket.
- Add focused regressions for unauthenticated requests, invalid cookies, the token-to-cookie exchange, token-free redirects, and repeated token URLs when a valid cookie already exists.

Cookies are not port-scoped, so a malicious sibling service on the same hostname can receive the cookie if the browser is sent to it. The random port-specific cookie name prevents accidental collisions but does not claim to isolate mutually hostile local services. Remote watch deployments should still be protected with TLS and normal network controls.

### Verification

- `go test ./d2cli -run 'Test(NewWatchAccessToken|WatcherAuthorizeRequest)' -count=1`
- `go test ./e2etests-cli -run 'TestCLI_E2E/watch' -count=1`
- `go test ./...`
- `go vet ./...`
