### PR TITLE
security: bound SVG image bundling resources

### DIFF
--- a/lib/imgbundler/cache.go
+++ b/lib/imgbundler/cache.go
@@ -1,0 +1,86 @@
+package imgbundler
+
+import (
+	"container/list"
+	"sync"
+)
+
+// imageCache is a bounded, concurrency-safe LRU cache. Its byte ceiling charges
+// key and value strings; the entry ceiling bounds fixed map/list overhead.
+// Values are immutable image-element prefixes, so callers may share a hit
+// without copying it.
+type imageCache struct {
+	mu         sync.Mutex
+	entries    map[imageCacheKey]*imageCacheEntry
+	recent     *list.List
+	maxEntries int
+	maxBytes   int64
+	bytes      int64
+}
+
+type imageCacheEntry struct {
+	key     imageCacheKey
+	value   []byte
+	bytes   int64
+	element *list.Element
+}
+
+func newImageCache(maxEntries int, maxBytes int64) *imageCache {
+	return &imageCache{
+		entries:    make(map[imageCacheKey]*imageCacheEntry),
+		recent:     list.New(),
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+	}
+}
+
+func (c *imageCache) Load(key imageCacheKey) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.recent.MoveToFront(entry.element)
+	return entry.value, true
+}
+
+func (c *imageCache) Store(key imageCacheKey, value []byte) {
+	if c == nil {
+		return
+	}
+	entryBytes := imageCacheEntryBytes(key, value)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if previous, ok := c.entries[key]; ok {
+		c.remove(previous)
+	}
+	if c.maxEntries <= 0 || c.maxBytes <= 0 || entryBytes > c.maxBytes {
+		return
+	}
+	for len(c.entries) >= c.maxEntries || entryBytes > c.maxBytes-c.bytes {
+		oldest := c.recent.Back()
+		if oldest == nil {
+			return
+		}
+		c.remove(oldest.Value.(*imageCacheEntry))
+	}
+	entry := &imageCacheEntry{key: key, value: value, bytes: entryBytes}
+	entry.element = c.recent.PushFront(entry)
+	c.entries[key] = entry
+	c.bytes += entryBytes
+}
+
+func (c *imageCache) remove(entry *imageCacheEntry) {
+	delete(c.entries, entry.key)
+	c.recent.Remove(entry.element)
+	c.bytes -= entry.bytes
+}
+
+func imageCacheEntryBytes(key imageCacheKey, value []byte) int64 {
+	return int64(len(key.href)) + int64(len(key.localPolicyKey)) + int64(len(value)) + 2
+}

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -30,9 +30,29 @@ import (
 	"github.com/d2lang/util-go/xdefer"
 )
 
-var imgCache sync.Map
+const (
+	maxImageSize    int64 = 1 << 25 // 33_554_432
+	maxImageWorkers       = 16
 
-const maxImageSize int64 = 1 << 25 // 33_554_432
+	// Keep legacy SVG bundling aligned with the raster pipeline's all-asset
+	// ceilings. Fetched bytes, post-content-decoding source bytes, generated
+	// data-URI bytes, and final SVG output are independent inclusive budgets.
+	// The locator ceiling also matches imageasset's source limit.
+	maxImageReferences                = 4_096
+	maxImageReferenceBytes            = 64 << 10
+	maxFetchedImageBytes        int64 = 512 << 20
+	maxSourceImageBytes         int64 = 512 << 20
+	maxBundledImageBytes        int64 = 512 << 20
+	maxBundledOutputBytes       int64 = 512 << 20
+	maxImageCacheEntries              = maxImageReferences
+	maxImageCacheBytes          int64 = maxBundledImageBytes
+	maxReportedImageFailures          = 8
+	maxImageReferenceLabelBytes       = 256
+	maxImageErrorLabelBytes           = 1_024
+	maxBundleReadChunkBytes           = 32 << 10
+)
+
+var imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 
 var imageRegex = regexp.MustCompile(`<image href="([^"]+)"`)
 
