### PR TITLE
security: verify CI Pandoc package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,22 @@ jobs:
         with:
           go-version-file: ./go.mod
           cache: true
+      - name: Install verified Pandoc formatter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v pandoc >/dev/null; then
+            pandoc --version
+            exit 0
+          fi
+          PANDOC_VERSION="3.1"
+          PANDOC_DEB="$RUNNER_TEMP/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          curl --retry 5 --retry-all-errors --retry-delay 2 -fsSL \
+            "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb" \
+            -o "$PANDOC_DEB"
+          echo "3c9d3d992cb97591b404a31394d79dcca2e2e1d96095f15dfe18b32d6a95a551  $PANDOC_DEB" \
+            | sha256sum --check --strict
+          sudo dpkg -i "$PANDOC_DEB"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

When a CI change touches Markdown and the runner has no `pandoc` executable, the shared formatting helper downloads the Pandoc 3.1 Debian package from a GitHub release and immediately installs it with `sudo dpkg -i`. The version is fixed, but the downloaded bytes are not authenticated locally. If that release asset were compromised or replaced, its Debian maintainer scripts and payload would execute as root before the repository build and tests continue.

This is a CI supply-chain issue. Exploitation requires control of the Pandoc release asset or its delivery path despite HTTPS; a pull request can trigger the download by changing Markdown, but cannot choose the URL or digest. GitHub-hosted runners are ephemeral and the workflow token is read-only, which limits persistence and repository impact but does not make unauthenticated root code execution safe.

### What changed

- Ensure Pandoc is present before the shared formatter starts.
- If the runner does not already provide it, download the exact 3.1 amd64 Debian package with bounded retries into `RUNNER_TEMP`.
- Verify its pinned SHA-256 (`3c9d…a551`) with strict `sha256sum` checking before invoking `sudo dpkg -i`.
- Abort the job on any download, checksum, or installation failure.

The digest was reproduced from the official release asset and matches the existing pinned value used by Terrastruct's build setup. Runners that already have Pandoc continue using their installed copy, matching the shared helper's existing behavior. No new workflow permission is introduced.

The shared `d2lang/ci` helper should adopt the same checksum for its other consumers; this PR closes the D2 repository's own vulnerable path independently.

### Verification

- Downloaded and SHA-256 hashed the official `pandoc-3.1-1-amd64.deb` asset (26,026,624 bytes)
- Corroborated the digest against the existing pinned Terrastruct build action
- `actionlint` on `.github/workflows/ci.yml`
- `git diff --check`
