### PR TITLE
fix(svg): validate legend shape links

### DIFF
--- a/d2js/d2wasm/api_test.go
+++ b/d2js/d2wasm/api_test.go
@@ -4,6 +4,7 @@ package d2wasm
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"syscall/js"
 	"testing"
@@ -93,6 +94,39 @@ func TestDeprecatedRawWASMWarningCannotChangeResponse(t *testing.T) {
 	got := call.Invoke().String()
 	if got != `{"data":"unchanged"}` {
 		t.Fatalf("response = %s, want legacy response unchanged", got)
+	}
+}
+
+func TestRenderRejectsDangerousLegendShapeLinks(t *testing.T) {
+	call := wrapWASMCall(Render)
+	defer call.Release()
+
+	for _, tc := range []struct {
+		name    string
+		request string
+		object  string
+	}{
+		{
+			name:    "shape",
+			request: `{"diagram":{"legend":{"shapes":[{"id":"unsafe-shape","type":"rectangle","label":"Shape","opacity":1,"strokeWidth":2,"fill":"B6","stroke":"B1","link":"javascript:alert(1)"}]}},"options":{}}`,
+			object:  `legend shape "unsafe-shape"`,
+		},
+		{
+			name:    "image shape",
+			request: `{"diagram":{"legend":{"shapes":[{"id":"unsafe-image","type":"image","label":"Image","opacity":1,"icon":{"Scheme":"https","Host":"example.com","Path":"/image.png"},"link":"data:text/html,<script>alert(1)</script>"}]}},"options":{}}`,
+			object:  `legend shape "unsafe-image"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			response := call.Invoke(tc.request).String()
+			var got WASMResponse
+			if err := json.Unmarshal([]byte(response), &got); err != nil {
+				t.Fatalf("invalid response %q: %v", response, err)
+			}
+			if got.Error == nil || got.Error.Code != 500 || !strings.Contains(got.Error.Message, tc.object+" uses an unsafe link URL scheme") {
+				t.Fatalf("error = %#v, want code 500 containing unsafe-link error for %s", got.Error, tc.object)
+			}
+		})
 	}
 }
 

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -258,6 +258,11 @@ func RenderLegend(buf *bytes.Buffer, diagram *d2target.Diagram, diagramHash stri
 	if diagram.Legend == nil || (len(diagram.Legend.Shapes) == 0 && len(diagram.Legend.Connections) == 0) {
 		return nil
 	}
+	for _, targetShape := range diagram.Legend.Shapes {
+		if textmeasure.IsDangerousLink(targetShape.Link) {
+			return fmt.Errorf("legend shape %q uses an unsafe link URL scheme", targetShape.ID)
+		}
+	}
 
 	_, br := diagram.BoundingBox()
 

--- a/d2renderers/d2svg/legend_link_security_test.go
+++ b/d2renderers/d2svg/legend_link_security_test.go
@@ -1,0 +1,47 @@
+package d2svg_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/d2target"
+)
+
+func TestRenderRejectsDangerousLegendShapeLinksFromJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		diagramJSON string
+		object      string
+	}{
+		{
+			name:        "shape",
+			diagramJSON: `{"legend":{"shapes":[{"id":"unsafe-shape","type":"rectangle","label":"Shape","opacity":1,"strokeWidth":2,"fill":"B6","stroke":"B1","link":"javascript:alert(1)"}]}}`,
+			object:      `legend shape "unsafe-shape"`,
+		},
+		{
+			name:        "image shape",
+			diagramJSON: `{"legend":{"shapes":[{"id":"unsafe-image","type":"image","label":"Image","opacity":1,"icon":{"Scheme":"https","Host":"example.com","Path":"/image.png"},"link":"data:text/html,<script>alert(1)</script>"}]}}`,
+			object:      `legend shape "unsafe-image"`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diagram := d2target.NewDiagram()
+			if err := json.Unmarshal([]byte(tc.diagramJSON), diagram); err != nil {
+				t.Fatalf("invalid test diagram JSON: %v", err)
+			}
+			out, err := d2svg.Render(diagram, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.object+" uses an unsafe link URL scheme") {
+				t.Fatalf("Render() output/error = %q/%v", out, err)
+			}
+			if out != nil {
+				t.Fatalf("Render() returned output on error: %q", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Summary

Reject dangerous URL schemes in legend shape links before SVG generation.

Raw target-diagram JSON can bypass the compiler's link validation. Legend shapes retain their `Link` field when cloned for SVG rendering, allowing `javascript:` and other dangerous schemes to reach an interactive `<a href>`. This change validates legend shape links with the existing shared `textmeasure.IsDangerousLink` policy before rendering any legend content.

### Why this is a security issue

Before this change, `d2svg.Render` validated links on ordinary shapes and connections but did not traverse `diagram.Legend.Shapes`. `renderLegendShapeIcon` then copied the complete legend shape, including its link, and `drawShape` emitted that value as both `href` and `xlink:href`. XML escaping prevents an attribute breakout, but it does not make a dangerous URL scheme safe.

An attacker who can supply raw `d2target.Diagram` JSON to the SVG or WASM render API can therefore create a clickable legend icon with a dangerous URL. If that interactive SVG is shown to a victim and the link is activated, the result can be script execution or attacker-controlled navigation in the browser context, depending on how the consumer embeds the SVG.

Normal D2 source is already validated during compilation. The vulnerable precondition is direct/raw target JSON or a programmatically constructed diagram, plus an interactive consumer; this is not a parser bypass for ordinary trusted D2 source. Severity is context-dependent and most significant for applications that render untrusted raw diagrams into same-origin pages.

A pre-fix regression produced:

```text
error=<nil>
unsafe-anchor="<a href=\"javascript:alert(1)\" xlink:href=\"javascript:alert(1)\">" present=true
```

The fixed renderer instead returns:

```text
error=legend shape "unsafe-shape" uses an unsafe link URL scheme
```

and emits no SVG output.

### Implementation

`RenderLegend` now checks each legend shape's link with the same normalized dangerous-URL policy already used for ordinary shapes and connections. This location protects both the top-level SVG renderer and direct callers of the exported legend renderer.

The patch deliberately leaves legend connection metadata alone: the legend connection renderer builds a fresh connection without copying `Link`, so that field is not an interactive sink and remains ignored as before.

### Compatibility

Safe relative URLs, board targets, and other schemes accepted by the existing shared policy render exactly as before. Compiler-produced diagrams with valid links are unaffected, while compiler-produced dangerous links were already rejected. The behavior change is limited to dangerous legend-shape links supplied through raw JSON or direct construction.

Tests cover both ordinary and image-shaped legend entries through raw JSON SVG rendering and the real WASM API.

### Tests

- `go test ./d2renderers/d2svg -run TestRenderRejectsDangerousLegendShapeLinksFromJSON -count=1`
- `./ci/test-wasm.sh -run TestRenderRejectsDangerousLegendShapeLinks -count=1`
- `go test ./...`
- `go vet ./...`
- `./ci/test-wasm.sh`

### Residual limitations

This patch applies the repository's existing link policy; opaque application schemes intentionally allowed by that policy remain allowed. Image-source validation is a separate boundary. WASM continues to map renderer validation errors to its existing generic code `500` response.