@@ -61,8 +81,97 @@ func BundleRemoteWithPolicy(ctx context.Context, l simplelog.Logger, in []byte, 
 }
 
 type repl struct {
-	from []byte
+	href string
 	to   []byte
+	err  error
+}
+
+type imageMatch struct {
+	start     int
+	end       int
+	hrefStart int
+	hrefEnd   int
+}
+
+type bundleLimitError struct {
+	name   string
+	actual int64
+	limit  int64
+}
+
+func (e *bundleLimitError) Error() string {
+	return fmt.Sprintf("%s exceeds maximum of %d bytes: %d", e.name, e.limit, e.actual)
+}
+
+type bundleBudget struct {
+	mu               sync.Mutex
+	fetchedBytes     int64
+	sourceBytes      int64
+	bundledBytes     int64
+	maxFetchedBytes  int64
+	maxSourceBytes   int64
+	maxBundledBytes  int64
+	exhaustedByError *bundleLimitError
+}
+
+func (b *bundleBudget) reserveFetched(bytes int64) error {
+	return b.reserve("cumulative fetched image bytes", &b.fetchedBytes, b.maxFetchedBytes, bytes)
+}
+
+func (b *bundleBudget) reserveSource(bytes int64) error {
+	return b.reserve("cumulative source image bytes", &b.sourceBytes, b.maxSourceBytes, bytes)
+}
+
+func (b *bundleBudget) reserveBundled(bytes int64) error {
+	return b.reserve("cumulative bundled image bytes", &b.bundledBytes, b.maxBundledBytes, bytes)
+}
+
+func (b *bundleBudget) reserve(name string, used *int64, limit, bytes int64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.exhaustedByError != nil {
+		return b.exhaustedByError
+	}
+	if bytes > limit-*used {
+		b.exhaustedByError = &bundleLimitError{name: name, actual: *used + bytes, limit: limit}
+		return b.exhaustedByError
+	}
+	*used += bytes
+	return nil
+}
+
+func (b *bundleBudget) exhausted() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.exhaustedByError == nil {
+		return nil
+	}
+	return b.exhaustedByError
+}
+
+type bundleBudgetReader struct {
+	ctx    context.Context
+	reader io.Reader
+	budget *bundleBudget
+}
+
+func (r *bundleBudgetReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if err := r.budget.exhausted(); err != nil {
+		return 0, err
+	}
+	if len(p) > maxBundleReadChunkBytes {
+		p = p[:maxBundleReadChunkBytes]
+	}
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		if budgetErr := r.budget.reserveFetched(int64(n)); budgetErr != nil {
+			return 0, budgetErr
+		}
+	}
+	return n, err
 }
 
 func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, localFiles localfile.Policy, isRemote, cacheImages bool, policy netpolicy.Policy) (_ []byte, err error) {
@@ -71,10 +180,15 @@ func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byt
 	} else {
 		defer xdefer.Errorf(&err, "failed to bundle local images")
 	}
