### PR TITLE
security: validate raw render targets

### DIFF
--- a/d2js/d2wasm/api_test.go
+++ b/d2js/d2wasm/api_test.go
@@ -4,10 +4,82 @@ package d2wasm
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"syscall/js"
 	"testing"
+
+	"github.com/d2lang/d2/d2target"
 )
+
+func TestRenderRejectsMalformedDiagramBeforeBoardTraversal(t *testing.T) {
+	request := RenderRequest{
+		Diagram: &d2target.Diagram{Layers: []*d2target.Diagram{nil}},
+	}
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	call := wrapWASMCall(Render)
+	defer call.Release()
+	got := call.Invoke(string(encoded)).String()
+	var response WASMResponse
+	if err := json.Unmarshal([]byte(got), &response); err != nil {
+		t.Fatalf("invalid response %q: %v", got, err)
+	}
+	if response.Error == nil || response.Error.Code != 400 || !strings.Contains(response.Error.Message, "root.layers[0] is nil") {
+		t.Fatalf("error = %#v, want invalid-diagram response", response.Error)
+	}
+}
+
+func TestRenderAnimationDefaultsMissingPadding(t *testing.T) {
+	animateInterval := int64(1_000)
+	request := RenderRequest{
+		Diagram: d2target.NewDiagram(),
+		Opts:    &RenderOptions{AnimateInterval: &animateInterval},
+	}
+	response := invokeRenderRequest(t, request)
+	if response.Error != nil {
+		t.Fatalf("Render() error = %#v", response.Error)
+	}
+	if response.Data == nil {
+		t.Fatal("Render() returned no animated SVG")
+	}
+}
+
+func TestRenderRejectsAppendixAnimation(t *testing.T) {
+	animateInterval := int64(1_000)
+	forceAppendix := true
+	request := RenderRequest{
+		Diagram: d2target.NewDiagram(),
+		Opts: &RenderOptions{
+			AnimateInterval: &animateInterval,
+			ForceAppendix:   &forceAppendix,
+		},
+	}
+	response := invokeRenderRequest(t, request)
+	if response.Error == nil || response.Error.Code != 400 || response.Error.Message != "forceAppendix is not supported for animated SVGs" {
+		t.Fatalf("Render() error = %#v, want unsupported-options response", response.Error)
+	}
+}
+
+func invokeRenderRequest(t *testing.T, request RenderRequest) WASMResponse {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	call := wrapWASMCall(Render)
+	defer call.Release()
+	got := call.Invoke(string(encoded)).String()
+	var response WASMResponse
+	if err := json.Unmarshal([]byte(got), &response); err != nil {
+		t.Fatalf("invalid response %q: %v", got, err)
+	}
+	return response
+}
 
 func TestDeprecatedRawWASMCallsWarnOnceAndRemainCallable(t *testing.T) {
 	t.Run("getObjOrder", func(t *testing.T) {

--- a/d2js/d2wasm/functions.go
+++ b/d2js/d2wasm/functions.go
@@ -356,11 +356,15 @@ func Render(args []js.Value) (interface{}, error) {
 	if input.Diagram == nil {
 		return nil, &WASMError{Message: "missing 'diagram' field in input JSON", Code: 400}
 	}
+	if err := d2target.ValidateRenderTarget(input.Diagram); err != nil {
+		return nil, &WASMError{Message: fmt.Sprintf("invalid diagram: %s", err.Error()), Code: 400}
+	}
 
 	animateInterval := 0
 	if input.Opts != nil && input.Opts.AnimateInterval != nil && *input.Opts.AnimateInterval > 0 {
 		animateInterval = int(*input.Opts.AnimateInterval)
 	}
+	forceAppendix := input.Opts != nil && input.Opts.ForceAppendix != nil && *input.Opts.ForceAppendix
 
 	var boardPath []string
 	noChildren := true
@@ -479,7 +483,9 @@ func Render(args []js.Value) (interface{}, error) {
 		return out, nil
 	}
 
-	forceAppendix := input.Opts != nil && input.Opts.ForceAppendix != nil && *input.Opts.ForceAppendix
+	if animateInterval > 0 && forceAppendix {
+		return nil, &WASMError{Message: "forceAppendix is not supported for animated SVGs", Code: 400}
+	}
 
 	var boards [][]byte
 	if noChildren {

--- a/d2renderers/d2animate/d2animate.go
+++ b/d2renderers/d2animate/d2animate.go
@@ -44,15 +44,22 @@ func makeKeyframe(delayMS, durationMS, totalMS, identifier int, diagramHash stri
 }
 
 func Wrap(rootDiagram *d2target.Diagram, svgs [][]byte, renderOpts d2svg.RenderOpts, intervalMS int) ([]byte, error) {
+	if err := d2target.ValidateRenderTarget(rootDiagram); err != nil {
+		return nil, err
+	}
 	buf := &bytes.Buffer{}
 
 	// TODO account for stroke width of root border
 
+	pad := d2svg.DEFAULT_PADDING
+	if renderOpts.Pad != nil {
+		pad = int(*renderOpts.Pad)
+	}
 	tl, br := rootDiagram.NestedBoundingBox()
-	left := tl.X - int(*renderOpts.Pad)
-	top := tl.Y - int(*renderOpts.Pad)
-	width := br.X - tl.X + int(*renderOpts.Pad)*2
-	height := br.Y - tl.Y + int(*renderOpts.Pad)*2
+	left := tl.X - pad
+	top := tl.Y - pad
+	width := br.X - tl.X + pad*2
+	height := br.Y - tl.Y + pad*2
 
 	var dimensions string
 	if renderOpts.Scale != nil {

--- a/d2renderers/d2animate/d2animate_test.go
+++ b/d2renderers/d2animate/d2animate_test.go
@@ -1,0 +1,29 @@
+package d2animate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestWrapDefaultsMissingPadding(t *testing.T) {
+	diagram := d2target.NewDiagram()
+	out, err := Wrap(diagram, [][]byte{[]byte(`<g></g>`)}, d2svg.RenderOpts{}, 1_000)
+	if err != nil {
+		t.Fatalf("Wrap() error = %v", err)
+	}
+	if !strings.Contains(string(out), `viewBox="0 0 200 200"`) {
+		t.Fatalf("Wrap() did not use default padding: %q", out)
+	}
+}
+
+func TestWrapRejectsMalformedTargetBeforeTraversal(t *testing.T) {
+	diagram := d2target.NewDiagram()
+	diagram.Layers = []*d2target.Diagram{nil}
+
+	if _, err := Wrap(diagram, [][]byte{[]byte(`<g></g>`)}, d2svg.RenderOpts{}, 1_000); err == nil || !strings.Contains(err.Error(), "root.layers[0] is nil") {
+		t.Fatalf("Wrap() error = %v, want malformed-target error", err)
+	}
+}

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -2473,6 +2473,15 @@ func EmbedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fon
 }
 
 func embedFonts(buf *bytes.Buffer, diagramHash, source string, fontFamily *d2fonts.FontFamily, monoFontFamily *d2fonts.FontFamily, corpus string, corpora fontCorpora) {
+	if fontFamily == nil || *fontFamily == "" {
+		family := d2fonts.SourceSansPro
+		fontFamily = &family
+	}
+	if monoFontFamily == nil || *monoFontFamily == "" {
+		family := d2fonts.SourceCodePro
+		monoFontFamily = &family
+	}
+
 	// Markdown generates text that may not exist literally in the D2 source,
 	// such as list markers and decoded entities. Include those rendered runs in
 	// every font subset, including multi-board animations where render-local
@@ -2838,17 +2847,36 @@ func appendOnTriggerLazy(buf *bytes.Buffer, source string, triggers []string, ne
 var DEFAULT_DARK_THEME *int64 = nil // no theme selected
 
 func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
+	if diagram == nil {
+		return nil, fmt.Errorf("render target is nil")
+	}
+	if err := validateRenderLinks(diagram); err != nil {
+		return nil, err
+	}
+	if err := d2target.ValidateRenderTarget(diagram); err != nil {
+		return nil, err
+	}
+	return renderValidated(diagram, opts)
+}
+
+func validateRenderLinks(diagram *d2target.Diagram) error {
 	for _, targetShape := range diagram.Shapes {
 		if textmeasure.IsDangerousLink(targetShape.Link) {
-			return nil, fmt.Errorf("shape %q uses an unsafe link URL scheme", targetShape.ID)
+			return fmt.Errorf("shape %q uses an unsafe link URL scheme", targetShape.ID)
 		}
 	}
 	for _, connection := range diagram.Connections {
 		if textmeasure.IsDangerousLink(connection.Link) {
-			return nil, fmt.Errorf("connection %q uses an unsafe link URL scheme", connection.ID)
+			return fmt.Errorf("connection %q uses an unsafe link URL scheme", connection.ID)
 		}
 	}
+	return nil
+}
 
+// renderValidated renders one board after its complete target tree has been
+// validated. Keeping this internal lets RenderMultiboard avoid repeatedly
+// walking every descendant subtree.
+func renderValidated(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 	sketch := false
 	pad := DEFAULT_PADDING
 	tl, br := diagram.BoundingBox()
@@ -3515,23 +3543,30 @@ func hash(s string) string {
 }
 
 func RenderMultiboard(diagram *d2target.Diagram, opts *RenderOpts) ([][]byte, error) {
+	if err := d2target.ValidateRenderTarget(diagram); err != nil {
+		return nil, err
+	}
+	return renderMultiboard(diagram, opts)
+}
+
+func renderMultiboard(diagram *d2target.Diagram, opts *RenderOpts) ([][]byte, error) {
 	var boards [][]byte
 	for _, dl := range diagram.Layers {
-		childrenBoards, err := RenderMultiboard(dl, opts)
+		childrenBoards, err := renderMultiboard(dl, opts)
 		if err != nil {
 			return nil, err
 		}
 		boards = append(boards, childrenBoards...)
 	}
 	for _, dl := range diagram.Scenarios {
-		childrenBoards, err := RenderMultiboard(dl, opts)
+		childrenBoards, err := renderMultiboard(dl, opts)
 		if err != nil {
 			return nil, err
 		}
 		boards = append(boards, childrenBoards...)
 	}
 	for _, dl := range diagram.Steps {
-		childrenBoards, err := RenderMultiboard(dl, opts)
+		childrenBoards, err := renderMultiboard(dl, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -3539,7 +3574,10 @@ func RenderMultiboard(diagram *d2target.Diagram, opts *RenderOpts) ([][]byte, er
 	}
 
 	if !diagram.IsFolderOnly {
-		out, err := Render(diagram, opts)
+		if err := validateRenderLinks(diagram); err != nil {
+			return boards, err
+		}
+		out, err := renderValidated(diagram, opts)
 		if err != nil {
 			return boards, err
 		}

--- a/d2renderers/d2svg/markdown.go
+++ b/d2renderers/d2svg/markdown.go
@@ -25,11 +25,11 @@ type markdownRenderer struct {
 }
 
 func newMarkdownRenderer(fontFamily, monoFontFamily *d2fonts.FontFamily, inlineTheme *d2themes.Theme) *markdownRenderer {
-	if fontFamily == nil {
+	if fontFamily == nil || *fontFamily == "" {
 		family := d2fonts.SourceSansPro
 		fontFamily = &family
 	}
-	if monoFontFamily == nil {
+	if monoFontFamily == nil || *monoFontFamily == "" {
 		family := d2fonts.SourceCodePro
 		monoFontFamily = &family
 	}

--- a/d2renderers/d2svg/render_target_validation_test.go
+++ b/d2renderers/d2svg/render_target_validation_test.go
@@ -1,0 +1,413 @@
+package d2svg_test
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+	"github.com/d2lang/d2/lib/geo"
+	"github.com/d2lang/d2/lib/label"
+)
+
+func TestRenderRejectsMalformedJSONTargetsWithoutPanicking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*d2target.Diagram)
+		wantError string
+	}{
+		{
+			name: "unsupported source arrowhead",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].SrcArrow = d2target.Arrowhead("attacker-controlled")
+			},
+			wantError: "unsupported arrowhead",
+		},
+		{
+			name: "unsupported destination arrowhead",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].DstArrow = d2target.Arrowhead("attacker-controlled")
+			},
+			wantError: "unsupported arrowhead",
+		},
+		{
+			name: "missing arrowhead value",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].DstArrow = ""
+			},
+			wantError: "unsupported arrowhead",
+		},
+		{
+			name: "empty route",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Route = nil
+			},
+			wantError: "at least two points",
+		},
+		{
+			name: "one-point route",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Route = diagram.Connections[0].Route[:1]
+			},
+			wantError: "at least two points",
+		},
+		{
+			name: "nil route point",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Route[0] = nil
+			},
+			wantError: "route[0] is nil",
+		},
+		{
+			name: "zero-length route segment",
+			configure: func(diagram *d2target.Diagram) {
+				point := *diagram.Connections[0].Route[0]
+				diagram.Connections[0].Route[1] = &point
+			},
+			wantError: "finite, non-zero segment length",
+		},
+		{
+			name: "non-normalizable route segment",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Route[1] = &geo.Point{X: math.SmallestNonzeroFloat64, Y: 30}
+			},
+			wantError: "finite, non-zero segment length",
+		},
+		{
+			name: "out-of-bounds route coordinate",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Route[1].X = math.MaxFloat64
+			},
+			wantError: "must fit integer bounds arithmetic",
+		},
+		{
+			name: "invalid cubic route length",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].IsCurve = true
+			},
+			wantError: "1+3n points",
+		},
+		{
+			name: "missing labeled-connection position",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Label = "label"
+				diagram.Connections[0].LabelPosition = ""
+			},
+			wantError: "not a connection label position",
+		},
+		{
+			name: "invalid labeled-connection position",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].Label = "label"
+				diagram.Connections[0].LabelPosition = "attacker-controlled"
+			},
+			wantError: "not a connection label position",
+		},
+		{
+			name: "out-of-range label percentage",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].LabelPercentage = math.MaxFloat64
+			},
+			wantError: "labelPercentage",
+		},
+		{
+			name: "root dash geometry",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Root.StrokeWidth = 18
+				diagram.Root.StrokeDash = 1
+			},
+			wantError: "finite non-negative dash lengths",
+		},
+		{
+			name: "shape dash geometry",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Shapes[0].StrokeWidth = 18
+				diagram.Shapes[0].StrokeDash = 1
+			},
+			wantError: "finite non-negative dash lengths",
+		},
+		{
+			name: "connection dash geometry",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Connections[0].StrokeWidth = 18
+				diagram.Connections[0].StrokeDash = 1
+			},
+			wantError: "finite non-negative dash lengths",
+		},
+		{
+			name: "unregistered regular font family",
+			configure: func(diagram *d2target.Diagram) {
+				family := d2fonts.FontFamily("attacker-controlled")
+				diagram.FontFamily = &family
+			},
+			wantError: "not a registered font family",
+		},
+		{
+			name: "unregistered mono font family",
+			configure: func(diagram *d2target.Diagram) {
+				family := d2fonts.FontFamily("attacker-controlled")
+				diagram.MonoFontFamily = &family
+			},
+			wantError: "not a registered font family",
+		},
+		{
+			name: "image without icon",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Shapes[0].Type = d2target.ShapeImage
+				diagram.Shapes[0].Icon = nil
+			},
+			wantError: "image is missing an icon",
+		},
+		{
+			name: "nil layer",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Layers = []*d2target.Diagram{nil}
+			},
+			wantError: "root.layers[0] is nil",
+		},
+		{
+			name: "nil scenario",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Scenarios = []*d2target.Diagram{nil}
+			},
+			wantError: "root.scenarios[0] is nil",
+		},
+		{
+			name: "nil step",
+			configure: func(diagram *d2target.Diagram) {
+				diagram.Steps = []*d2target.Diagram{nil}
+			},
+			wantError: "root.steps[0] is nil",
+		},
+		{
+			name: "unsupported legend arrowhead",
+			configure: func(diagram *d2target.Diagram) {
+				connection := *d2target.BaseConnection()
+				connection.Label = "connection"
+				connection.DstArrow = d2target.Arrowhead("attacker-controlled")
+				diagram.Legend = &d2target.Legend{Connections: []d2target.Connection{connection}}
+			},
+			wantError: "unsupported arrowhead",
+		},
+		{
+			name: "legend shape dash geometry",
+			configure: func(diagram *d2target.Diagram) {
+				shape := *d2target.BaseShape()
+				shape.Label = "shape"
+				shape.StrokeWidth = 18
+				shape.StrokeDash = 1
+				diagram.Legend = &d2target.Legend{Shapes: []d2target.Shape{shape}}
+			},
+			wantError: "finite non-negative dash lengths",
+		},
+		{
+			name: "legend connection dash geometry",
+			configure: func(diagram *d2target.Diagram) {
+				connection := *d2target.BaseConnection()
+				connection.Label = "connection"
+				connection.StrokeWidth = 18
+				connection.StrokeDash = 1
+				diagram.Legend = &d2target.Legend{Connections: []d2target.Connection{connection}}
+			},
+			wantError: "finite non-negative dash lengths",
+		},
+		{
+			name: "legend image without icon",
+			configure: func(diagram *d2target.Diagram) {
+				shape := *d2target.BaseShape()
+				shape.Type = d2target.ShapeImage
+				shape.Label = "image"
+				diagram.Legend = &d2target.Legend{Shapes: []d2target.Shape{shape}}
+			},
+			wantError: "image is missing an icon",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := validRenderTarget()
+			test.configure(diagram)
+			diagram = roundTripRenderTarget(t, diagram)
+
+			out, err := renderWithoutPanic(t, diagram)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("Render() output/error = %q/%v, want error containing %q", out, err, test.wantError)
+			}
+			if out != nil {
+				t.Fatalf("Render() returned output on error: %q", out)
+			}
+		})
+	}
+}
+
+func TestRenderRejectsNonFiniteDirectTargetWithoutPanicking(t *testing.T) {
+	t.Parallel()
+
+	diagram := validRenderTarget()
+	diagram.Connections[0].Route[0].X = math.Inf(1)
+	out, err := renderWithoutPanic(t, diagram)
+	if err == nil || !strings.Contains(err.Error(), "finite coordinates") {
+		t.Fatalf("Render() output/error = %q/%v, want finite-coordinate error", out, err)
+	}
+}
+
+func TestRenderDefaultsMissingOrEmptyJSONFontFamilies(t *testing.T) {
+	t.Parallel()
+
+	empty := d2fonts.FontFamily("")
+	for _, test := range []struct {
+		name        string
+		regularFont *d2fonts.FontFamily
+		monoFont    *d2fonts.FontFamily
+	}{
+		{name: "missing"},
+		{name: "empty", regularFont: &empty, monoFont: &empty},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := validRenderTarget()
+			diagram.FontFamily = test.regularFont
+			diagram.MonoFontFamily = test.monoFont
+			diagram.Shapes[0].FontFamily = "default"
+			diagram.Shapes[0].Bold = false
+			monoShape := diagram.Shapes[0]
+			monoShape.ID = "mono"
+			monoShape.Pos.Y = 80
+			monoShape.FontFamily = "mono"
+			diagram.Shapes = append(diagram.Shapes, monoShape)
+			diagram = roundTripRenderTarget(t, diagram)
+
+			out, err := renderWithoutPanic(t, diagram)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			if !strings.Contains(string(out), "font-regular") || !strings.Contains(string(out), "font-mono") {
+				t.Fatalf("Render() did not embed both default font families")
+			}
+		})
+	}
+}
+
+func TestRenderAcceptsValidJSONTarget(t *testing.T) {
+	t.Parallel()
+
+	diagram := roundTripRenderTarget(t, validRenderTarget())
+	out, err := renderWithoutPanic(t, diagram)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !strings.Contains(string(out), `<svg`) {
+		t.Fatalf("Render() output is not SVG: %q", out)
+	}
+}
+
+func TestRenderAcceptsLegendConnectionWithSynthesizedRoute(t *testing.T) {
+	diagram := validRenderTarget()
+	connection := *d2target.BaseConnection()
+	connection.Label = "connection"
+	diagram.Legend = &d2target.Legend{Connections: []d2target.Connection{connection}}
+	diagram = roundTripRenderTarget(t, diagram)
+
+	if _, err := renderWithoutPanic(t, diagram); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+}
+
+func TestRenderRejectsCyclicBoardBeforeHashing(t *testing.T) {
+	diagram := validRenderTarget()
+	diagram.Layers = []*d2target.Diagram{diagram}
+
+	if _, err := renderWithoutPanic(t, diagram); err == nil || !strings.Contains(err.Error(), "reuses board") {
+		t.Fatalf("Render() error = %v, want reused-board error", err)
+	}
+}
+
+func TestRenderMultiboardRetainsNestedLinkValidation(t *testing.T) {
+	root := d2target.NewDiagram()
+	child := validRenderTarget()
+	child.Shapes[0].Link = "javascript:alert(1)"
+	root.Layers = []*d2target.Diagram{child}
+
+	if _, err := d2svg.RenderMultiboard(root, nil); err == nil || !strings.Contains(err.Error(), "unsafe link URL scheme") {
+		t.Fatalf("RenderMultiboard() error = %v, want unsafe-link error", err)
+	}
+}
+
+func TestRenderAcceptsRegisteredCustomFontFamily(t *testing.T) {
+	family, err := d2fonts.AddFontFamily("render-validation-custom", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("AddFontFamily() error = %v", err)
+	}
+	diagram := validRenderTarget()
+	diagram.FontFamily = family
+	diagram = roundTripRenderTarget(t, diagram)
+
+	if _, err := renderWithoutPanic(t, diagram); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+}
+
+func validRenderTarget() *d2target.Diagram {
+	fontFamily := d2fonts.SourceSansPro
+	monoFontFamily := d2fonts.SourceCodePro
+	diagram := d2target.NewDiagram()
+	diagram.FontFamily = &fontFamily
+	diagram.MonoFontFamily = &monoFontFamily
+	diagram.Root.Stroke = "transparent"
+
+	targetShape := *d2target.BaseShape()
+	targetShape.ID = "shape"
+	targetShape.Type = d2target.ShapeRectangle
+	targetShape.Pos = d2target.Point{X: 0, Y: 0}
+	targetShape.Width = 100
+	targetShape.Height = 60
+	targetShape.Fill = "#ffffff"
+	targetShape.Stroke = "#000000"
+	targetShape.Label = "shape"
+	targetShape.LabelPosition = label.InsideMiddleCenter.String()
+	targetShape.FontSize = d2fonts.FONT_SIZE_M
+	targetShape.LabelWidth = 40
+	targetShape.LabelHeight = 20
+	diagram.Shapes = []d2target.Shape{targetShape}
+
+	connection := *d2target.BaseConnection()
+	connection.ID = "connection"
+	connection.Src = targetShape.ID
+	connection.Dst = targetShape.ID
+	connection.Stroke = "#000000"
+	connection.Route = []*geo.Point{{X: 0, Y: 30}, {X: 100, Y: 30}}
+	diagram.Connections = []d2target.Connection{connection}
+
+	return diagram
+}
+
+func roundTripRenderTarget(t *testing.T, diagram *d2target.Diagram) *d2target.Diagram {
+	t.Helper()
+	encoded, err := json.Marshal(diagram)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var decoded d2target.Diagram
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	return &decoded
+}
+
+func renderWithoutPanic(t *testing.T, diagram *d2target.Diagram) (out []byte, err error) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("Render() panicked: %v", recovered)
+		}
+	}()
+	return d2svg.Render(diagram, nil)
+}

