### PR TITLE
security: build CI formatter from checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
+      - name: Build the D2 formatter from this checkout
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/d2-ci-bin"
+          go build -trimpath -o "$RUNNER_TEMP/d2-ci-bin/d2" .
+          echo "$RUNNER_TEMP/d2-ci-bin" >> "$GITHUB_PATH"
       - run: COLOR=1 ./make.sh
         env:
           # Disable chat notifications from the shared CI helper.


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

When CI sees a changed `.d2` file and no `d2` executable on `PATH`, the shared formatter helper downloads `https://d2lang.com/install.sh` and pipes the current response directly to `sh`. Neither the script contents nor the D2 release selected by that script are pinned to the reviewed commit. A compromise, DNS/CDN error, or accidental replacement of the first-party installer could therefore execute arbitrary code as the GitHub Actions runner before the repository build and tests.

The workflow token is read-only and the helper clears `GITHUB_TOKEN` for the installer child process, which limits direct repository impact, but arbitrary same-UID runner code can still inspect runner state, alter the checkout or caches, and falsify the remainder of that CI job. The trigger requires a `.d2` change; an ordinary pull request can exercise it.

### What changed

- Build the D2 formatter from the exact checked-out source after the pinned Go setup step.
- Put only that runner-temporary binary directory on `GITHUB_PATH` before `make.sh` starts.
- Leave the shared formatter helper unchanged; because `d2` is now present, its mutable network bootstrap is not reached in this repository's CI.

This makes the formatter subject to the same reviewed source commit and Go module verification as the rest of the job. A source change that prevents D2 from compiling will now fail before formatting, which is an intentional fail-closed tradeoff. No release credential or new workflow permission is introduced.

The shared `d2lang/ci` helper should still replace its installer pipe for the benefit of its other consumers; this PR closes the D2 repository's own execution path independently.

### Verification

- Built the root command with the exact workflow command: `go build -trimpath`
- `actionlint` on `.github/workflows/ci.yml`
- `git diff --check`