-	imgs := imageRegex.FindAllSubmatch(svg, -1)
-	imgs = filterImageElements(imgs, isRemote)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 
-	if len(imgs) == 0 {
+	matches, hrefs, err := findImageElements(ctx, svg, isRemote)
+	if err != nil {
+		return svg, err
+	}
+
+	if len(hrefs) == 0 {
 		return svg, nil
 	}
 	var client *http.Client
@@ -85,79 +199,118 @@ func bundle(ctx context.Context, l simplelog.Logger, inputPath string, svg []byt
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
-	defer cancel()
-
-	return runWorkers(ctx, l, inputPath, svg, imgs, localFiles, isRemote, cacheImages, client, policy)
+	budget := &bundleBudget{
+		maxFetchedBytes: maxFetchedImageBytes,
+		maxSourceBytes:  maxSourceImageBytes,
+		maxBundledBytes: maxBundledImageBytes,
+	}
+	return runWorkers(ctx, l, inputPath, svg, matches, hrefs, localFiles, isRemote, cacheImages, client, policy, budget)
 }
 
-// filterImageElements finds all unique image elements in imgs that are
-// eligible for bundling in the current context.
-func filterImageElements(imgs [][][]byte, isRemote bool) [][][]byte {
-	unq := make(map[string]struct{})
-	imgs2 := imgs[:0]
-	for _, img := range imgs {
-		href := string(img[1])
-		if _, ok := unq[href]; ok {
-			continue
+// findImageElements records every eligible occurrence, but returns each href
+// only once for fetching. Iterative matching avoids allocating an unbounded
+// regexp result before the reference ceiling can be enforced.
+func findImageElements(ctx context.Context, svg []byte, isRemote bool) ([]imageMatch, []string, error) {
+	var matches []imageMatch
+	var hrefs []string
+	unique := make(map[string]struct{})
+	for offset := 0; offset < len(svg); {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
 		}
-		unq[href] = struct{}{}
+		indices := imageRegex.FindSubmatchIndex(svg[offset:])
+		if indices == nil {
+			break
+		}
+		match := imageMatch{
+			start:     offset + indices[0],
+			end:       offset + indices[1],
+			hrefStart: offset + indices[2],
+			hrefEnd:   offset + indices[3],
+		}
+		offset = match.end
+		hrefBytes := svg[match.hrefStart:match.hrefEnd]
 
-		// Skip already bundled images.
-		if strings.HasPrefix(href, "data:") {
+		// Skip already bundled images before applying the locator limit: a valid
+		// data URI may be larger than the source image it contains.
+		if bytes.HasPrefix(hrefBytes, []byte("data:")) {
 			continue
 		}
+		href := string(hrefBytes)
 
 		u, err := url.Parse(html.UnescapeString(href))
-		isRemoteImg := err == nil && strings.HasPrefix(u.Scheme, "http")
-
-		if isRemoteImg == isRemote {
-			imgs2 = append(imgs2, img)
+		isRemoteImage := err == nil && strings.HasPrefix(u.Scheme, "http")
+		if isRemoteImage != isRemote {
+			continue
+		}
+		if len(hrefBytes) > maxImageReferenceBytes {
+			return nil, nil, &bundleLimitError{name: "image reference", actual: int64(len(hrefBytes)), limit: maxImageReferenceBytes}
+		}
+		if len(matches) == maxImageReferences {
+			return nil, nil, fmt.Errorf("image references exceed maximum of %d", maxImageReferences)
+		}
+		matches = append(matches, match)
+		if _, ok := unique[href]; !ok {
+			unique[href] = struct{}{}
+			hrefs = append(hrefs, href)
 		}
 	}
-	return imgs2
+	return matches, hrefs, nil
 }
 
-func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, imgs [][][]byte, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) (_ []byte, err error) {
+func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg []byte, matches []imageMatch, hrefs []string, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy, budget *bundleBudget) (_ []byte, err error) {
 	var wg sync.WaitGroup
 	replc := make(chan repl)
 
-	wg.Add(len(imgs))
+	wg.Add(len(hrefs))
 	go func() {
 		wg.Wait()
 		close(replc)
 	}()
 
-	// Limits the number of workers to 16.
-	sema := make(chan struct{}, 16)
-
-	var errhrefsMu sync.Mutex
+	sema := make(chan struct{}, maxImageWorkers)
 	var errhrefs []string
+	var failedCount int
+	var limitErr error
+	replacements := make(map[string][]byte, len(hrefs))
 
 	// Start workers as the sema allows.
 	go func() {
-		for _, img := range imgs {
-			img := img
-			sema <- struct{}{}
+		for i, href := range hrefs {
+			select {
+			case sema <- struct{}{}:
+			case <-ctx.Done():
+				for range hrefs[i:] {
+					wg.Done()
+				}
+				return
+			}
+			if budget.exhausted() != nil {
+				<-sema
+				for range hrefs[i:] {
+					wg.Done()
+				}
+				return
+			}
 			go func() {
 				defer func() {
 					wg.Done()
 					<-sema
 				}()
 
-				bundledImage, err := worker(ctx, l, inputPath, img[1], localFiles, isRemote, cacheImages, client, policy)
+				bundledImage, err := worker(ctx, l, inputPath, href, localFiles, isRemote, cacheImages, client, policy, budget)
 				if err != nil {
-					l.Error(fmt.Sprintf("failed to bundle %s: %v", img[1], err))
-					errhrefsMu.Lock()
-					errhrefs = append(errhrefs, string(img[1]))
-					errhrefsMu.Unlock()
-					return
+					l.Error(fmt.Sprintf("failed to bundle %s: %s",
+						boundedLabel(href, maxImageReferenceLabelBytes),
+						boundedLabel(err.Error(), maxImageErrorLabelBytes),
+					))
 				}
 				select {
 				case <-ctx.Done():
 				case replc <- repl{
-					from: img[0],
+					href: href,
 					to:   bundledImage,
+					err:  err,
 				}:
 				}
 			}()
@@ -174,14 +327,80 @@ func runWorkers(ctx context.Context, l simplelog.Logger, inputPath string, svg [
 			l.Info("fetching images...")
 		case repl, ok := <-replc:
 			if !ok {
-				if len(errhrefs) > 0 {
-					return svg, fmt.Errorf("%v", errhrefs)
+				output, err := applyReplacements(ctx, svg, matches, replacements, maxBundledOutputBytes)
+				if err != nil {
+					return svg, errors.Join(err, limitErr)
 				}
-				return svg, nil
+				if len(errhrefs) > 0 {
+					failureErr := fmt.Errorf("%v", errhrefs)
+					if failedCount > len(errhrefs) {
+						failureErr = fmt.Errorf("%v (and %d more)", errhrefs, failedCount-len(errhrefs))
+					}
+					return output, errors.Join(failureErr, limitErr)
+				}
+				return output, nil
 			}
-			svg = bytes.Replace(svg, repl.from, repl.to, -1)
+			if repl.err != nil {
+				failedCount++
+				if len(errhrefs) < maxReportedImageFailures {
+					errhrefs = append(errhrefs, boundedLabel(repl.href, maxImageReferenceLabelBytes))
+				}
+				var bundleLimit *bundleLimitError
+				if limitErr == nil && errors.As(repl.err, &bundleLimit) {
+					limitErr = bundleLimit
+				}
+				continue
+			}
+			replacements[repl.href] = repl.to
 		}
 	}
+}
+
+func boundedLabel(label string, maxBytes int) string {
+	if len(label) <= maxBytes {
+		return label
+	}
+	return label[:maxBytes-3] + "..."
+}
+
+func applyReplacements(ctx context.Context, svg []byte, matches []imageMatch, replacements map[string][]byte, maxOutputBytes int64) ([]byte, error) {
+	if len(replacements) == 0 {
+		return svg, nil
+	}
+	outputBytes := int64(len(svg))
+	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		replacement, ok := replacements[string(svg[match.hrefStart:match.hrefEnd])]
+		if !ok {
+			continue
+		}
+		outputBytes += int64(len(replacement)) - int64(match.end-match.start)
+		if outputBytes > maxOutputBytes {
+			return nil, &bundleLimitError{name: "bundled SVG output", actual: outputBytes, limit: maxOutputBytes}
+		}
+	}
+	if outputBytes > maxOutputBytes {
+		return nil, &bundleLimitError{name: "bundled SVG output", actual: outputBytes, limit: maxOutputBytes}
+	}
+
+	output := make([]byte, 0, int(outputBytes))
+	previous := 0
+	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		replacement, ok := replacements[string(svg[match.hrefStart:match.hrefEnd])]
+		if !ok {
+			continue
+		}
+		output = append(output, svg[previous:match.start]...)
+		output = append(output, replacement...)
+		previous = match.end
+	}
+	output = append(output, svg[previous:]...)
+	return output, nil
 }
 
 type imageCacheKey struct {
@@ -191,11 +410,15 @@ type imageCacheKey struct {
 	localPolicyKey       string
 }
 
-func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []byte, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy) ([]byte, error) {
-	cacheKey := imageCacheKey{href: string(href), isRemote: isRemote, allowPrivateNetworks: policy.AllowPrivateNetworks}
+func worker(ctx context.Context, l simplelog.Logger, inputPath string, href string, localFiles localfile.Policy, isRemote, cacheImages bool, client *http.Client, policy netpolicy.Policy, budget *bundleBudget) ([]byte, error) {
+	if err := budget.exhausted(); err != nil {
+		return nil, err
+	}
+	cacheKey := imageCacheKey{href: href, isRemote: isRemote, allowPrivateNetworks: policy.AllowPrivateNetworks}
+	hrefLabel := boundedLabel(href, maxImageReferenceLabelBytes)
 	localPath := ""
 	if !isRemote {
-		localPath = html.UnescapeString(string(href))
+		localPath = html.UnescapeString(href)
 		if inputPath != "-" && !filepath.IsAbs(localPath) {
 			localPath = filepath.Join(filepath.Dir(inputPath), localPath)
 		}
@@ -207,45 +430,57 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 	}
 	if cacheImages {
 		if hit, ok := imgCache.Load(cacheKey); ok {
-			return hit.([]byte), nil
+			if err := budget.reserveBundled(int64(len(hit))); err != nil {
+				return nil, err
+			}
+			return hit, nil
 		}
 	}
 	var buf []byte
 	var mimeType string
 	var err error
 	if isRemote {
-		l.Debug(fmt.Sprintf("fetching %s remotely", string(href)))
-		buf, mimeType, err = httpGet(ctx, l, client, html.UnescapeString(string(href)))
+		l.Debug(fmt.Sprintf("fetching %s remotely", hrefLabel))
+		buf, mimeType, err = httpGet(ctx, l, client, html.UnescapeString(href), budget)
 	} else {
-		l.Debug(fmt.Sprintf("reading %s from disk", string(href)))
-		buf, err = readLocal(ctx, localFiles, localPath)
+		l.Debug(fmt.Sprintf("reading %s from disk", hrefLabel))
+		buf, err = readLocal(ctx, localFiles, localPath, budget)
 	}
 	if err != nil {
+		return nil, err
+	}
+	if err := budget.reserveSource(int64(len(buf))); err != nil {
 		return nil, err
 	}
 
 	declaredMIMEType := mimeType
 	mimeType, ok := canonicalImageMIMEType(declaredMIMEType)
 	if !ok {
-		mimeType, ok = sniffImageMIMEType(href, buf, isRemote)
+		mimeType, ok = sniffImageMIMEType([]byte(href), buf, isRemote)
 		if !ok {
 			mimeType = "application/octet-stream"
 		}
-		l.Debug(fmt.Sprintf("invalid or unsupported mimetype %q - sniffed MIME type for %s: %s", declaredMIMEType, string(href), mimeType))
+		l.Debug(fmt.Sprintf("invalid or unsupported mimetype %q - sniffed MIME type for %s: %s", declaredMIMEType, hrefLabel, mimeType))
 	} else {
-		l.Debug(fmt.Sprintf("mimetype provided for %s: %s", string(href), mimeType))
+		l.Debug(fmt.Sprintf("mimetype provided for %s: %s", hrefLabel, mimeType))
 	}
-	b64 := base64.StdEncoding.EncodeToString(buf)
-	dataURI := fmt.Sprintf("data:%s;base64,%s", mimeType, b64)
-
-	out := []byte(fmt.Sprintf(`<image href="%s"`, svg.EscapeText(dataURI)))
+	prefix := `<image href="data:` + svg.EscapeText(mimeType) + `;base64,`
+	encodedBytes := base64.StdEncoding.EncodedLen(len(buf))
+	outputBytes := len(prefix) + encodedBytes + 1
+	if err := budget.reserveBundled(int64(outputBytes)); err != nil {
+		return nil, err
+	}
+	out := make([]byte, outputBytes)
+	copy(out, prefix)
+	base64.StdEncoding.Encode(out[len(prefix):len(prefix)+encodedBytes], buf)
+	out[len(out)-1] = '"'
 	if cacheImages {
 		imgCache.Store(cacheKey, out)
 	}
 	return out, nil
 }
 
-func readLocal(ctx context.Context, localFiles localfile.Policy, filePath string) (_ []byte, err error) {
+func readLocal(ctx context.Context, localFiles localfile.Policy, filePath string, budget *bundleBudget) (_ []byte, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -268,7 +503,7 @@ func readLocal(ctx context.Context, localFiles localfile.Policy, filePath string
 	if info.Size() > maxImageSize {
 		return nil, fmt.Errorf("local image exceeds maximum size of %d bytes", maxImageSize)
 	}
-	buf, err := io.ReadAll(io.LimitReader(file, maxImageSize+1))
+	buf, err := io.ReadAll(&bundleBudgetReader{ctx: ctx, reader: io.LimitReader(file, maxImageSize+1), budget: budget})
 	if err != nil {
 		return nil, err
 	}
@@ -283,9 +518,10 @@ func readLocal(ctx context.Context, localFiles localfile.Policy, filePath string
 
 var httpClient = &http.Client{}
 
-func httpGet(ctx context.Context, l simplelog.Logger, client *http.Client, href string) ([]byte, string, error) {
+func httpGet(ctx context.Context, l simplelog.Logger, client *http.Client, href string, budget *bundleBudget) ([]byte, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	hrefLabel := boundedLabel(href, maxImageReferenceLabelBytes)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", href, nil)
 	if err != nil {
@@ -307,12 +543,12 @@ func httpGet(ctx context.Context, l simplelog.Logger, client *http.Client, href 
 		return nil, "", err
 	}
 	defer resp.Body.Close()
-	l.Debug(fmt.Sprintf("fetched %s remotely - response code %v", string(href), resp.StatusCode))
+	l.Debug(fmt.Sprintf("fetched %s remotely - response code %v", hrefLabel, resp.StatusCode))
 	if resp.StatusCode != 200 {
 		return nil, "", fmt.Errorf("expected status 200 but got %d %s", resp.StatusCode, resp.Status)
 	}
 	r := http.MaxBytesReader(nil, resp.Body, maxImageSize)
-	buf, err := io.ReadAll(r)
+	buf, err := io.ReadAll(&bundleBudgetReader{ctx: ctx, reader: r, budget: budget})
 	if err != nil {
 		return nil, "", err
 	}
@@ -321,7 +557,7 @@ func httpGet(ctx context.Context, l simplelog.Logger, client *http.Client, href 
 	if contentEncoding != "" {
 		buf, err = decodeContentEncoding(buf, contentEncoding)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to decode %q response for %s: %w", contentEncoding, href, err)
+			return nil, "", fmt.Errorf("failed to decode %q response for %s: %w", contentEncoding, hrefLabel, err)
 		}
 	}
 	l.Debug(fmt.Sprintf("fetched content type: %s, Content length: %d bytes", contentType, len(buf)))

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -15,7 +15,6 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/andybalholm/brotli"
@@ -64,7 +63,7 @@ func TestRegex(t *testing.T) {
 }
 
 func TestInlineRemote(t *testing.T) {
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	ctx := log.With(context.Background(), testlog.New(t))
 	svgURL := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	pngURL := "https://cdn4.iconfinder.com/data/icons/smart-phones-technologies/512/android-phone.png"
@@ -125,7 +124,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		t.Fatal("no png image inserted")
 	}
 
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	// Test almost too large response
 	httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
 		respRecorder := httptest.NewRecorder()
@@ -140,7 +139,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		t.Fatal(err)
 	}
 
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	// Test too large response
 	httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
 		respRecorder := httptest.NewRecorder()
@@ -155,7 +154,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		t.Fatal("expected error")
 	}
 
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	// Test error response
 	httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
 		respRecorder := httptest.NewRecorder()
@@ -169,7 +168,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 }
 
 func TestInlineLocal(t *testing.T) {
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	ctx := log.With(context.Background(), testlog.New(t))
 	svgURL, err := filepath.Abs("./test_svg.svg")
 	if err != nil {
@@ -268,7 +267,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 // TestDuplicateURL ensures that we don't fetch the same image twice
 func TestDuplicateURL(t *testing.T) {
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	ctx := log.With(context.Background(), testlog.New(t))
 	url1 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	url2 := "https://icons.terrastruct.com/essentials/004-picture.svg"
@@ -323,7 +322,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 }
 
 func TestInlineRemoteCompressedSVG(t *testing.T) {
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	ctx := log.With(context.Background(), testlog.New(t))
 	svgURL := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	rawSVG := []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>`)
@@ -449,9 +448,15 @@ func TestInlineRemoteContentTypeIsSafeAndCanonical(t *testing.T) {
 			body:        testPNGFile,
 			wantType:    "image/png",
 		},
+		{
+			name:        "XML-sensitive subtype",
+			contentType: "image/x&y",
+			body:        testPNGFile,
+			wantType:    "image/x&y",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			imgCache = sync.Map{}
+			imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 			httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
 				if req.URL.String() != imageURL {
 					t.Fatalf("unexpected URL %s", req.URL)
@@ -506,7 +511,7 @@ func assertBundledImageHref(t *testing.T, source []byte, wantHref string) {
 }
 
 func TestImgCache(t *testing.T) {
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	ctx := log.With(context.Background(), testlog.New(t))
 	url1 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	url2 := "https://icons.terrastruct.com/essentials/004-picture.svg"

--- a/lib/imgbundler/local_policy_test.go
+++ b/lib/imgbundler/local_policy_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/d2lang/d2/internal/testlog"
@@ -155,7 +154,7 @@ func writeLocalPolicyImage(t *testing.T, directory, name, contents string) strin
 
 func localPolicyContext(t *testing.T) context.Context {
 	t.Helper()
-	imgCache = sync.Map{}
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 	return log.With(context.Background(), testlog.New(t))
 }
 

--- a/lib/imgbundler/network_policy_test.go
+++ b/lib/imgbundler/network_policy_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -62,7 +61,7 @@ func TestBundleRemoteNetworkPolicy(t *testing.T) {
 	})
 
 	t.Run("cache is separated by policy", func(t *testing.T) {
-		imgCache = sync.Map{}
+		imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
 		mappedClient := httpClient
 		httpClient = server.Client()
 		before := privateHits.Load()

--- a/lib/imgbundler/resource_limits_test.go
+++ b/lib/imgbundler/resource_limits_test.go
@@ -1,0 +1,266 @@
+package imgbundler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d2lang/d2/internal/testlog"
+	"github.com/d2lang/d2/lib/localfile"
+	"github.com/d2lang/d2/lib/log"
+	"github.com/d2lang/d2/lib/netpolicy"
+	"github.com/d2lang/d2/lib/simplelog"
+)
+
+func TestBundleCapsImageReferences(t *testing.T) {
+	imagePath := filepath.Join(t.TempDir(), "image.svg")
+	if err := os.WriteFile(imagePath, []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	makeSource := func(references int) []byte {
+		var source strings.Builder
+		source.WriteString(`<svg xmlns="http://www.w3.org/2000/svg">`)
+		for i := 0; i < references; i++ {
+			fmt.Fprintf(&source, `<image href="%s"/>`, imagePath)
+		}
+		source.WriteString(`</svg>`)
+		return []byte(source.String())
+	}
+
+	ctx := log.With(context.Background(), testlog.New(t))
+	if _, err := BundleLocalWithPolicy(ctx, simplelog.FromLibLog(ctx), "-", makeSource(maxImageReferences), localfile.Unrestricted(), false); err != nil {
+		t.Fatalf("inclusive reference limit failed: %v", err)
+	}
+	_, err := BundleLocalWithPolicy(ctx, simplelog.FromLibLog(ctx), "-", makeSource(maxImageReferences+1), localfile.Unrestricted(), false)
+	if err == nil {
+		t.Fatal("BundleLocal accepted more than 4,096 image references")
+	}
+	if !strings.Contains(err.Error(), "image references exceed maximum of 4096") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func imageCacheStats(cache *imageCache) (entries int, bytes int64) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return len(cache.entries), cache.bytes
+}
+
+func TestApplyReplacementsCapsOutputAndHandlesDuplicates(t *testing.T) {
+	source := []byte(`<svg><image href="same"/><g/><image href="same"/></svg>`)
+	matches, hrefs, err := findImageElements(context.Background(), source, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 || len(hrefs) != 1 {
+		t.Fatalf("got %d matches and %d unique hrefs", len(matches), len(hrefs))
+	}
+	replacement := []byte(`<image href="data:image/png;base64,AAAA"`)
+	want := bytes.ReplaceAll(source, []byte(`<image href="same"`), replacement)
+
+	output, err := applyReplacements(context.Background(), source, matches, map[string][]byte{"same": replacement}, int64(len(want)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, want) {
+		t.Fatalf("unexpected output:\n%s\nwant:\n%s", output, want)
+	}
+	_, err = applyReplacements(context.Background(), source, matches, map[string][]byte{"same": replacement}, int64(len(want)-1))
+	if err == nil || !strings.Contains(err.Error(), "bundled SVG output exceeds maximum") {
+		t.Fatalf("expected output limit error, got %v", err)
+	}
+}
+
+func TestBundleBudgetIsCumulativeAndSticky(t *testing.T) {
+	budget := &bundleBudget{maxFetchedBytes: 6, maxSourceBytes: 6, maxBundledBytes: 6}
+	if err := budget.reserveBundled(4); err != nil {
+		t.Fatal(err)
+	}
+	if err := budget.reserveBundled(3); err == nil {
+		t.Fatal("budget accepted cumulative bytes above its limit")
+	}
+	if err := budget.reserveBundled(2); err == nil {
+		t.Fatal("budget continued after its first limit error")
+	}
+	if err := budget.reserveSource(1); err == nil {
+		t.Fatal("one exhausted dimension did not stop the operation")
+	}
+}
+
+func TestRunWorkersEnforcesCumulativeBundleBudget(t *testing.T) {
+	imagePath := filepath.Join(t.TempDir(), "image.svg")
+	if err := os.WriteFile(imagePath, []byte(`<svg/>`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := localPolicySVG(imagePath)
+	matches, hrefs, err := findImageElements(context.Background(), source, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name        string
+		budget      *bundleBudget
+		wantMessage string
+	}{
+		{name: "fetched bytes", budget: &bundleBudget{maxFetchedBytes: 1, maxSourceBytes: 1 << 20, maxBundledBytes: 1 << 20}, wantMessage: "cumulative fetched image bytes exceeds maximum"},
+		{name: "source bytes", budget: &bundleBudget{maxFetchedBytes: 1 << 20, maxSourceBytes: 1, maxBundledBytes: 1 << 20}, wantMessage: "cumulative source image bytes exceeds maximum"},
+		{name: "bundled bytes", budget: &bundleBudget{maxFetchedBytes: 1 << 20, maxSourceBytes: 1 << 20, maxBundledBytes: 1}, wantMessage: "cumulative bundled image bytes exceeds maximum"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := log.With(context.Background(), testlog.New(t))
+			output, err := runWorkers(ctx, simplelog.FromLibLog(ctx), "-", source, matches, hrefs, localfile.Unrestricted(), false, false, nil, netpolicy.Policy{}, tc.budget)
+			if err == nil || !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("expected cumulative byte limit error, got %v", err)
+			}
+			if !bytes.Equal(output, source) {
+				t.Fatal("failed resource changed output")
+			}
+		})
+	}
+}
+
+func TestAggregateLimitStopsSchedulingNewFetches(t *testing.T) {
+	var source strings.Builder
+	source.WriteString(`<svg>`)
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&source, `<image href="https://example.com/%d"/>`, i)
+	}
+	source.WriteString(`</svg>`)
+	sourceBytes := []byte(source.String())
+	matches, hrefs, err := findImageElements(context.Background(), sourceBytes, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) *http.Response {
+		requests.Add(1)
+		response := httptest.NewRecorder()
+		response.Header().Set("Content-Type", "image/png")
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.WriteString("xx")
+		return response.Result()
+	})}
+	ctx := log.With(context.Background(), testlog.New(t))
+	_, err = runWorkers(ctx, simplelog.FromLibLog(ctx), "-", sourceBytes, matches, hrefs, localfile.Policy{}, true, false, client, netpolicy.Policy{}, &bundleBudget{maxFetchedBytes: 1, maxSourceBytes: 1 << 20, maxBundledBytes: 1 << 20})
+	if err == nil || !strings.Contains(err.Error(), "cumulative fetched image bytes exceeds maximum") {
+		t.Fatalf("expected cumulative fetch limit error, got %v", err)
+	}
+	if got := requests.Load(); got > maxImageWorkers {
+		t.Fatalf("aggregate failure allowed %d requests, worker ceiling %d", got, maxImageWorkers)
+	}
+}
+
+func TestWorkerChargesCacheHitToBundleBudget(t *testing.T) {
+	previousCache := imgCache
+	imgCache = newImageCache(maxImageCacheEntries, maxImageCacheBytes)
+	t.Cleanup(func() { imgCache = previousCache })
+	href := "https://example.com/image.png"
+	value := []byte(`<image href="data:image/png;base64,AAAA"`)
+	imgCache.Store(imageCacheKey{href: href, isRemote: true}, value)
+
+	ctx := log.With(context.Background(), testlog.New(t))
+	_, err := worker(ctx, simplelog.FromLibLog(ctx), "", href, localfile.Policy{}, true, true, nil, netpolicy.Policy{}, &bundleBudget{maxFetchedBytes: 1, maxSourceBytes: 1, maxBundledBytes: int64(len(value) - 1)})
+	if err == nil || !strings.Contains(err.Error(), "cumulative bundled image bytes exceeds maximum") {
+		t.Fatalf("expected cached value to consume aggregate budget, got %v", err)
+	}
+	output, err := worker(ctx, simplelog.FromLibLog(ctx), "", href, localfile.Policy{}, true, true, nil, netpolicy.Policy{}, &bundleBudget{maxFetchedBytes: 1, maxSourceBytes: 1, maxBundledBytes: int64(len(value))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, value) {
+		t.Fatal("cache hit changed value")
+	}
+}
+
+func TestImageCacheIsBoundedLRU(t *testing.T) {
+	cache := newImageCache(2, 1<<20)
+	first := imageCacheKey{href: "first"}
+	second := imageCacheKey{href: "second"}
+	third := imageCacheKey{href: "third"}
+	cache.Store(first, []byte("1"))
+	cache.Store(second, []byte("2"))
+	if _, ok := cache.Load(first); !ok {
+		t.Fatal("first cache entry unexpectedly missing")
+	}
+	cache.Store(third, []byte("3"))
+	if _, ok := cache.Load(second); ok {
+		t.Fatal("cache did not evict its least-recently-used entry")
+	}
+	if entries, _ := imageCacheStats(cache); entries != 2 {
+		t.Fatalf("cache retained %d entries, want 2", entries)
+	}
+
+	entryBytes := imageCacheEntryBytes(first, []byte("1234"))
+	byteCache := newImageCache(2, entryBytes)
+	byteCache.Store(first, []byte("1234"))
+	other := imageCacheKey{href: "other"}
+	byteCache.Store(other, []byte("1234"))
+	entries, bytes := imageCacheStats(byteCache)
+	if entries != 1 || bytes > entryBytes {
+		t.Fatalf("byte-bounded cache retained %d entries and %d bytes", entries, bytes)
+	}
+	if _, ok := byteCache.Load(first); ok {
+		t.Fatal("byte-bounded cache did not evict its oldest entry")
+	}
+	if _, ok := byteCache.Load(other); !ok {
+		t.Fatal("byte-bounded cache did not retain the replacement entry")
+	}
+}
+
+func TestConfiguredImageCacheCapsEntries(t *testing.T) {
+	cache := newImageCache(maxImageCacheEntries, maxImageCacheBytes)
+	for i := 0; i < maxImageCacheEntries+1; i++ {
+		cache.Store(imageCacheKey{href: fmt.Sprintf("image-%d", i)}, []byte("x"))
+	}
+	entries, bytes := imageCacheStats(cache)
+	if entries != maxImageCacheEntries {
+		t.Fatalf("cache retained %d entries, want %d", entries, maxImageCacheEntries)
+	}
+	if bytes > maxImageCacheBytes {
+		t.Fatalf("cache retained %d bytes, limit %d", bytes, maxImageCacheBytes)
+	}
+}
+
+func TestBundleSkipsLargeDataURI(t *testing.T) {
+	href := "data:image/png;base64," + strings.Repeat("A", maxImageReferenceBytes)
+	source := []byte(fmt.Sprintf(`<svg><image href="%s"/></svg>`, href))
+	ctx := log.With(context.Background(), testlog.New(t))
+	output, err := BundleRemote(ctx, simplelog.FromLibLog(ctx), source, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, source) {
+		t.Fatal("already-bundled data URI changed")
+	}
+}
+
+func TestBundleIgnoresOversizedReferencesForOtherPass(t *testing.T) {
+	remoteHref := "https://example.com/" + strings.Repeat("a", maxImageReferenceBytes)
+	source := []byte(fmt.Sprintf(`<svg><image href="%s"/></svg>`, remoteHref))
+	ctx := log.With(context.Background(), testlog.New(t))
+	output, err := BundleLocalWithPolicy(ctx, simplelog.FromLibLog(ctx), "-", source, localfile.Unrestricted(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, source) {
+		t.Fatal("remote reference changed during local bundling")
+	}
+}
+
+func TestBundleCapsEligibleReferenceBytes(t *testing.T) {
+	href := strings.Repeat("a", maxImageReferenceBytes+1)
+	source := []byte(fmt.Sprintf(`<svg><image href="%s"/></svg>`, href))
+	ctx := log.With(context.Background(), testlog.New(t))
+	_, err := BundleLocalWithPolicy(ctx, simplelog.FromLibLog(ctx), "-", source, localfile.Unrestricted(), false)
+	if err == nil || !strings.Contains(err.Error(), "image reference exceeds maximum") {
+		t.Fatalf("expected image-reference limit error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

Legacy SVG image bundling previously imposed a 32 MiB limit on each individual image, but no limit on the number or aggregate size of images in one render. A small attacker-controlled SVG containing 4,097 references to the same tiny local image was accepted, and distinct images could make the bundler retain hundreds of megabytes per operation. Each unique replacement also copied the complete SVG again, producing quadratic work, while the optional process-wide image cache retained entries forever.

This is an availability vulnerability for preview services, editor workers, CI jobs, and other long-lived processes that bundle attacker-controlled SVG assets. The local-image variant requires the referenced files to be allowed by the caller's local-resource policy; the remote variant requires network access. It does not by itself cross either policy boundary.

### What changed

- Allow at most 4,096 eligible image references and 64 KiB per locator.
- Apply independent inclusive 512 MiB budgets to fetched bytes, decoded source bytes, generated data-URI bytes, and final SVG output.
- Charge fetches incrementally in 32 KiB chunks and stop scheduling work after the first aggregate-limit failure; no more than the existing 16 workers can already be in flight.
- Charge cache hits to the current render's output budget.
- Collect matches incrementally and apply all replacements in one source-order pass, eliminating repeated whole-document copying while retaining duplicate-URL fetch deduplication and partial-success behavior.
- Replace the unbounded global cache with a concurrency-safe LRU limited to 4,096 entries and 512 MiB of key/value data.
- Bound logged and returned failure labels so a large reference set cannot create another oversized error.
- Add exact-boundary, over-limit, cache-eviction, duplicate-reference, and worker-stop regressions.

These ceilings align with the existing raster asset pipeline. Already-bundled data URIs are exempt from the locator ceiling, and the local-only pass continues to ignore remote locators. The CLI's local and remote bundling passes have separate aggregate source/fetch/data-URI budgets, but each pass enforces the same final-output ceiling and the remote pass receives the local pass's resulting size.

### Verification

- Focused resource-limit tests repeated 10 times
- `go test -race ./lib/imgbundler`
- `go test ./...`
- `go vet ./...`
- Post-rebase `go test ./lib/imgbundler`
- Post-rebase `go vet ./lib/imgbundler`
- `git diff --check`