--- a/d2target/render_validation.go
+++ b/d2target/render_validation.go
@@ -1,0 +1,437 @@
+package d2target
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/d2lang/d2/d2renderers/d2fonts"
+	"github.com/d2lang/d2/lib/label"
+	"github.com/d2lang/d2/lib/svg"
+)
+
+const (
+	// Bound raw render targets before they reach recursive hashing and
+	// multi-board rendering. Validation itself remains iterative.
+	maxRenderTargetBoardDepth = 1_024
+	maxRenderTargetBoardCount = 4_096
+)
+
+// ValidateRenderTarget checks the invariants required by renderers which
+// consume Diagram JSON directly. Compiler output already satisfies these
+// invariants, but callers of the public render API can construct a Diagram
+// without going through the compiler.
+func ValidateRenderTarget(root *Diagram) error {
+	if root == nil {
+		return fmt.Errorf("render target is nil")
+	}
+
+	type boardEntry struct {
+		diagram *Diagram
+		path    string
+		depth   int
+	}
+
+	stack := []boardEntry{{diagram: root, path: "root"}}
+	seen := map[*Diagram]string{root: "root"}
+	boardCount := 1
+
+	for len(stack) > 0 {
+		entry := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		if err := validateRenderBoard(entry.diagram, entry.path); err != nil {
+			return err
+		}
+
+		groups := []struct {
+			name     string
+			children []*Diagram
+		}{
+			{name: "layers", children: entry.diagram.Layers},
+			{name: "scenarios", children: entry.diagram.Scenarios},
+			{name: "steps", children: entry.diagram.Steps},
+		}
+		// Push in reverse so errors follow the renderer's layers, scenarios,
+		// steps traversal order without using recursive calls.
+		for groupIndex := len(groups) - 1; groupIndex >= 0; groupIndex-- {
+			group := groups[groupIndex]
+			for childIndex := len(group.children) - 1; childIndex >= 0; childIndex-- {
+				child := group.children[childIndex]
+				childPath := fmt.Sprintf("%s.%s[%d]", entry.path, group.name, childIndex)
+				if child == nil {
+					return fmt.Errorf("render target board %s is nil", childPath)
+				}
+				childDepth := entry.depth + 1
+				if childDepth > maxRenderTargetBoardDepth {
+					return fmt.Errorf("render target board tree exceeds depth %d at %s", maxRenderTargetBoardDepth, childPath)
+				}
+				if firstPath, ok := seen[child]; ok {
+					return fmt.Errorf("render target board %s reuses board %s", childPath, firstPath)
+				}
+				boardCount++
+				if boardCount > maxRenderTargetBoardCount {
+					return fmt.Errorf("render target board tree exceeds %d total boards", maxRenderTargetBoardCount)
+				}
+				seen[child] = childPath
+				stack = append(stack, boardEntry{diagram: child, path: childPath, depth: childDepth})
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateRenderBoard(diagram *Diagram, path string) error {
+	if err := validateRenderFontFamily(diagram.FontFamily, path+".fontFamily"); err != nil {
+		return err
+	}
+	if err := validateRenderFontFamily(diagram.MonoFontFamily, path+".monoFontFamily"); err != nil {
+		return err
+	}
+	if err := validateRenderShapeNumbers(diagram.Root, path+".root"); err != nil {
+		return err
+	}
+	for i, targetShape := range diagram.Shapes {
+		if err := validateRenderShape(targetShape, fmt.Sprintf("%s.shapes[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+
+	for i, connection := range diagram.Connections {
+		if err := validateRenderConnection(connection, fmt.Sprintf("%s.connections[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+
+	if diagram.Legend != nil {
+		for i, targetShape := range diagram.Legend.Shapes {
+			if err := validateRenderLegendShape(targetShape, fmt.Sprintf("%s.legend.shapes[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		for i, connection := range diagram.Legend.Connections {
+			connectionPath := fmt.Sprintf("%s.legend.connections[%d]", path, i)
+			if err := validateRenderLegendConnection(connection, connectionPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateRenderLegendShape(targetShape Shape, path string) error {
+	// Legend rendering replaces the icon geometry and suppresses the shape's
+	// own label. Validate only the numeric fields which survive that projection.
+	targetShape.Pos = Point{}
+	targetShape.Width = 1
+	targetShape.Height = 1
+	targetShape.Text.Label = ""
+	targetShape.Text.FontSize = 0
+	targetShape.Text.LabelWidth = 0
+	targetShape.Text.LabelHeight = 0
+	return validateRenderShape(targetShape, path)
+}
+
+func validateRenderLegendConnection(connection Connection, path string) error {
+	// Legend rendering synthesizes its own two-point route and suppresses the
+	// connection label. Project the fields it copies before applying numeric
+	// validation so harmless unused JSON fields remain compatible.
+	legendConnection := *BaseConnection()
+	legendConnection.SrcArrow = connection.SrcArrow
+	legendConnection.DstArrow = connection.DstArrow
+	legendConnection.StrokeDash = connection.StrokeDash
+	legendConnection.StrokeWidth = connection.StrokeWidth
+	legendConnection.BorderRadius = connection.BorderRadius
+	legendConnection.Opacity = connection.Opacity
+	if err := validateRenderConnectionNumbers(legendConnection, path); err != nil {
+		return err
+	}
+	if err := validateRenderArrowhead(connection.SrcArrow, path+".srcArrow"); err != nil {
+		return err
+	}
+	return validateRenderArrowhead(connection.DstArrow, path+".dstArrow")
+}
+
+func validateRenderShape(targetShape Shape, path string) error {
+	if err := validateRenderShapeNumbers(targetShape, path); err != nil {
+		return err
+	}
+	if targetShape.Type == ShapeImage && targetShape.Icon == nil {
+		return fmt.Errorf("render target %s image is missing an icon", path)
+	}
+	return nil
+}
+
+func validateRenderConnection(connection Connection, path string) error {
+	if err := validateRenderConnectionNumbers(connection, path); err != nil {
+		return err
+	}
+	if err := validateRenderArrowhead(connection.SrcArrow, path+".srcArrow"); err != nil {
+		return err
+	}
+	if err := validateRenderArrowhead(connection.DstArrow, path+".dstArrow"); err != nil {
+		return err
+	}
+	if len(connection.Route) < 2 {
+		return fmt.Errorf("render target %s.route must contain at least two points", path)
+	}
+	if connection.IsCurve && (len(connection.Route)-1)%3 != 0 {
+		return fmt.Errorf("render target %s.route must contain 1+3n points for a cubic connection", path)
+	}
+	for i, point := range connection.Route {
+		if point == nil {
+			return fmt.Errorf("render target %s.route[%d] is nil", path, i)
+		}
+		if !finiteRenderNumber(point.X) || !finiteRenderNumber(point.Y) {
+			return fmt.Errorf("render target %s.route[%d] must contain finite coordinates", path, i)
+		}
+		pointPath := fmt.Sprintf("%s.route[%d]", path, i)
+		if err := validateRenderRouteCoordinate(pointPath, "x", point.X, connection.StrokeWidth); err != nil {
+			return err
+		}
+		if err := validateRenderRouteCoordinate(pointPath, "y", point.Y, connection.StrokeWidth); err != nil {
+			return err
+		}
+		if i > 0 {
+			previous := connection.Route[i-1]
+			dx, dy := point.X-previous.X, point.Y-previous.Y
+			lengthSquared := dx*dx + dy*dy
+			if !finiteRenderNumber(lengthSquared) || lengthSquared == 0 {
+				return fmt.Errorf("render target %s.route[%d:%d] must have a finite, non-zero segment length", path, i-1, i)
+			}
+		}
+	}
+
+	if connection.Label != "" {
+		position := label.FromString(connection.LabelPosition)
+		if !position.IsEdgePosition() {
+			return fmt.Errorf("render target %s.labelPosition %q is not a connection label position", path, connection.LabelPosition)
+		}
+		if !finiteRenderNumber(connection.LabelPercentage) {
+			return fmt.Errorf("render target %s.labelPercentage must be finite", path)
+		}
+		labelTopLeft := connection.GetLabelTopLeft()
+		if labelTopLeft == nil || !finiteRenderNumber(labelTopLeft.X) || !finiteRenderNumber(labelTopLeft.Y) {
+			return fmt.Errorf("render target %s.labelPosition does not resolve to a finite point on the route", path)
+		}
+	}
+
+	for _, endpoint := range []struct {
+		name  string
+		label *Text
+		isDst bool
+	}{
+		{name: "srcLabel", label: connection.SrcLabel},
+		{name: "dstLabel", label: connection.DstLabel, isDst: true},
+	} {
+		if endpoint.label == nil || endpoint.label.Label == "" {
+			continue
+		}
+		labelTopLeft := connection.GetArrowheadLabelPosition(endpoint.isDst)
+		if labelTopLeft == nil || !finiteRenderNumber(labelTopLeft.X) || !finiteRenderNumber(labelTopLeft.Y) {
+			return fmt.Errorf("render target %s.%s does not resolve to a finite point on the route", path, endpoint.name)
+		}
+	}
+
+	return nil
+}
+
+func validateRenderArrowhead(arrowhead Arrowhead, path string) error {
+	switch arrowhead {
+	case NoArrowhead,
+		ArrowArrowhead,
+		UnfilledTriangleArrowhead,
+		TriangleArrowhead,
+		LineArrowhead,
+		FilledDiamondArrowhead,
+		DiamondArrowhead,
+		FilledCircleArrowhead,
+		CircleArrowhead,
+		CrossArrowhead,
+		FilledBoxArrowhead,
+		BoxArrowhead,
+		CfOne,
+		CfMany,
+		CfOneRequired,
+		CfManyRequired:
+		return nil
+	default:
+		return fmt.Errorf("render target %s uses unsupported arrowhead %q", path, arrowhead)
+	}
+}
+
+func validateRenderFontFamily(family *d2fonts.FontFamily, path string) error {
+	if family == nil || *family == "" {
+		return nil
+	}
+	for _, style := range d2fonts.FontStyles {
+		font := d2fonts.Font{Family: *family, Style: style}
+		face, ok := d2fonts.FontFaces.Lookup(font)
+		if !ok || len(face) == 0 {
+			return fmt.Errorf("render target %s %q is not a registered font family", path, *family)
+		}
+	}
+	return nil
+}
+
+func validateRenderShapeNumbers(targetShape Shape, path string) error {
+	for _, field := range []struct {
+		name  string
+		value int
+	}{
+		{name: "width", value: targetShape.Width},
+		{name: "height", value: targetShape.Height},
+		{name: "strokeWidth", value: targetShape.StrokeWidth},
+		{name: "borderRadius", value: targetShape.BorderRadius},
+		{name: "iconBorderRadius", value: targetShape.IconBorderRadius},
+	} {
+		if field.value < 0 {
+			return invalidRenderField(path, field.name, field.value, "must be non-negative")
+		}
+	}
+	if err := validateRenderOpacity(path, targetShape.Opacity); err != nil {
+		return err
+	}
+	if err := validateRenderDash(path, targetShape.StrokeDash, targetShape.StrokeWidth); err != nil {
+		return err
+	}
+	if targetShape.ContentAspectRatio != nil && (!finiteRenderNumber(*targetShape.ContentAspectRatio) || *targetShape.ContentAspectRatio <= 0) {
+		return invalidRenderField(path, "contentAspectRatio", *targetShape.ContentAspectRatio, "must be finite and greater than zero")
+	}
+	if err := validateRenderTextNumbers(path, "", targetShape.Text); err != nil {
+		return err
+	}
+	return validateRenderShapeIntegerBounds(path, targetShape)
+}
+
+func validateRenderConnectionNumbers(connection Connection, path string) error {
+	if connection.StrokeWidth < 0 {
+		return invalidRenderField(path, "strokeWidth", connection.StrokeWidth, "must be non-negative")
+	}
+	if err := validateRenderOpacity(path, connection.Opacity); err != nil {
+		return err
+	}
+	if err := validateRenderDash(path, connection.StrokeDash, connection.StrokeWidth); err != nil {
+		return err
+	}
+	if !finiteRenderNumber(connection.BorderRadius) || connection.BorderRadius < 0 {
+		return invalidRenderField(path, "borderRadius", connection.BorderRadius, "must be finite and non-negative")
+	}
+	if !finiteRenderNumber(connection.IconBorderRadius) || connection.IconBorderRadius < 0 {
+		return invalidRenderField(path, "iconBorderRadius", connection.IconBorderRadius, "must be finite and non-negative")
+	}
+	if !finiteRenderNumber(connection.LabelPercentage) || connection.LabelPercentage < 0 || connection.LabelPercentage > 1 {
+		return invalidRenderField(path, "labelPercentage", connection.LabelPercentage, "must be finite and within [0,1]")
+	}
+	if err := validateRenderTextNumbers(path, "", connection.Text); err != nil {
+		return err
+	}
+	if connection.SrcLabel != nil {
+		if err := validateRenderTextNumbers(path, "srcLabel.", *connection.SrcLabel); err != nil {
+			return err
+		}
+	}
+	if connection.DstLabel != nil {
+		if err := validateRenderTextNumbers(path, "dstLabel.", *connection.DstLabel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRenderOpacity(path string, opacity float64) error {
+	if !finiteRenderNumber(opacity) || opacity < 0 || opacity > 1 {
+		return invalidRenderField(path, "opacity", opacity, "must be finite and within [0,1]")
+	}
+	return nil
+}
+
+func validateRenderDash(path string, dash float64, strokeWidth int) error {
+	if !finiteRenderNumber(dash) || dash < 0 {
+		return invalidRenderField(path, "strokeDash", dash, "must be finite and non-negative")
+	}
+	if dash > 0 && strokeWidth > 0 {
+		dashSize, gapSize := svg.GetStrokeDashAttributes(float64(strokeWidth), dash)
+		if !finiteRenderNumber(dashSize) || !finiteRenderNumber(gapSize) || dashSize < 0 || gapSize < 0 {
+			return invalidRenderField(path, "strokeDash", dash, "must produce finite non-negative dash lengths with strokeWidth")
+		}
+	}
+	return nil
+}
+
+func validateRenderTextNumbers(path, prefix string, text Text) error {
+	for _, field := range []struct {
+		name  string
+		value int
+	}{
+		{name: prefix + "fontSize", value: text.FontSize},
+		{name: prefix + "labelWidth", value: text.LabelWidth},
+		{name: prefix + "labelHeight", value: text.LabelHeight},
+	} {
+		if field.value < 0 {
+			return invalidRenderField(path, field.name, field.value, "must be non-negative")
+		}
+	}
+	return nil
+}
+
+func validateRenderShapeIntegerBounds(path string, targetShape Shape) error {
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	halfStroke := int64(targetShape.StrokeWidth/2 + targetShape.StrokeWidth%2)
+	for _, axis := range []struct {
+		name      string
+		position  int
+		dimension int
+	}{
+		{name: "pos.x", position: targetShape.Pos.X, dimension: targetShape.Width},
+		{name: "pos.y", position: targetShape.Pos.Y, dimension: targetShape.Height},
+	} {
+		if _, ok := checkedRenderSub(int64(axis.position), halfStroke, minInt, maxInt); !ok {
+			return invalidRenderField(path, axis.name, axis.position, "must fit bounds arithmetic with strokeWidth")
+		}
+		end, ok := checkedRenderAdd(int64(axis.position), int64(axis.dimension), minInt, maxInt)
+		if !ok {
+			return invalidRenderField(path, axis.name, axis.position, "must fit bounds arithmetic with its dimension")
+		}
+		if _, ok := checkedRenderAdd(end, halfStroke, minInt, maxInt); !ok {
+			return invalidRenderField(path, axis.name, axis.position, "must fit bounds arithmetic with strokeWidth")
+		}
+	}
+	return nil
+}
+
+func validateRenderRouteCoordinate(path, field string, coordinate float64, strokeWidth int) error {
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	halfStroke := math.Ceil(float64(strokeWidth) / 2)
+	// BoundingBox floors/ceils route coordinates and converts them to int.
+	// Strict comparisons avoid the rounded float64 representation of MaxInt.
+	if math.Floor(coordinate)-halfStroke <= float64(minInt) || math.Ceil(coordinate)+halfStroke >= float64(maxInt) {
+		return invalidRenderField(path, field, coordinate, "must fit integer bounds arithmetic")
+	}
+	return nil
+}
+
+func checkedRenderAdd(a, value, minInt, maxInt int64) (int64, bool) {
+	if value > 0 && a > maxInt-value || value < 0 && a < minInt-value {
+		return 0, false
+	}
+	return a + value, true
+}
+
+func checkedRenderSub(a, value, minInt, maxInt int64) (int64, bool) {
+	if value > 0 && a < minInt+value || value < 0 && a > maxInt+value {
+		return 0, false
+	}
+	return a - value, true
+}
+
+func invalidRenderField(path, field string, value any, requirement string) error {
+	return fmt.Errorf("render target %s.%s has invalid value %v: %s", path, field, value, requirement)
+}
+
+func finiteRenderNumber(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}

--- a/d2target/render_validation_test.go
+++ b/d2target/render_validation_test.go
@@ -1,0 +1,63 @@
+package d2target
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRenderTargetBoundsBoardTree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maximum depth", func(t *testing.T) {
+		root := NewDiagram()
+		cursor := root
+		for range maxRenderTargetBoardDepth {
+			child := NewDiagram()
+			cursor.Layers = []*Diagram{child}
+			cursor = child
+		}
+		if err := ValidateRenderTarget(root); err != nil {
+			t.Fatalf("ValidateRenderTarget() at maximum depth: %v", err)
+		}
+		if _, err := root.HashID(nil); err != nil {
+			t.Fatalf("HashID() at maximum validated depth: %v", err)
+		}
+
+		cursor.Layers = []*Diagram{NewDiagram()}
+		err := ValidateRenderTarget(root)
+		if err == nil || !strings.Contains(err.Error(), "exceeds depth") {
+			t.Fatalf("ValidateRenderTarget() error = %v, want depth error", err)
+		}
+	})
+
+	t.Run("maximum board count", func(t *testing.T) {
+		root := NewDiagram()
+		root.Layers = make([]*Diagram, maxRenderTargetBoardCount-1)
+		for i := range root.Layers {
+			root.Layers[i] = NewDiagram()
+		}
+		if err := ValidateRenderTarget(root); err != nil {
+			t.Fatalf("ValidateRenderTarget() at maximum board count: %v", err)
+		}
+		if _, err := root.HashID(nil); err != nil {
+			t.Fatalf("HashID() at maximum validated board count: %v", err)
+		}
+
+		root.Layers = append(root.Layers, NewDiagram())
+		err := ValidateRenderTarget(root)
+		if err == nil || !strings.Contains(err.Error(), "total boards") {
+			t.Fatalf("ValidateRenderTarget() error = %v, want board-count error", err)
+		}
+	})
+}
+
+func TestValidateRenderTargetRejectsReusedBoard(t *testing.T) {
+	t.Parallel()
+
+	root := NewDiagram()
+	root.Layers = []*Diagram{root}
+	err := ValidateRenderTarget(root)
+	if err == nil || !strings.Contains(err.Error(), "reuses board") {
+		t.Fatalf("ValidateRenderTarget() error = %v, want reused-board error", err)
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

The public JavaScript/WASM `D2.render(diagram)` API accepts serialized `d2target.Diagram` JSON without passing it through the compiler. The SVG and animation renderers nevertheless assumed compiler invariants: supported arrowheads, complete routes, non-nil points and icons, valid label positions, registered fonts, finite geometry, and a tree of non-nil boards. Tiny malformed requests could therefore panic on nil dereferences or out-of-range indexes. A cyclic board graph constructed by a direct Go caller recursed during hashing until the Go runtime terminated the process, which cannot be converted into an ordinary error with `recover`.

This is an availability vulnerability for browser workers, preview services, and long-lived Go processes that render attacker-controlled target JSON. Most individual panics kill the current WASM worker or Go request process; cyclic recursive hashing can take down the entire Go process. It does not affect ordinary D2 source that successfully passes through compilation.

### What changed

- Add one iterative pre-render validator for raw target trees, capped at 1,024 levels and 4,096 boards, and reject nil, cyclic, or reused board pointers before recursive hashing or traversal.
- Reject unsupported or missing arrowheads; short, nil, non-finite, zero-length, underflowing, or malformed cubic routes; invalid label positions/percentages; image shapes without icons; and missing legend image data.
- Validate the finite ranges and integer arithmetic used by opacity, dash geometry, shape bounds, route bounds, text dimensions, border radii, and aspect ratios so attacker values cannot become panics or `NaN`/`Inf` SVG.
- Default omitted or empty regular/mono font families, while rejecting non-empty families that have not been registered. Custom `AddFontFamily` families remain supported.
- Validate legend shapes and connections after projecting only the fields the legend renderer actually uses, preserving harmless unused JSON fields.
- Apply validation at the SVG, multiboard, animation, and WASM entry points. Multiboard rendering validates the tree once and uses an internal prevalidated path rather than repeatedly walking every descendant subtree.
- Make animation wrapping use the normal default padding when `pad` is omitted, and return a 400 response for the unsupported `animateInterval` plus `forceAppendix` SVG combination instead of passing an SVG fragment to appendix code that indexes absent document markers.

Valid compiler output and valid raw target JSON continue to render normally. Paint and fill-pattern trust is intentionally handled separately because external SVG paint URLs are a distinct browser-network issue rather than a structural panic.

### Verification

- Focused `d2target`, SVG, and animation validation tests
- Full JavaScript/WASM API tests under Node
- `go test ./...`
- `go vet ./...`
- Post-rebase `go test ./d2target ./d2renderers/d2svg ./d2renderers/d2animate`
- Post-rebase focused `go vet`
- `git diff --check`
