### PR TITLE
fix(latex): bound renderer input complexity

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -48,6 +48,7 @@
   - Validate raw geometry, routes, arrows, fonts, and arithmetic before recursive
     rendering. [#2912](https://github.com/d2lang/d2/pull/2912)
   - Limit raw graphs to 1,024 levels and 4,096 boards. [#2912](https://github.com/d2lang/d2/pull/2912)
+  - Limit LaTeX labels to 4 KiB and 128 nested groups. [#2922](https://github.com/d2lang/d2/pull/2922)
 - links and paints:
   - Reject dangerous ordinary link schemes after decoding common obfuscation. [#2896](https://github.com/d2lang/d2/pull/2896)
   - Require gradient stop positions to be finite numbers or percentages. [#2905](https://github.com/d2lang/d2/pull/2905)

--- a/d2js/js/test/unit/basic.test.js
+++ b/d2js/js/test/unit/basic.test.js
@@ -1,6 +1,25 @@
 import { expect, test, describe } from "bun:test";
 import { D2 } from "../../dist/node-esm/index.js";
 
+const excessiveLatexGroups = "{".repeat(129) + "x" + "}".repeat(129);
+const excessiveLatexGroupsError = "latex group nesting depth 129 exceeds limit 128";
+
+async function expectLatexGroupLimit(run) {
+  const d2 = new D2();
+  try {
+    let caught;
+    try {
+      await run(d2);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.message).toContain(excessiveLatexGroupsError);
+  } finally {
+    await d2.dispose();
+  }
+}
+
 describe("D2 Unit Tests", () => {
   test("basic compilation works", async () => {
     const d2 = new D2();
@@ -196,6 +215,32 @@ container.child -> outside
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
     await d2.dispose();
+  }, 20000);
+
+  test("latex compile rejects excessive group nesting", async () => {
+    await expectLatexGroupLimit((d2) =>
+      d2.compile(`x: |latex
+  ${excessiveLatexGroups}
+|`)
+    );
+  }, 20000);
+
+  test("raw latex shape render rejects excessive group nesting", async () => {
+    await expectLatexGroupLimit(async (d2) => {
+      const result = await d2.compile("x");
+      result.diagram.shapes[0].label = excessiveLatexGroups;
+      result.diagram.shapes[0].language = "latex";
+      await d2.render(result.diagram);
+    });
+  }, 20000);
+
+  test("raw latex connection render rejects excessive group nesting", async () => {
+    await expectLatexGroupLimit(async (d2) => {
+      const result = await d2.compile("x -> y: label");
+      result.diagram.connections[0].label = excessiveLatexGroups;
+      result.diagram.connections[0].language = "latex";
+      await d2.render(result.diagram);
+    });
   }, 20000);
 
   test("unicode characters work", async () => {

--- a/d2lib/latex_limits_test.go
+++ b/d2lib/latex_limits_test.go
@@ -1,0 +1,40 @@
+package d2lib
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2latex"
+	"github.com/d2lang/d2/lib/textmeasure"
+)
+
+func TestCompileRejectsExcessiveLatexGroupNesting(t *testing.T) {
+	ruler, err := textmeasure.NewRuler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	formula := strings.Repeat("{", d2latex.MaxGroupNestingDepth+1) + "x" + strings.Repeat("}", d2latex.MaxGroupNestingDepth+1)
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "object label",
+			input: "x: |latex\n  " + formula + "\n|",
+		},
+		{
+			name:  "edge label",
+			input: "x -> y: |latex\n  " + formula + "\n|",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := Compile(context.Background(), test.input, &CompileOptions{Ruler: ruler}, nil)
+			want := "latex group nesting depth 129 exceeds limit 128"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("Compile() error = %v, want %q", err, want)
+			}
+		})
+	}
+}

--- a/d2renderers/d2latex/latex_common.go
+++ b/d2renderers/d2latex/latex_common.go
@@ -6,11 +6,17 @@ import (
 )
 
 func Render(s string) (_ string, err error) {
+	if err := ValidateInput(s); err != nil {
+		return "", err
+	}
 	defer xdefer.Errorf(&err, "latex failed to parse")
 	return mathjax.Render(s)
 }
 
 func Measure(s string) (width, height int, err error) {
+	if err := ValidateInput(s); err != nil {
+		return 0, 0, err
+	}
 	defer xdefer.Errorf(&err, "latex failed to parse")
 	return mathjax.Measure(s)
 }

--- a/d2renderers/d2latex/latex_test.go
+++ b/d2renderers/d2latex/latex_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -49,6 +50,108 @@ func TestD2SourceBackslashParity(t *testing.T) {
 	}
 	if width != wantW || height != wantH {
 		t.Fatalf("Measure() = (%d, %d), want (%d, %d)", width, height, wantW, wantH)
+	}
+}
+
+func TestInputLimits(t *testing.T) {
+	if err := ValidateInput(strings.Repeat("x", MaxInputBytes)); err != nil {
+		t.Fatalf("ValidateInput() rejected exact byte limit: %v", err)
+	}
+	exactDepth := strings.Repeat("{", MaxGroupNestingDepth) + "x" + strings.Repeat("}", MaxGroupNestingDepth)
+	if _, err := Render(exactDepth); err != nil {
+		t.Fatalf("Render() rejected exact group depth: %v", err)
+	}
+	if _, _, err := Measure(exactDepth); err != nil {
+		t.Fatalf("Measure() rejected exact group depth: %v", err)
+	}
+
+	tooLarge := strings.Repeat("x", MaxInputBytes+1)
+	tooDeep := strings.Repeat("{", MaxGroupNestingDepth+1) + "x" + strings.Repeat("}", MaxGroupNestingDepth+1)
+	operations := []struct {
+		name string
+		run  func(string) error
+	}{
+		{name: "Render", run: func(input string) error {
+			_, err := Render(input)
+			return err
+		}},
+		{name: "Measure", run: func(input string) error {
+			_, _, err := Measure(input)
+			return err
+		}},
+	}
+	for _, operation := range operations {
+		operation := operation
+		t.Run(operation.name+"/bytes", func(t *testing.T) {
+			err := operation.run(tooLarge)
+			want := "latex input is 4097 bytes, exceeding limit 4096"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("%s() error = %v, want %q", operation.name, err, want)
+			}
+		})
+		t.Run(operation.name+"/groups", func(t *testing.T) {
+			err := operation.run(tooDeep)
+			want := "latex group nesting depth 129 exceeds limit 128"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("%s() error = %v, want %q", operation.name, err, want)
+			}
+		})
+	}
+}
+
+func TestValidateInputTeXEscapingAndComments(t *testing.T) {
+	atLimit := strings.Repeat("{", MaxGroupNestingDepth)
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "exact group depth",
+			input: atLimit + "x" + strings.Repeat("}", MaxGroupNestingDepth),
+		},
+		{
+			name:  "escaped braces",
+			input: strings.Repeat(`\{`, MaxGroupNestingDepth+1),
+		},
+		{
+			name:  "three backslashes escape brace",
+			input: atLimit + `\\\{`,
+		},
+		{
+			name:    "two backslashes leave group brace",
+			input:   atLimit + `\\{`,
+			wantErr: true,
+		},
+		{
+			name:  "braces inside comment",
+			input: atLimit + "%" + strings.Repeat("{", MaxGroupNestingDepth+1) + "\n" + strings.Repeat("}", MaxGroupNestingDepth),
+		},
+		{
+			name:  "even backslashes leave comment marker",
+			input: atLimit + `\\%{` + "\n" + strings.Repeat("}", MaxGroupNestingDepth),
+		},
+		{
+			name:    "escaped comment marker",
+			input:   atLimit + `\%{`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid UTF-8",
+			input:   string([]byte{0xff}),
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateInput(test.input)
+			if test.wantErr && err == nil {
+				t.Fatal("ValidateInput() unexpectedly succeeded")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("ValidateInput() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/d2renderers/d2latex/limits.go
+++ b/d2renderers/d2latex/limits.go
@@ -1,0 +1,66 @@
+package d2latex
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+const (
+	// MaxInputBytes bounds the work and output that a single LaTeX label can
+	// cause in the embedded MathJax renderer.
+	MaxInputBytes = 4 << 10
+
+	// MaxGroupNestingDepth prevents deeply nested TeX groups from exhausting
+	// the Go stack in mathjax-go's recursive group parser.
+	MaxGroupNestingDepth = 128
+)
+
+// ValidateInput applies D2's resource limits to a LaTeX label. Render and
+// Measure both call it so compiler, WASM, and raw render-target paths share
+// the same admission policy.
+func ValidateInput(s string) error {
+	if len(s) > MaxInputBytes {
+		return fmt.Errorf("latex input is %d bytes, exceeding limit %d", len(s), MaxInputBytes)
+	}
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("latex input must be valid UTF-8")
+	}
+
+	depth := 0
+	backslashes := 0
+	inComment := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inComment {
+			if c == '\n' || c == '\r' {
+				inComment = false
+			}
+			continue
+		}
+		if c == '\\' {
+			backslashes++
+			continue
+		}
+
+		escaped := backslashes%2 != 0
+		backslashes = 0
+		if escaped {
+			continue
+		}
+
+		switch c {
+		case '%':
+			inComment = true
+		case '{':
+			depth++
+			if depth > MaxGroupNestingDepth {
+				return fmt.Errorf("latex group nesting depth %d exceeds limit %d", depth, MaxGroupNestingDepth)
+			}
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return nil
+}

--- a/d2renderers/d2scenebuild/latex.go
+++ b/d2renderers/d2scenebuild/latex.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"image/color"
-	"unicode/utf8"
 
 	"github.com/d2lang/d2/d2renderers/d2latex"
 	"github.com/d2lang/d2/d2renderers/d2scene"
@@ -13,8 +12,6 @@ import (
 	"github.com/d2lang/d2/lib/geo"
 	"github.com/d2lang/d2/lib/label"
 )
-
-const maxLatexInputBytes = 4 << 10
 
 type latexAssetKey struct {
 	formula string
@@ -91,11 +88,8 @@ func (b *builder) resolveLatexAsset(object, formula, rawColor string) (latexAsse
 }
 
 func (b *builder) validateLatexInput(object, formula string) error {
-	if !utf8.ValidString(formula) {
-		return invalidField(object, "label", nil, "must be valid UTF-8")
-	}
-	if len(formula) > maxLatexInputBytes {
-		return fmt.Errorf("scene: %s latex input is %d bytes, exceeding limit %d", object, len(formula), maxLatexInputBytes)
+	if err := d2latex.ValidateInput(formula); err != nil {
+		return fmt.Errorf("scene: %s %w", object, err)
 	}
 	return nil
 }

--- a/d2renderers/d2scenebuild/latex_test.go
+++ b/d2renderers/d2scenebuild/latex_test.go
@@ -165,7 +165,7 @@ func TestBuildLatexInputAndImportBudgets(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "label language latex without configured SVG import limits") {
 		t.Fatalf("missing import options error = %v", err)
 	}
-	_, err = Build(context.Background(), makeDiagram(strings.Repeat("x", maxLatexInputBytes+1)), Options{Assets: testAssetOptions(t)})
+	_, err = Build(context.Background(), makeDiagram(strings.Repeat("x", d2latex.MaxInputBytes+1)), Options{Assets: testAssetOptions(t)})
 	if err == nil || !strings.Contains(err.Error(), "latex input is 4097 bytes, exceeding limit 4096") {
 		t.Fatalf("input limit error = %v", err)
 	}

--- a/d2renderers/d2svg/latex_limits_test.go
+++ b/d2renderers/d2svg/latex_limits_test.go
@@ -1,0 +1,34 @@
+package d2svg_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2renderers/d2latex"
+	"github.com/d2lang/d2/d2renderers/d2svg"
+	"github.com/d2lang/d2/lib/label"
+)
+
+func TestRenderRejectsExcessiveLatexGroupNesting(t *testing.T) {
+	formula := strings.Repeat("{", d2latex.MaxGroupNestingDepth+1) + "x" + strings.Repeat("}", d2latex.MaxGroupNestingDepth+1)
+	for _, target := range []string{"shape", "connection"} {
+		t.Run(target, func(t *testing.T) {
+			diagram := validRenderTarget()
+			if target == "shape" {
+				diagram.Shapes[0].Label = formula
+				diagram.Shapes[0].Language = "latex"
+			} else {
+				diagram.Connections[0].Label = formula
+				diagram.Connections[0].Language = "latex"
+				diagram.Connections[0].LabelPosition = label.InsideMiddleCenter.String()
+				diagram.Connections[0].LabelPercentage = 0.5
+			}
+
+			_, err := d2svg.Render(diagram, nil)
+			want := "latex group nesting depth 129 exceeds limit 128"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("Render() error = %v, want %q", err, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Human

---

## AI

### Summary

- reject LaTeX labels over 4 KiB or 128 nested groups before invoking MathJax
- apply one validation policy to measurement, rendering, normal compilation, raw SVG targets, and D2.js/WASM
- preserve valid UTF-8, escaped braces, and TeX comment behavior

### Security

Deeply nested LaTeX could make the embedded MathJax parser consume hundreds of megabytes before D2 could honor cancellation. The limits now reject that input before either measurement or rendering begins, including when callers submit a raw render target.

### Compatibility

Existing LaTeX labels within 4 KiB and 128 nested groups render unchanged. Inputs beyond either limit now return a descriptive error.

### Testing

- full Go test suite
- focused LaTeX, d2lib, SVG, and scene-builder tests
- D2.js WASM rebuild, all 52 unit tests, and type tests
- regression coverage for object and edge labels plus raw shape and connection targets
