### PR TITLE
fix(svg): validate raw render paints

### DIFF
--- a/d2renderers/d2svg/color_attribute_escaping_test.go
+++ b/d2renderers/d2svg/color_attribute_escaping_test.go
@@ -1,10 +1,7 @@
 package d2svg_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"encoding/xml"
-	"io"
 	"strings"
 	"testing"
 
@@ -14,47 +11,46 @@ import (
 	"github.com/d2lang/d2/lib/geo"
 )
 
-func TestRenderEscapesTargetColorAttributes(t *testing.T) {
+func TestRenderRejectsTargetColorAttributeInjection(t *testing.T) {
 	t.Parallel()
 
 	const payload = `red" onload="alert(1)`
 	tests := []struct {
 		name      string
-		attribute string
 		configure func(*d2target.Diagram)
 	}{
-		{name: "root-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Root.Fill = payload }},
-		{name: "root-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Root.Stroke = payload }},
-		{name: "shape-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].Fill = payload }},
-		{name: "shape-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Shapes[0].Stroke = payload }},
-		{name: "shape-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].Color = payload }},
-		{name: "shape-label-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Shapes[0].LabelFill = payload }},
+		{name: "root-fill", configure: func(d *d2target.Diagram) { d.Root.Fill = payload }},
+		{name: "root-stroke", configure: func(d *d2target.Diagram) { d.Root.Stroke = payload }},
+		{name: "shape-fill", configure: func(d *d2target.Diagram) { d.Shapes[0].Fill = payload }},
+		{name: "shape-stroke", configure: func(d *d2target.Diagram) { d.Shapes[0].Stroke = payload }},
+		{name: "shape-color", configure: func(d *d2target.Diagram) { d.Shapes[0].Color = payload }},
+		{name: "shape-label-fill", configure: func(d *d2target.Diagram) { d.Shapes[0].LabelFill = payload }},
 		{
-			name: "shape-primary-accent", attribute: "fill",
+			name: "shape-primary-accent",
 			configure: func(d *d2target.Diagram) {
 				setClassShape(&d.Shapes[0])
 				d.Shapes[0].PrimaryAccentColor = payload
 			},
 		},
 		{
-			name: "shape-secondary-accent", attribute: "fill",
+			name: "shape-secondary-accent",
 			configure: func(d *d2target.Diagram) {
 				setClassShape(&d.Shapes[0])
 				d.Shapes[0].SecondaryAccentColor = payload
 			},
 		},
 		{
-			name: "shape-neutral-accent", attribute: "fill",
+			name: "shape-neutral-accent",
 			configure: func(d *d2target.Diagram) {
 				setSQLTableShape(&d.Shapes[0])
 				d.Shapes[0].NeutralAccentColor = payload
 			},
 		},
-		{name: "connection-stroke", attribute: "stroke", configure: func(d *d2target.Diagram) { d.Connections[0].Stroke = payload }},
-		{name: "connection-fill", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].Fill = payload }},
-		{name: "connection-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].Color = payload }},
-		{name: "connection-source-label-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].SrcLabel.Color = payload }},
-		{name: "connection-destination-label-color", attribute: "fill", configure: func(d *d2target.Diagram) { d.Connections[0].DstLabel.Color = payload }},
+		{name: "connection-stroke", configure: func(d *d2target.Diagram) { d.Connections[0].Stroke = payload }},
+		{name: "connection-fill", configure: func(d *d2target.Diagram) { d.Connections[0].Fill = payload }},
+		{name: "connection-color", configure: func(d *d2target.Diagram) { d.Connections[0].Color = payload }},
+		{name: "connection-source-label-color", configure: func(d *d2target.Diagram) { d.Connections[0].SrcLabel.Color = payload }},
+		{name: "connection-destination-label-color", configure: func(d *d2target.Diagram) { d.Connections[0].DstLabel.Color = payload }},
 	}
 
 	for _, test := range tests {
@@ -76,10 +72,12 @@ func TestRenderEscapesTargetColorAttributes(t *testing.T) {
 			}
 
 			out, err := d2svg.Render(&decoded, nil)
-			if err != nil {
-				t.Fatalf("Render() error = %v", err)
+			if err == nil || !strings.Contains(err.Error(), "uses unsupported paint") {
+				t.Fatalf("Render() output/error = %q/%v, want paint rejection", out, err)
 			}
-			assertSafeColorAttribute(t, out, test.attribute, payload)
+			if out != nil {
+				t.Fatalf("Render() returned browser-consumable output for rejected paint: %q", out)
+			}
 		})
 	}
 }
@@ -154,43 +152,5 @@ func setSQLTableShape(shape *d2target.Shape) {
 			Type:       d2target.Text{Label: "string", LabelWidth: 40},
 			Constraint: []string{"primary_key"},
 		},
-	}
-}
-
-func assertSafeColorAttribute(t *testing.T, source []byte, attribute, value string) {
-	t.Helper()
-
-	decoder := xml.NewDecoder(bytes.NewReader(source))
-	decoder.Strict = true
-	found := false
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Render() emitted invalid XML: %v\n%s", err, source)
-		}
-		start, ok := token.(xml.StartElement)
-		if !ok {
-			continue
-		}
-		if strings.EqualFold(start.Name.Local, "script") {
-			t.Fatalf("Render() emitted an injected script element: %s", source)
-		}
-		for _, attr := range start.Attr {
-			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
-				t.Fatalf("Render() emitted an event-handler attribute %q: %s", attr.Name.Local, source)
-			}
-			if attr.Name.Local == attribute && attr.Value == value {
-				found = true
-			}
-		}
-	}
-	if !found {
-		t.Fatalf("Render() did not preserve %s value %q after XML decoding: %s", attribute, value, source)
-	}
-	if !bytes.Contains(source, []byte(`&#34; onload=&#34;`)) {
-		t.Fatalf("Render() did not XML-escape the color attribute: %s", source)
 	}
 }

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -2882,6 +2882,10 @@ func validateRenderLinks(diagram *d2target.Diagram) error {
 // validated. Keeping this internal lets RenderMultiboard avoid repeatedly
 // walking every descendant subtree.
 func renderValidated(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
+	if err := validateRenderPaints(diagram, opts); err != nil {
+		return nil, err
+	}
+
 	sketch := false
 	pad := DEFAULT_PADDING
 	tl, br := diagram.BoundingBox()
@@ -3193,7 +3197,7 @@ func renderValidated(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error
 	bufStr := buf.String()
 	patternDefs := ""
 	for _, pattern := range d2ast.FillPatterns {
-		if strings.Contains(bufStr, fmt.Sprintf("%s-overlay", pattern)) || diagram.Root.FillPattern == pattern {
+		if strings.Contains(bufStr, fmt.Sprintf("%s-overlay", pattern)) || strings.EqualFold(diagram.Root.FillPattern, pattern) {
 			if patternDefs == "" {
 				fmt.Fprint(upperBuf, `<style type="text/css"><![CDATA[`)
 			}
@@ -3275,6 +3279,12 @@ func renderValidated(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error
 }
 
 func ThemeCSS(diagramHash string, themeID *int64, darkThemeID *int64, overrides, darkOverrides *d2target.ThemeOverrides) (stylesheet string, err error) {
+	if err := validateThemeOverrides(overrides, "theme override"); err != nil {
+		return "", err
+	}
+	if err := validateThemeOverrides(darkOverrides, "dark theme override"); err != nil {
+		return "", err
+	}
 	if themeID == nil {
 		themeID = &d2themescatalog.NeutralDefault.ID
 	}

--- a/d2renderers/d2svg/paint_validation.go
+++ b/d2renderers/d2svg/paint_validation.go
@@ -1,0 +1,161 @@
+package d2svg
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2target"
+	"github.com/d2lang/d2/lib/color"
+	"github.com/d2lang/util-go/go2"
+)
+
+// validateRenderPaints keeps raw render targets within the same paint grammar
+// as compiler-produced targets. In particular, arbitrary CSS paint servers such
+// as url(https://example.com/paint.svg) must not reach an SVG attribute.
+func validateRenderPaints(diagram *d2target.Diagram, opts *RenderOpts) error {
+	if err := validatePaint(diagram.Root.Fill, "root fill"); err != nil {
+		return err
+	}
+	if err := validatePaint(diagram.Root.Stroke, "root stroke"); err != nil {
+		return err
+	}
+	if err := validateFillPattern(diagram.Root.FillPattern, "root fill pattern"); err != nil {
+		return err
+	}
+
+	for i := range diagram.Shapes {
+		if err := validateShapePaints(&diagram.Shapes[i], fmt.Sprintf("shape %q", diagram.Shapes[i].ID)); err != nil {
+			return err
+		}
+	}
+	for i := range diagram.Connections {
+		if err := validateConnectionPaints(&diagram.Connections[i], fmt.Sprintf("connection %q", diagram.Connections[i].ID)); err != nil {
+			return err
+		}
+	}
+	if diagram.Legend != nil {
+		for i := range diagram.Legend.Shapes {
+			if err := validateShapePaints(&diagram.Legend.Shapes[i], fmt.Sprintf("legend shape %q", diagram.Legend.Shapes[i].ID)); err != nil {
+				return err
+			}
+		}
+		for i := range diagram.Legend.Connections {
+			connection := &diagram.Legend.Connections[i]
+			object := fmt.Sprintf("legend connection %q", connection.ID)
+			if err := validatePaint(connection.Stroke, object+" stroke"); err != nil {
+				return err
+			}
+			if err := validatePaint(connection.Fill, object+" fill"); err != nil {
+				return err
+			}
+		}
+	}
+
+	if opts != nil {
+		if err := validateThemeOverrides(opts.ThemeOverrides, "theme override"); err != nil {
+			return err
+		}
+		if err := validateThemeOverrides(opts.DarkThemeOverrides, "dark theme override"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateShapePaints(shape *d2target.Shape, object string) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "fill", value: shape.Fill},
+		{name: "stroke", value: shape.Stroke},
+		{name: "font color", value: shape.Color},
+		{name: "label fill", value: shape.LabelFill},
+		{name: "primary accent color", value: shape.PrimaryAccentColor},
+		{name: "secondary accent color", value: shape.SecondaryAccentColor},
+		{name: "neutral accent color", value: shape.NeutralAccentColor},
+	} {
+		if err := validatePaint(field.value, object+" "+field.name); err != nil {
+			return err
+		}
+	}
+	return validateFillPattern(shape.FillPattern, object+" fill pattern")
+}
+
+func validateConnectionPaints(connection *d2target.Connection, object string) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "stroke", value: connection.Stroke},
+		{name: "fill", value: connection.Fill},
+		{name: "font color", value: connection.Color},
+	} {
+		if err := validatePaint(field.value, object+" "+field.name); err != nil {
+			return err
+		}
+	}
+	if connection.SrcLabel != nil {
+		if err := validatePaint(connection.SrcLabel.Color, object+" source label color"); err != nil {
+			return err
+		}
+	}
+	if connection.DstLabel != nil {
+		if err := validatePaint(connection.DstLabel.Color, object+" destination label color"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePaint(value, field string) error {
+	if value == "" || value == color.None || color.IsThemeColor(value) || color.ValidColor(value) {
+		return nil
+	}
+	return fmt.Errorf("%s uses unsupported paint %q", field, value)
+}
+
+func validateFillPattern(value, field string) error {
+	if value == "" || go2.Contains(d2ast.FillPatterns, strings.ToLower(value)) {
+		return nil
+	}
+	return fmt.Errorf("%s uses unsupported value %q", field, value)
+}
+
+func validateThemeOverrides(overrides *d2target.ThemeOverrides, object string) error {
+	if overrides == nil {
+		return nil
+	}
+	for _, field := range []struct {
+		name  string
+		value *string
+	}{
+		{name: "N1", value: overrides.N1},
+		{name: "N2", value: overrides.N2},
+		{name: "N3", value: overrides.N3},
+		{name: "N4", value: overrides.N4},
+		{name: "N5", value: overrides.N5},
+		{name: "N6", value: overrides.N6},
+		{name: "N7", value: overrides.N7},
+		{name: "B1", value: overrides.B1},
+		{name: "B2", value: overrides.B2},
+		{name: "B3", value: overrides.B3},
+		{name: "B4", value: overrides.B4},
+		{name: "B5", value: overrides.B5},
+		{name: "B6", value: overrides.B6},
+		{name: "AA2", value: overrides.AA2},
+		{name: "AA4", value: overrides.AA4},
+		{name: "AA5", value: overrides.AA5},
+		{name: "AB4", value: overrides.AB4},
+		{name: "AB5", value: overrides.AB5},
+	} {
+		if field.value == nil {
+			continue
+		}
+		if !go2.Contains(color.NamedColors, strings.ToLower(*field.value)) && !color.ColorHexRegex.MatchString(*field.value) {
+			return fmt.Errorf("%s %s uses unsupported color %q", object, field.name, *field.value)
+		}
+	}
+	return nil
+}

--- a/d2renderers/d2svg/paint_validation_test.go
+++ b/d2renderers/d2svg/paint_validation_test.go
@@ -1,0 +1,334 @@
+package d2svg_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+	"github.com/d2lang/d2/lib/geo"
+	"github.com/d2lang/d2/lib/label"
+	"github.com/d2lang/util-go/go2"
+)
+
+const externalPaintServer = `url(http://127.0.0.1:65535/paint.svg#paint)`
+
+func TestRenderRejectsExternalPaintServersFromRawJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		wantField string
+		configure func(*d2target.Diagram, *d2svg.RenderOpts)
+	}{
+		{name: "root fill", wantField: "root fill", configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Root.Fill = externalPaintServer }},
+		{name: "root stroke", wantField: "root stroke", configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Root.Stroke = externalPaintServer }},
+		{name: "shape fill", wantField: `shape "source" fill`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Shapes[0].Fill = externalPaintServer }},
+		{name: "shape stroke", wantField: `shape "source" stroke`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Shapes[0].Stroke = externalPaintServer }},
+		{name: "shape font color", wantField: `shape "source" font color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Shapes[0].Color = externalPaintServer }},
+		{name: "shape label fill", wantField: `shape "source" label fill`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Shapes[0].LabelFill = externalPaintServer }},
+		{name: "shape primary accent", wantField: `shape "source" primary accent color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Shapes[0].Type = d2target.ShapeClass
+			d.Shapes[0].PrimaryAccentColor = externalPaintServer
+		}},
+		{name: "shape secondary accent", wantField: `shape "source" secondary accent color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Shapes[0].Type = d2target.ShapeClass
+			d.Shapes[0].SecondaryAccentColor = externalPaintServer
+		}},
+		{name: "shape neutral accent", wantField: `shape "source" neutral accent color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Shapes[0].Type = d2target.ShapeSQLTable
+			d.Shapes[0].NeutralAccentColor = externalPaintServer
+		}},
+		{name: "connection stroke", wantField: `connection "edge" stroke`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Connections[0].Stroke = externalPaintServer }},
+		{name: "connection fill", wantField: `connection "edge" fill`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Connections[0].Fill = externalPaintServer }},
+		{name: "connection font color", wantField: `connection "edge" font color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) { d.Connections[0].Color = externalPaintServer }},
+		{name: "source arrowhead label", wantField: `connection "edge" source label color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Connections[0].SrcLabel = &d2target.Text{Label: "source", Color: externalPaintServer}
+		}},
+		{name: "destination arrowhead label", wantField: `connection "edge" destination label color`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Connections[0].DstLabel = &d2target.Text{Label: "destination", Color: externalPaintServer}
+		}},
+		{name: "legend shape", wantField: `legend shape "legend-shape" fill`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			d.Legend = &d2target.Legend{Shapes: []d2target.Shape{{ID: "legend-shape", Fill: externalPaintServer}}}
+		}},
+		{name: "legend connection stroke", wantField: `legend connection "legend-edge" stroke`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			connection := *d2target.BaseConnection()
+			connection.ID = "legend-edge"
+			connection.Stroke = externalPaintServer
+			d.Legend = &d2target.Legend{Connections: []d2target.Connection{connection}}
+		}},
+		{name: "legend connection fill", wantField: `legend connection "legend-edge" fill`, configure: func(d *d2target.Diagram, _ *d2svg.RenderOpts) {
+			connection := *d2target.BaseConnection()
+			connection.ID = "legend-edge"
+			connection.Fill = externalPaintServer
+			d.Legend = &d2target.Legend{Connections: []d2target.Connection{connection}}
+		}},
+		{name: "light theme override", wantField: "theme override N1", configure: func(_ *d2target.Diagram, opts *d2svg.RenderOpts) {
+			opts.ThemeOverrides = &d2target.ThemeOverrides{N1: go2.Pointer(externalPaintServer)}
+		}},
+		{name: "dark theme override", wantField: "dark theme override AB5", configure: func(_ *d2target.Diagram, opts *d2svg.RenderOpts) {
+			opts.DarkThemeOverrides = &d2target.ThemeOverrides{AB5: go2.Pointer(externalPaintServer)}
+		}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := paintValidationDiagram()
+			opts := &d2svg.RenderOpts{}
+			tc.configure(diagram, opts)
+			diagram = roundTripTargetJSON(t, diagram)
+
+			out, err := d2svg.Render(diagram, opts)
+			if err == nil || !strings.Contains(err.Error(), tc.wantField+" uses unsupported") {
+				t.Fatalf("Render() output/error = %q/%v, want rejection for %s", out, err, tc.wantField)
+			}
+			if out != nil {
+				t.Fatalf("Render() returned browser-consumable output containing an external paint server: %q", out)
+			}
+		})
+	}
+}
+
+func TestRenderMultiboardRejectsExternalPaintServerInNestedBoard(t *testing.T) {
+	t.Parallel()
+
+	root := d2target.NewDiagram()
+	child := paintValidationDiagram()
+	child.Shapes[0].Fill = externalPaintServer
+	root.Layers = []*d2target.Diagram{child}
+
+	out, err := d2svg.RenderMultiboard(root, nil)
+	if err == nil || !strings.Contains(err.Error(), `shape "source" fill uses unsupported`) {
+		t.Fatalf("RenderMultiboard() output/error = %q/%v, want nested paint rejection", out, err)
+	}
+}
+
+func TestRenderRejectsFillPatternAttributeInjectionFromRawJSON(t *testing.T) {
+	t.Parallel()
+
+	const injection = `dots" onload="fetch('http://127.0.0.1:65535/event')`
+	for _, tc := range []struct {
+		name      string
+		wantField string
+		configure func(*d2target.Diagram)
+	}{
+		{name: "root", wantField: "root fill pattern", configure: func(d *d2target.Diagram) { d.Root.FillPattern = injection }},
+		{name: "shape", wantField: `shape "source" fill pattern`, configure: func(d *d2target.Diagram) { d.Shapes[0].FillPattern = injection }},
+		{name: "legend shape", wantField: `legend shape "legend-shape" fill pattern`, configure: func(d *d2target.Diagram) {
+			d.Legend = &d2target.Legend{Shapes: []d2target.Shape{{ID: "legend-shape", FillPattern: injection}}}
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := paintValidationDiagram()
+			tc.configure(diagram)
+			diagram = roundTripTargetJSON(t, diagram)
+
+			out, err := d2svg.Render(diagram, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantField+" uses unsupported value") {
+				t.Fatalf("Render() output/error = %q/%v, want fill-pattern rejection", out, err)
+			}
+			if out != nil {
+				t.Fatalf("Render() returned output on error: %q", out)
+			}
+		})
+	}
+}
+
+func TestRenderPreservesSupportedPaintGrammar(t *testing.T) {
+	t.Parallel()
+
+	for _, paint := range []string{
+		"",
+		"none",
+		"LightSteelBlue",
+		"#abc",
+		"#0A0f25",
+		"N1",
+		"AA4",
+		"linear-gradient(to right, red, #00f)",
+		"radial-gradient(white, #000000)",
+	} {
+		paint := paint
+		t.Run("paint "+paint, func(t *testing.T) {
+			t.Parallel()
+			diagram := paintValidationDiagram()
+			diagram.Shapes[0].Fill = paint
+			out, err := d2svg.Render(roundTripTargetJSON(t, diagram), nil)
+			if err != nil {
+				t.Fatalf("Render() rejected supported paint %q: %v", paint, err)
+			}
+			assertStrictSafeSVG(t, out)
+		})
+	}
+
+	for _, pattern := range []string{"", "none", "dots", "LINES", "Grain", "paper"} {
+		pattern := pattern
+		t.Run("fill pattern "+pattern, func(t *testing.T) {
+			t.Parallel()
+			diagram := paintValidationDiagram()
+			diagram.Shapes[0].FillPattern = pattern
+			out, err := d2svg.Render(roundTripTargetJSON(t, diagram), nil)
+			if err != nil {
+				t.Fatalf("Render() rejected supported fill pattern %q: %v", pattern, err)
+			}
+			assertStrictSafeSVG(t, out)
+		})
+	}
+
+	t.Run("theme overrides", func(t *testing.T) {
+		t.Parallel()
+		diagram := paintValidationDiagram()
+		darkThemeID := int64(200)
+		out, err := d2svg.Render(diagram, &d2svg.RenderOpts{
+			DarkThemeID:        &darkThemeID,
+			ThemeOverrides:     &d2target.ThemeOverrides{N1: go2.Pointer("PapayaWhip")},
+			DarkThemeOverrides: &d2target.ThemeOverrides{AB5: go2.Pointer("#0A0f25")},
+		})
+		if err != nil {
+			t.Fatalf("Render() rejected supported theme overrides: %v", err)
+		}
+		assertStrictSafeSVG(t, out)
+	})
+}
+
+func TestRenderCanonicalizesSupportedFillPatterns(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		pattern string
+		want    string
+	}{
+		{pattern: "LINES", want: "lines"},
+		{pattern: "Grain", want: "grain"},
+	} {
+		tc := tc
+		t.Run(tc.pattern, func(t *testing.T) {
+			t.Parallel()
+			diagram := paintValidationDiagram()
+			diagram.Shapes[0].FillPattern = tc.pattern
+			out, err := d2svg.Render(roundTripTargetJSON(t, diagram), nil)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			if !strings.Contains(string(out), tc.want+"-overlay") {
+				t.Fatalf("Render() did not emit the canonical pattern class %q:\n%s", tc.want+"-overlay", out)
+			}
+			if !strings.Contains(string(out), "url(#"+tc.want+"-") {
+				t.Fatalf("Render() did not define the canonical pattern %q:\n%s", tc.want, out)
+			}
+			if strings.Contains(string(out), tc.pattern+"-overlay") {
+				t.Fatalf("Render() retained non-canonical pattern class %q:\n%s", tc.pattern+"-overlay", out)
+			}
+			assertStrictSafeSVG(t, out)
+		})
+	}
+
+	t.Run("NONE", func(t *testing.T) {
+		t.Parallel()
+		diagram := paintValidationDiagram()
+		diagram.Shapes[0].FillPattern = "NONE"
+		out, err := d2svg.Render(roundTripTargetJSON(t, diagram), nil)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		if strings.Contains(string(out), "NONE-overlay") || strings.Contains(string(out), "none-overlay") {
+			t.Fatalf("Render() emitted an overlay for the none pattern:\n%s", out)
+		}
+		assertStrictSafeSVG(t, out)
+	})
+}
+
+func TestThemeCSSRejectsUnsupportedOverrides(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		overrides *d2target.ThemeOverrides
+		dark      *d2target.ThemeOverrides
+		want      string
+	}{
+		{name: "external light paint", overrides: &d2target.ThemeOverrides{B1: go2.Pointer(externalPaintServer)}, want: "theme override B1 uses unsupported color"},
+		{name: "external dark paint", dark: &d2target.ThemeOverrides{N7: go2.Pointer(externalPaintServer)}, want: "dark theme override N7 uses unsupported color"},
+		{name: "CSS declaration", overrides: &d2target.ThemeOverrides{AA2: go2.Pointer(`red;}.attacker{background:url(http://127.0.0.1/)`)}, want: "theme override AA2 uses unsupported color"},
+		{name: "gradient", overrides: &d2target.ThemeOverrides{AB4: go2.Pointer("linear-gradient(red, blue)")}, want: "theme override AB4 uses unsupported color"},
+		{name: "theme token", overrides: &d2target.ThemeOverrides{N1: go2.Pointer("N2")}, want: "theme override N1 uses unsupported color"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stylesheet, err := d2svg.ThemeCSS("d2-test", nil, nil, tc.overrides, tc.dark)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ThemeCSS() stylesheet/error = %q/%v, want %q", stylesheet, err, tc.want)
+			}
+			if stylesheet != "" {
+				t.Fatalf("ThemeCSS() returned stylesheet on error: %q", stylesheet)
+			}
+		})
+	}
+}
+
+func paintValidationDiagram() *d2target.Diagram {
+	diagram := d2target.NewDiagram()
+	diagram.Root.Fill = "#ffffff"
+	diagram.Root.Stroke = "none"
+	diagram.Shapes = []d2target.Shape{
+		{ID: "source", Type: d2target.ShapeRectangle, Pos: d2target.Point{}, Width: 40, Height: 40, Fill: "#ffffff", Stroke: "#000000", StrokeWidth: 2, Opacity: 1},
+		{ID: "destination", Type: d2target.ShapeRectangle, Pos: d2target.Point{X: 100}, Width: 40, Height: 40, Fill: "#ffffff", Stroke: "#000000", StrokeWidth: 2, Opacity: 1},
+	}
+	connection := *d2target.BaseConnection()
+	connection.ID = "edge"
+	connection.Src = "source"
+	connection.Dst = "destination"
+	connection.Route = []*geo.Point{{X: 40, Y: 20}, {X: 100, Y: 20}}
+	connection.Stroke = "#000000"
+	connection.LabelPosition = label.InsideMiddleCenter.String()
+	diagram.Connections = []d2target.Connection{connection}
+	return diagram
+}
+
+func roundTripTargetJSON(t *testing.T, diagram *d2target.Diagram) *d2target.Diagram {
+	t.Helper()
+	raw, err := json.Marshal(diagram)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded d2target.Diagram
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	return &decoded
+}
+
+func assertStrictSafeSVG(t *testing.T, source []byte) {
+	t.Helper()
+	decoder := xml.NewDecoder(strings.NewReader(string(source)))
+	decoder.Strict = true
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("Render() emitted invalid XML: %v\n%s", err, source)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(start.Name.Local, "script") {
+			t.Fatalf("Render() emitted a script element: %s", source)
+		}
+		for _, attr := range start.Attr {
+			if strings.HasPrefix(strings.ToLower(attr.Name.Local), "on") {
+				t.Fatalf("Render() emitted event-handler attribute %q: %s", attr.Name.Local, source)
+			}
+		}
+	}
+}

