### PR TITLE
security: protect local npm publish token

### DIFF
--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 . "$(dirname "$0")/../../../ci/sub/lib.sh"
+. "$(dirname "$0")/npm-auth.sh"
 cd -- "$(dirname "$0")/.."
 
 cd ../..
@@ -84,7 +85,7 @@ if [ -n "${NPM_VERSION:-}" ]; then
   fi
 
   restore_package_files() {
-    rm -f .npmrc
+    remove_npm_auth_config
     if [ -f package.json.bak ]; then
       mv package.json.bak package.json
     fi
@@ -357,9 +358,10 @@ NODE
         exit 1
       fi
 
-      # Create .npmrc file with auth token. Direct publishing is retained only
-      # for local bootstrap or recovery; GitHub Actions uses trusted publishing.
-      echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      # Direct publishing is retained only for local bootstrap or recovery;
+      # GitHub Actions uses trusted publishing. Keep its short-lived token out
+      # of the checkout and in a private temporary npm user configuration.
+      create_npm_auth_config
 
       # Preflight every target before publishing either one. A retry may skip a
       # version only when the registry tarball exactly matches this run's pack.
@@ -393,7 +395,7 @@ NODE
         fi
 
         echo "Publishing ${package_name}@${PUBLISH_VERSION} with tag '${NPM_TAG}'..."
-        npm publish "$PACKAGE_TARBALL" --tag "$NPM_TAG"
+        NPM_CONFIG_USERCONFIG="$NPM_AUTH_CONFIG" npm publish "$PACKAGE_TARBALL" --tag "$NPM_TAG"
 
         published_verified=0
         for verify_attempt in 1 2 3 4 5; do

--- a/d2js/js/ci/npm-auth.sh
+++ b/d2js/js/ci/npm-auth.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This variable is deliberately initialized instead of inherited. Cleanup must
+# never remove a path supplied by the caller's environment.
+NPM_AUTH_CONFIG=
+
+create_npm_auth_config() {
+  NPM_AUTH_CONFIG=$(mktemp "${TMPDIR:-/tmp}/d2-npm-auth.XXXXXX")
+  chmod 600 "$NPM_AUTH_CONFIG"
+  printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" >"$NPM_AUTH_CONFIG"
+  unset NPM_TOKEN
+}
+
+remove_npm_auth_config() {
+  if [ -n "$NPM_AUTH_CONFIG" ]; then
+    rm -f "$NPM_AUTH_CONFIG"
+    NPM_AUTH_CONFIG=
+  fi
+}

--- a/d2js/js/ci/npm_auth_test.go
+++ b/d2js/js/ci/npm_auth_test.go
@@ -1,0 +1,124 @@
+package ci_test
+
+import (
+	"embed"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Include the shell implementation and its call site in the test inputs so
+// edits to either invalidate Go's test cache.
+//
+//go:embed npm-auth.sh build.sh
+var npmAuthSources embed.FS
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	runtime.KeepAlive(npmAuthSources)
+	os.Exit(code)
+}
+
+func TestNPMAuthConfigIsPrivateAndRemoved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell credential helper")
+	}
+	tempDir := t.TempDir()
+	helper := filepath.Join(tempDir, "npm-auth.sh")
+	source, err := npmAuthSources.ReadFile("npm-auth.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(helper, source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", "-c", `. "$1"
+umask 000
+NPM_TOKEN=unit-test-token
+create_npm_auth_config
+[ "${NPM_TOKEN+x}" != x ]
+printf '%s' "$NPM_AUTH_CONFIG"`, "sh", helper)
+	cmd.Env = append(os.Environ(), "TMPDIR="+tempDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("create npm auth config: %v: %s", err, output)
+	}
+	config := strings.TrimSpace(string(output))
+	t.Cleanup(func() { _ = os.Remove(config) })
+
+	info, err := os.Stat(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("npm auth config mode = %04o, want 0600", got)
+	}
+	contents, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "//registry.npmjs.org/:_authToken=unit-test-token\n" {
+		t.Fatal("npm auth config did not contain exactly the scoped registry credential")
+	}
+
+	checkout := filepath.Join(tempDir, "checkout")
+	if err := os.Mkdir(checkout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectConfig := filepath.Join(checkout, ".npmrc")
+	if err := os.WriteFile(projectConfig, []byte("project-setting=true\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	cleanup := exec.Command("sh", "-c", `. "$1"
+NPM_AUTH_CONFIG=$2
+remove_npm_auth_config`, "sh", helper, config)
+	cleanup.Dir = checkout
+	if output, err := cleanup.CombinedOutput(); err != nil {
+		t.Fatalf("remove npm auth config: %v: %s", err, output)
+	}
+	if _, err := os.Stat(config); !os.IsNotExist(err) {
+		t.Fatalf("npm auth config remains after cleanup: %v", err)
+	}
+	if contents, err := os.ReadFile(projectConfig); err != nil || string(contents) != "project-setting=true\n" {
+		t.Fatalf("cleanup changed the checkout's existing .npmrc: contents=%q err=%v", contents, err)
+	}
+}
+
+func TestNPMAuthConfigExitCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell credential helper")
+	}
+	tempDir := t.TempDir()
+	helper := filepath.Join(tempDir, "npm-auth.sh")
+	source, err := npmAuthSources.ReadFile("npm-auth.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(helper, source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	record := filepath.Join(tempDir, "config-path")
+	cmd := exec.Command("sh", "-c", `set -eu
+. "$1"
+trap remove_npm_auth_config EXIT
+NPM_TOKEN=unit-test-token
+create_npm_auth_config
+printf '%s' "$NPM_AUTH_CONFIG" >"$2"
+false`, "sh", helper, record)
+	cmd.Env = append(os.Environ(), "TMPDIR="+tempDir)
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("failure fixture unexpectedly succeeded: %s", output)
+	}
+	config, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(string(config)); !os.IsNotExist(err) {
+		t.Fatalf("npm auth config remains after error exit: %v", err)
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Why this is a security issue

The local direct-publish recovery path previously wrote `NPM_TOKEN` to `d2js/js/.npmrc` using ordinary shell redirection. With the common `022` umask, the file was mode `0644`. On a shared build host, another local account able to traverse the checkout could read that short-lived publishing credential; an abnormal exit could also leave it in the working tree for later accidental disclosure. A stolen token can publish malicious versions of whichever D2 npm package identities its scope permits.

This is a low-severity local-boundary issue. Exploitation requires an operator to select token-based recovery publishing plus an attacker with local filesystem access while the token exists, or later access to a leftover file. Production GitHub Actions publishing uses trusted publishing/OIDC and does not enter this branch.

### What changed

- Create a unique npm user configuration with `mktemp` and explicitly set mode `0600` before writing the registry-scoped credential.
- Keep the credential outside the checkout and pass it only to `npm publish` through `NPM_CONFIG_USERCONFIG`.
- Unset `NPM_TOKEN` before invoking npm.
- Remove the temporary credential idempotently through the existing exit trap on success or error.
- Initialize the internal path rather than inheriting it, so a caller cannot redirect cleanup to an arbitrary file.
- Preserve any pre-existing project `.npmrc` instead of deleting it during cleanup.

Package contents, version preflight, registry integrity checks, tags, and recovery publishing behavior are unchanged. An uncatchable `SIGKILL` can still leave the file in the temporary directory, but it remains owner-only. A process already running as the publishing user can still inspect that user's files or environment; least-privilege, short-lived npm tokens remain appropriate.

### Verification

- Tests prove mode `0600` even under `umask 000`, exact registry scope, environment removal, project `.npmrc` preservation, normal cleanup, and forced-error cleanup.
- `sh -n d2js/js/ci/build.sh d2js/js/ci/npm-auth.sh`
- `dash -n d2js/js/ci/build.sh d2js/js/ci/npm-auth.sh`
- `go test ./d2js/js/ci -count=10`
- `go vet ./d2js/js/ci`
- `go test -p 2 ./...`
- `go vet -p 2 ./...`
- `git diff --check`