--- a/d2themes/element.go
+++ b/d2themes/element.go
@@ -3,6 +3,7 @@ package d2themes
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/d2lang/d2/lib/color"
 	"github.com/d2lang/d2/lib/svg"
@@ -237,13 +238,14 @@ func (el *ThemableElement) Render() string {
 	}
 
 	out += " />"
-	if el.FillPattern != "" && el.FillPattern != "none" {
+	fillPattern := strings.ToLower(el.FillPattern)
+	if fillPattern != "" && fillPattern != "none" {
 		patternEl := el.Copy()
 		patternEl.Fill = ""
 		patternEl.Stroke = ""
 		patternEl.BackgroundColor = ""
 		patternEl.Color = ""
-		patternEl.ClassName = fmt.Sprintf("%s-overlay", el.FillPattern)
+		patternEl.ClassName = fmt.Sprintf("%s-overlay", fillPattern)
 		patternEl.FillPattern = ""
 		out += patternEl.Render()
 	}


### PR DESCRIPTION
## Human

---

## AI

### Summary

Reject paint and fill-pattern strings supplied through the raw SVG render APIs unless they match the same grammar accepted for compiler-produced targets. Validate light and dark theme overrides before either inline SVG or theme CSS is generated.

### Why this is a security issue

The D2 compiler already restricts authored colors, but the public `d2svg.Render` path also accepts a hand-built `d2target.Diagram` (including Diagram JSON passed to the WASM render API) and previously trusted its paint fields.

A value such as `url(http://127.0.0.1:8000/paint.svg#x)` was copied into an SVG `fill` or `stroke` attribute. When the returned SVG was opened in Chromium, Chromium issued a request to that URL. An attacker who can provide raw render-target JSON could therefore make a viewer's browser contact an attacker-controlled or browser-reachable internal address, enabling tracking and blind internal-network request attempts.

`fillPattern` was more direct: it became a generated class name such as `<rect class="<value>-overlay">`. A value containing a quote could break out of the class attribute and add an event handler. Theme overrides were also inserted into both SVG attributes and generated CSS without rechecking the compiler's named-color/hex restriction. In an active SVG context, those injection paths could execute attacker-supplied markup or CSS.

This requires control of raw Diagram/RenderOpts data; ordinary D2 source already passes through compiler validation. Script impact also requires the SVG to be opened or embedded in an active SVG context. The external paint-server request was reproduced in headless Chromium.

### Fix

- Validate every paint-bearing field that can reach SVG output: root, shapes, connections, arrowhead labels, class/SQL-table accent colors, and legend projections.
- Accept empty values, the renderer's safe `none` sentinel, CSS named colors, three- and six-digit hex, D2 theme tokens, and valid D2 gradients.
- Restrict fill patterns case-insensitively to `none`, `dots`, `lines`, `grain`, and `paper`.
- Canonicalize accepted fill-pattern names at SVG serialization/definition lookup so compiler-accepted mixed-case values keep working without mutating caller data.
- Restrict light and dark theme override values to the compiler-supported named-color/hex grammar.
- Run validation before rendering and inside public `ThemeCSS`, returning no SVG or stylesheet on rejection.

### Tests

- Raw JSON round-trip regressions cover direct external paint servers in every reachable field, including legends and both override sets, and assert that no browser-consumable bytes are returned.
- Fill-pattern regressions cover class/event-handler injection for root, ordinary, and legend shapes.
- Theme CSS regressions cover external URLs and declaration injection.
- Positive regressions preserve empty/`none`, mixed-case named colors, short/full hex, D2 theme tokens, linear/radial gradients, every fill pattern, and valid light/dark overrides; rendered output is parsed as strict XML and checked for script/event-handler nodes.
- `go test ./...`
- `go vet ./...`

### Scope

This change deliberately leaves gradient direction/stop-position serialization to its separate validation PR and does not replace context-correct SVG attribute escaping. Those are independent defense-in-depth fixes.
