### PR TITLE
security: bound variable substitution expansion

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -38,6 +38,11 @@
   - Limit active import chains to 128. [#2904](https://github.com/d2lang/d2/pull/2904)
   - Reject cyclic composite variables with source diagnostics instead of allowing
     unbounded recursion. [#2907](https://github.com/d2lang/d2/pull/2907)
+  - Limit variable substitution output and automatic board, import, and class
+    copies to a 65,536-unit compilation budget by default; Go callers can
+    configure the limit. [#2923](https://github.com/d2lang/d2/pull/2923)
+  - Honor cancellation while expanding substitutions and materializing compiled
+    graphs. [#2923](https://github.com/d2lang/d2/pull/2923)
 - decoding and assets:
   - Cap decompressed URL-encoded D2 input at 16 MiB. [#2902](https://github.com/d2lang/d2/pull/2902)
   - Bound image references, locators, fetched and decoded bytes, cached data, and

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/d2lang/util-go/go2"
 
@@ -26,10 +27,13 @@ import (
 )
 
 type CompileOptions struct {
-	// Context stops parsing when canceled. A nil Context is treated as
+	// Context stops parsing and compilation when canceled. A nil Context is treated as
 	// context.Background().
 	Context  context.Context
 	UTF16Pos bool
+	// MaxVariableExpansion bounds work added by variable substitutions and the
+	// automatic copies they induce. Zero uses d2ir.DefaultMaxVariableExpansion.
+	MaxVariableExpansion int64
 	// FS is the file system used for resolving imports in the D2 text. Nil
 	// disables imports. Callers that accept untrusted input should prefer a
 	// filesystem constrained to the intended import root; lib/localfile provides
@@ -50,41 +54,74 @@ func Compile(p string, r io.Reader, opts *CompileOptions) (*d2graph.Graph, *d2ta
 	}
 
 	ir, _, err := d2ir.Compile(ast, &d2ir.CompileOptions{
-		Context:  opts.Context,
-		UTF16Pos: opts.UTF16Pos,
-		FS:       opts.FS,
+		Context:              opts.Context,
+		UTF16Pos:             opts.UTF16Pos,
+		MaxVariableExpansion: opts.MaxVariableExpansion,
+		FS:                   opts.FS,
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	g, err := compileIR(ast, ir)
+	g, err := compileIRContext(opts.Context, ast, ir)
 	if err != nil {
 		return nil, nil, err
+	}
+	if opts.Context != nil {
+		if err := opts.Context.Err(); err != nil {
+			return nil, nil, err
+		}
 	}
 	g.FS = opts.FS
 	g.SortObjectsByAST()
 	g.SortEdgesByAST()
+	if opts.Context != nil {
+		if err := opts.Context.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
 	config, err := compileConfig(ir)
 	if err != nil {
 		return nil, nil, err
+	}
+	if opts.Context != nil {
+		if err := opts.Context.Err(); err != nil {
+			return nil, nil, err
+		}
 	}
 	return g, config, nil
 }
 
 func compileIR(ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
+	return compileIRContext(context.Background(), ast, m)
+}
+
+func compileIRContext(ctx context.Context, ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	c := &compiler{
 		err: &d2parser.ParseError{},
+		ctx: ctx,
 	}
 
 	g := d2graph.NewGraph()
 	g.AST = ast
 	g.BaseAST = ast
 	c.compileBoard(g, m)
+	if c.stopped() {
+		return nil, c.fatalErr
+	}
 	if len(c.err.Errors) > 0 {
 		return nil, c.err
 	}
 	c.validateBoardLinks(g)
+	if c.stopped() {
+		return nil, c.fatalErr
+	}
 	if len(c.err.Errors) > 0 {
 		return nil, c.err
 	}
@@ -92,28 +129,66 @@ func compileIR(ast *d2ast.Map, m *d2ir.Map) (*d2graph.Graph, error) {
 }
 
 func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
+	if c.stopped() {
+		return g
+	}
 	// Graph compilation reads the IR. Nested boards still need an independent
 	// root for class lookup, and boards with children need a copy because the
 	// folder comparison below uses CopyBase, which also modifies its source.
 	if !ir.Root() || hasBoardFields(ir) {
+		if err := d2ir.ReserveVariableExpansionCopy(c.ctx, ir); err != nil {
+			c.fatalErr = err
+			return g
+		}
 		ir = ir.Copy(nil).(*d2ir.Map)
 	}
 	c.compileMap(g.Root, ir)
+	if c.stopped() {
+		return g
+	}
 	c.setDefaultShapes(g)
+	if c.stopped() {
+		return g
+	}
 	if len(c.err.Errors) == 0 {
 		c.validateKeys(g.Root, ir)
 	}
+	if c.stopped() {
+		return g
+	}
 	c.validateLabels(g)
+	if c.stopped() {
+		return g
+	}
 	c.validateNear(g)
+	if c.stopped() {
+		return g
+	}
 	c.validateEdges(g)
+	if c.stopped() {
+		return g
+	}
 	c.validatePositionsCompatibility(g)
+	if c.stopped() {
+		return g
+	}
 
 	c.compileLegend(g, ir)
+	if c.stopped() {
+		return g
+	}
 
 	c.compileBoardsField(g, ir, "layers")
 	c.compileBoardsField(g, ir, "scenarios")
 	c.compileBoardsField(g, ir, "steps")
+	if c.stopped() {
+		return g
+	}
 	if len(g.Layers) > 0 || len(g.Scenarios) > 0 || len(g.Steps) > 0 {
+		if err := d2ir.ReserveVariableExpansionCopy(c.ctx, ir); err != nil {
+			c.fatalErr = err
+			return g
+		}
 		if d2ir.ParentMap(ir).CopyBase(nil).Equal(ir.CopyBase(nil)) {
 			g.IsFolderOnly = true
 		}
@@ -133,6 +208,9 @@ func hasBoardFields(ir *d2ir.Map) bool {
 }
 
 func (c *compiler) compileLegend(g *d2graph.Graph, m *d2ir.Map) {
+	if c.stopped() {
+		return
+	}
 	varsField := m.GetField(d2ast.FlatUnquotedString("vars"))
 	if varsField == nil || varsField.Map() == nil {
 		return
@@ -146,10 +224,16 @@ func (c *compiler) compileLegend(g *d2graph.Graph, m *d2ir.Map) {
 	legendGraph := d2graph.NewGraph()
 
 	c.compileMap(legendGraph.Root, legendField.Map())
+	if c.stopped() {
+		return
+	}
 	c.setDefaultShapes(legendGraph)
 
 	objects := make([]*d2graph.Object, 0)
 	for _, obj := range legendGraph.Objects {
+		if c.stopped() {
+			return
+		}
 		if obj.Style.Opacity != nil {
 			if opacity, err := strconv.ParseFloat(obj.Style.Opacity.Value, 64); err == nil && opacity == 0 {
 				continue
@@ -163,6 +247,9 @@ func (c *compiler) compileLegend(g *d2graph.Graph, m *d2ir.Map) {
 	}
 
 	for _, edge := range legendGraph.Edges {
+		if c.stopped() {
+			return
+		}
 		edge.Route = []*geo.Point{
 			{X: 10, Y: 10},
 			{X: 110, Y: 10},
@@ -184,11 +271,17 @@ func (c *compiler) compileLegend(g *d2graph.Graph, m *d2ir.Map) {
 }
 
 func (c *compiler) compileBoardsField(g *d2graph.Graph, ir *d2ir.Map, fieldName string) {
+	if c.stopped() {
+		return
+	}
 	boards := ir.GetField(d2ast.FlatUnquotedString(fieldName))
 	if boards.Map() == nil {
 		return
 	}
 	for _, f := range boards.Map().Fields {
+		if c.stopped() {
+			return
+		}
 		m := f.Map()
 		if f.Map() == nil {
 			m = &d2ir.Map{}
@@ -204,6 +297,9 @@ func (c *compiler) compileBoardsField(g *d2graph.Graph, ir *d2ir.Map, fieldName 
 			g2.BaseAST = findFieldAST(g.BaseAST, f)
 		}
 		c.compileBoard(g2, m)
+		if c.stopped() {
+			return
+		}
 		if f.Primary() != nil {
 			c.compileLabel(&g2.Root.Attributes, f)
 		}
@@ -278,6 +374,23 @@ func _findFieldAST(ast *d2ast.Map, path []string) *d2ast.Map {
 type compiler struct {
 	err             *d2parser.ParseError
 	activeClassMaps map[*d2ir.Map]struct{}
+	classMapsByRoot map[*d2ir.Map]map[string]*d2ir.Map
+	ctx             context.Context
+	fatalErr        error
+}
+
+func (c *compiler) stopped() bool {
+	if c.fatalErr != nil {
+		return true
+	}
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.fatalErr = err
+		return true
+	}
+	return false
 }
 
 func (c *compiler) errorf(n d2ast.Node, f string, v ...interface{}) {
@@ -292,6 +405,9 @@ func (c *compiler) errorf(n d2ast.Node, f string, v ...interface{}) {
 }
 
 func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
+	if c.stopped() {
+		return
+	}
 	class := m.GetField(d2ast.FlatUnquotedString("class"))
 	if class != nil {
 		var classNames []string
@@ -300,6 +416,9 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 		} else if class.Composite != nil {
 			if arr, ok := class.Composite.(*d2ir.Array); ok {
 				for _, class := range arr.Values {
+					if c.stopped() {
+						return
+					}
 					if scalar, ok := class.(*d2ir.Scalar); ok {
 						classNames = append(classNames, scalar.Value.ScalarString())
 					} else {
@@ -310,9 +429,17 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 		}
 
 		for _, className := range classNames {
-			classMap := m.GetClassMap(className)
+			if c.stopped() {
+				return
+			}
+			classMap := c.getClassMap(m, className)
 			if classMap != nil {
 				if c.beginClass(class, className, classMap) {
+					if err := d2ir.ReserveVariableExpansionCopy(c.ctx, classMap); err != nil {
+						c.fatalErr = err
+						c.endClass(classMap)
+						return
+					}
 					c.compileMap(obj, classMap)
 					c.endClass(classMap)
 				}
@@ -321,8 +448,11 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 					split := strings.Split(className, ",")
 					allFound := true
 					for _, maybeClassName := range split {
+						if c.stopped() {
+							return
+						}
 						maybeClassName = strings.TrimSpace(maybeClassName)
-						if m.GetClassMap(maybeClassName) == nil {
+						if c.getClassMap(m, maybeClassName) == nil {
 							allFound = false
 							break
 						}
@@ -343,6 +473,9 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 		}
 	}
 	for _, f := range m.Fields {
+		if c.stopped() {
+			return
+		}
 		if f.Name.ScalarString() == "shape" && f.Name.IsUnquoted() {
 			continue
 		}
@@ -359,8 +492,14 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 		case d2target.ShapeSQLTable:
 			c.compileSQLTable(obj)
 		}
+		if c.stopped() {
+			return
+		}
 
 		for _, e := range m.Edges {
+			if c.stopped() {
+				return
+			}
 			c.compileEdge(obj, e)
 		}
 	}
@@ -382,7 +521,91 @@ func (c *compiler) endClass(classMap *d2ir.Map) {
 	delete(c.activeClassMaps, classMap)
 }
 
+func (c *compiler) getClassMap(m *d2ir.Map, name string) *d2ir.Map {
+	root := d2ir.RootMap(m)
+	if c.classMapsByRoot == nil {
+		c.classMapsByRoot = make(map[*d2ir.Map]map[string]*d2ir.Map)
+	}
+	classMaps, ok := c.classMapsByRoot[root]
+	if !ok {
+		classMaps = make(map[string]*d2ir.Map)
+		classes := root.GetField(d2ast.FlatUnquotedString("classes"))
+		if classes != nil && classes.Map() != nil {
+			for _, class := range classes.Map().Fields {
+				if c.stopped() {
+					return nil
+				}
+				if class == nil || class.Name == nil {
+					continue
+				}
+				className := class.Name.ScalarString()
+				if _, reserved := d2ast.ReservedKeywords[strings.ToLower(className)]; reserved && !class.Name.IsUnquoted() {
+					// GetClassMap queries with an unquoted name, so quoted
+					// reserved words do not match it.
+					continue
+				}
+				key := foldClassName(className)
+				if _, exists := classMaps[key]; exists {
+					continue
+				}
+				// Retain nil values: like GetField, the first matching
+				// declaration wins even when it is not a map.
+				classMaps[key] = class.Map()
+			}
+		}
+		if c.stopped() {
+			return nil
+		}
+		c.classMapsByRoot[root] = classMaps
+	}
+	return classMaps[foldClassName(name)]
+}
+
+// foldClassName produces the same Unicode simple-fold equivalence classes as
+// strings.EqualFold, which is what d2ir.GetClassMap historically used.
+func foldClassName(s string) string {
+	ascii := true
+	lower := false
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			ascii = false
+			break
+		}
+		if s[i] >= 'a' && s[i] <= 'z' {
+			lower = true
+		}
+	}
+	if ascii {
+		if !lower {
+			return s
+		}
+		folded := []byte(s)
+		for i := range folded {
+			if folded[i] >= 'a' && folded[i] <= 'z' {
+				folded[i] -= 'a' - 'A'
+			}
+		}
+		return string(folded)
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		min := r
+		for next := unicode.SimpleFold(r); next != r; next = unicode.SimpleFold(next) {
+			if next < min {
+				min = next
+			}
+		}
+		b.WriteRune(min)
+	}
+	return b.String()
+}
+
 func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
+	if c.stopped() {
+		return
+	}
 	keyword := strings.ToLower(f.Name.ScalarString())
 	_, isStyleReserved := d2ast.StyleKeywords[keyword]
 	if isStyleReserved && f.Name.IsUnquoted() {
@@ -397,10 +620,16 @@ func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
 				c.errorf(f.Map().Edges[0].LastRef().AST(), "classes cannot contain an edge")
 			}
 			for _, classesField := range f.Map().Fields {
+				if c.stopped() {
+					return
+				}
 				if classesField.Map() == nil {
 					continue
 				}
 				for _, cf := range classesField.Map().Fields {
+					if c.stopped() {
+						return
+					}
 					if _, ok := d2ast.ReservedKeywords[cf.Name.ScalarString()]; !(ok && f.Name.IsUnquoted()) {
 						c.errorf(cf.LastRef().AST(), "%s is an invalid class field, must be reserved keyword", cf.Name.ScalarString())
 					}
@@ -447,12 +676,18 @@ func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
 	}
 	if f.Map() != nil {
 		c.compileMap(obj, f.Map())
+		if c.stopped() {
+			return
+		}
 	}
 
 	if obj.Label.MapKey == nil {
 		obj.Label.MapKey = f.LastPrimaryKey()
 	}
 	for _, fr := range f.References {
+		if c.stopped() {
+			return
+		}
 		if fr.Primary() {
 			if fr.Context_.Key.Value.Map != nil {
 				obj.Map = fr.Context_.Key.Value.Map
@@ -515,9 +750,15 @@ func (c *compiler) compileLabel(attrs *d2graph.Attributes, f d2ir.Node) {
 }
 
 func (c *compiler) compilePosition(attrs *d2graph.Attributes, f *d2ir.Field) {
+	if c.stopped() {
+		return
+	}
 	name := f.Name
 	if f.Map() != nil {
 		for _, f := range f.Map().Fields {
+			if c.stopped() {
+				return
+			}
 			if f.Name.ScalarString() == "near" && f.Name.IsUnquoted() {
 				if f.Primary() == nil {
 					c.errorf(f.LastPrimaryKey(), `invalid "near" field`)
@@ -580,6 +821,9 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 			case "class":
 				if arr, ok := f.Composite.(*d2ir.Array); ok {
 					for _, class := range arr.Values {
+						if c.stopped() {
+							return
+						}
 						if scalar, ok := class.(*d2ir.Scalar); ok {
 							attrs.Classes = append(attrs.Classes, scalar.Value.ScalarString())
 						}
@@ -588,6 +832,9 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 			case "constraint":
 				if arr, ok := f.Composite.(*d2ir.Array); ok {
 					for _, constraint := range arr.Values {
+						if c.stopped() {
+							return
+						}
 						if scalar, ok := constraint.(*d2ir.Scalar); ok {
 							switch scalar.Value.(type) {
 							case *d2ast.Null:
@@ -637,6 +884,9 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 		c.compilePosition(attrs, f)
 		if f.Map() != nil {
 			for _, ff := range f.Map().Fields {
+				if c.stopped() {
+					return
+				}
 				if ff.Name.ScalarString() == "style" && ff.Name.IsUnquoted() {
 					if ff.Map() == nil || len(ff.Map().Fields) == 0 {
 						c.errorf(f.LastRef().AST(), `"style" expected to be set to a map of key-values, or contain an additional keyword like "style.opacity: 0.4"`)
@@ -830,6 +1080,9 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 
 func (c *compiler) compileStyle(styles *d2graph.Style, m *d2ir.Map) {
 	for _, f := range m.Fields {
+		if c.stopped() {
+			return
+		}
 		c.compileStyleField(styles, f)
 	}
 }
@@ -897,6 +1150,9 @@ func compileStyleFieldInit(styles *d2graph.Style, f *d2ir.Field) {
 }
 
 func (c *compiler) compileEdge(obj *d2graph.Object, e *d2ir.Edge) {
+	if c.stopped() {
+		return
+	}
 	edge, err := obj.Connect(e.ID.SrcPath, e.ID.DstPath, e.ID.SrcArrow, e.ID.DstArrow, "")
 	if err != nil {
 		c.errorf(e.References[0].AST(), err.Error())
@@ -915,6 +1171,9 @@ func (c *compiler) compileEdge(obj *d2graph.Object, e *d2ir.Edge) {
 
 	edge.Label.MapKey = e.LastPrimaryKey()
 	for _, er := range e.References {
+		if c.stopped() {
+			return
+		}
 		r := d2graph.EdgeReference{
 			Edge:            er.Context_.Edge,
 			MapKey:          er.Context_.Key,
@@ -932,6 +1191,9 @@ func (c *compiler) compileEdge(obj *d2graph.Object, e *d2ir.Edge) {
 }
 
 func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
+	if c.stopped() {
+		return
+	}
 	class := m.GetField(d2ast.FlatUnquotedString("class"))
 	if class != nil {
 		var classNames []string
@@ -940,6 +1202,9 @@ func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
 		} else if class.Composite != nil {
 			if arr, ok := class.Composite.(*d2ir.Array); ok {
 				for _, class := range arr.Values {
+					if c.stopped() {
+						return
+					}
 					if scalar, ok := class.(*d2ir.Scalar); ok {
 						classNames = append(classNames, scalar.Value.ScalarString())
 					} else {
@@ -950,9 +1215,17 @@ func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
 		}
 
 		for _, className := range classNames {
-			classMap := m.GetClassMap(className)
+			if c.stopped() {
+				return
+			}
+			classMap := c.getClassMap(m, className)
 			if classMap != nil {
 				if c.beginClass(class, className, classMap) {
+					if err := d2ir.ReserveVariableExpansionCopy(c.ctx, classMap); err != nil {
+						c.fatalErr = err
+						c.endClass(classMap)
+						return
+					}
 					c.compileEdgeMap(edge, classMap)
 					c.endClass(classMap)
 				}
@@ -960,6 +1233,9 @@ func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
 		}
 	}
 	for _, f := range m.Fields {
+		if c.stopped() {
+			return
+		}
 		_, ok := d2ast.ReservedKeywords[f.Name.ScalarString()]
 		if !(ok && f.Name.IsUnquoted()) {
 			c.errorf(f.References[0].AST(), `edge map keys must be reserved keywords`)
@@ -995,6 +1271,9 @@ func (c *compiler) compileEdgeField(edge *d2graph.Edge, f *d2ir.Field) {
 }
 
 func (c *compiler) compileArrowheads(edge *d2graph.Edge, f *d2ir.Field) {
+	if c.stopped() {
+		return
+	}
 	var attrs *d2graph.Attributes
 	if f.Name.ScalarString() == "source-arrowhead" {
 		if edge.SrcArrowhead == nil {
@@ -1014,6 +1293,9 @@ func (c *compiler) compileArrowheads(edge *d2graph.Edge, f *d2ir.Field) {
 
 	if f.Map() != nil {
 		for _, f2 := range f.Map().Fields {
+			if c.stopped() {
+				return
+			}
 			keyword := strings.ToLower(f2.Name.ScalarString())
 			_, isReserved := d2ast.SimpleReservedKeywords[keyword]
 			isReserved = isReserved && f2.Name.IsUnquoted()
@@ -1047,8 +1329,14 @@ var ShortToFullLanguageAliases = map[string]string{
 var FullToShortLanguageAliases map[string]string
 
 func (c *compiler) compileClass(obj *d2graph.Object) {
+	if c.stopped() {
+		return
+	}
 	obj.Class = &d2target.Class{}
 	for _, f := range obj.ChildrenArray {
+		if c.stopped() {
+			return
+		}
 		visibility := "public"
 		name := f.IDVal
 		// See https://www.uml-diagrams.org/visibility.html
@@ -1095,7 +1383,13 @@ func (c *compiler) compileClass(obj *d2graph.Object) {
 	}
 
 	for _, ch := range obj.ChildrenArray {
+		if c.stopped() {
+			return
+		}
 		for i := 0; i < len(obj.Graph.Objects); i++ {
+			if c.stopped() {
+				return
+			}
 			if obj.Graph.Objects[i] == ch {
 				obj.Graph.Objects = append(obj.Graph.Objects[:i], obj.Graph.Objects[i+1:]...)
 				i--
@@ -1107,8 +1401,14 @@ func (c *compiler) compileClass(obj *d2graph.Object) {
 }
 
 func (c *compiler) compileSQLTable(obj *d2graph.Object) {
+	if c.stopped() {
+		return
+	}
 	obj.SQLTable = &d2target.SQLTable{}
 	for _, col := range obj.ChildrenArray {
+		if c.stopped() {
+			return
+		}
 		typ := col.Label.Value
 		if typ == col.IDVal {
 			// Not great, AST should easily allow specifying alternate primary field
@@ -1124,7 +1424,13 @@ func (c *compiler) compileSQLTable(obj *d2graph.Object) {
 	}
 
 	for _, ch := range obj.ChildrenArray {
+		if c.stopped() {
+			return
+		}
 		for i := 0; i < len(obj.Graph.Objects); i++ {
+			if c.stopped() {
+				return
+			}
 			if obj.Graph.Objects[i] == ch {
 				obj.Graph.Objects = append(obj.Graph.Objects[:i], obj.Graph.Objects[i+1:]...)
 				i--
@@ -1137,6 +1443,9 @@ func (c *compiler) compileSQLTable(obj *d2graph.Object) {
 
 func (c *compiler) validateKeys(obj *d2graph.Object, m *d2ir.Map) {
 	for _, f := range m.Fields {
+		if c.stopped() {
+			return
+		}
 		if _, ok := d2ast.BoardKeywords[f.Name.ScalarString()]; ok && f.Name.IsUnquoted() {
 			continue
 		}
@@ -1200,6 +1509,9 @@ func (c *compiler) validateKey(obj *d2graph.Object, f *d2ir.Field) {
 
 func (c *compiler) validateLabels(g *d2graph.Graph) {
 	for _, obj := range g.Objects {
+		if c.stopped() {
+			return
+		}
 		if strings.EqualFold(obj.Shape.Value, d2target.ShapeText) {
 			if obj.Attributes.Language != "" {
 				// blockstrings have already been validated
@@ -1218,6 +1530,9 @@ func (c *compiler) validateLabels(g *d2graph.Graph) {
 
 func (c *compiler) validateNear(g *d2graph.Graph) {
 	for _, obj := range g.Objects {
+		if c.stopped() {
+			return
+		}
 		if obj.NearKey != nil {
 			nearObj, isKey := g.Root.HasChild(d2graph.Key(obj.NearKey))
 			_, isConst := d2ast.NearConstants[d2graph.Key(obj.NearKey)[0]]
@@ -1277,6 +1592,9 @@ func (c *compiler) validateNear(g *d2graph.Graph) {
 	}
 
 	for _, edge := range g.Edges {
+		if c.stopped() {
+			return
+		}
 		if edge.Src.IsConstantNear() && edge.Dst.IsDescendantOf(edge.Src) {
 			c.errorf(edge.GetAstEdge(), "edge from constant near %#v cannot enter itself", edge.Src.AbsID())
 			continue
@@ -1291,7 +1609,13 @@ func (c *compiler) validateNear(g *d2graph.Graph) {
 
 func (c *compiler) validatePositionsCompatibility(g *d2graph.Graph) {
 	for _, o := range g.Objects {
+		if c.stopped() {
+			return
+		}
 		for _, pos := range []*d2graph.Scalar{o.Top, o.Left} {
+			if c.stopped() {
+				return
+			}
 			if pos != nil {
 				if o.Parent != nil {
 					if strings.EqualFold(o.Parent.Shape.Value, d2target.ShapeHierarchy) {
@@ -1311,6 +1635,9 @@ func (c *compiler) validatePositionsCompatibility(g *d2graph.Graph) {
 
 func (c *compiler) validateEdges(g *d2graph.Graph) {
 	for _, edge := range g.Edges {
+		if c.stopped() {
+			return
+		}
 		// edges from a grid to something outside is ok
 		//   grid -> outside : ok
 		//   grid -> grid.cell : not ok
@@ -1344,6 +1671,9 @@ func (c *compiler) validateEdges(g *d2graph.Graph) {
 
 func (c *compiler) validateBoardLinks(g *d2graph.Graph) {
 	for _, obj := range g.Objects {
+		if c.stopped() {
+			return
+		}
 		if obj.Link == nil {
 			continue
 		}
@@ -1375,12 +1705,21 @@ func (c *compiler) validateBoardLinks(g *d2graph.Graph) {
 		}
 	}
 	for _, b := range g.Layers {
+		if c.stopped() {
+			return
+		}
 		c.validateBoardLinks(b)
 	}
 	for _, b := range g.Scenarios {
+		if c.stopped() {
+			return
+		}
 		c.validateBoardLinks(b)
 	}
 	for _, b := range g.Steps {
+		if c.stopped() {
+			return
+		}
 		c.validateBoardLinks(b)
 	}
 }
@@ -1580,6 +1919,9 @@ FOR:
 
 func (c *compiler) setDefaultShapes(g *d2graph.Graph) {
 	for _, obj := range g.Objects {
+		if c.stopped() {
+			return
+		}
 		if obj.Shape.Value == "" {
 			if obj.OuterSequenceDiagram() != nil {
 				obj.Shape.Value = d2target.ShapeRectangle

--- a/d2compiler/variable_expansion_internal_test.go
+++ b/d2compiler/variable_expansion_internal_test.go
@@ -1,0 +1,143 @@
+package d2compiler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2ir"
+	"github.com/d2lang/d2/d2parser"
+)
+
+func TestGraphMaterializationBoundsUnusedAliasesAcrossBoards(t *testing.T) {
+	t.Parallel()
+
+	for _, boardKind := range []string{"layers", "scenarios", "steps"} {
+		boardKind := boardKind
+		t.Run(boardKind, func(t *testing.T) {
+			t.Parallel()
+			var source strings.Builder
+			source.WriteString("vars: {\n  v0: {leaf}\n")
+			for i := 1; i <= 10; i++ {
+				fmt.Fprintf(&source, "  v%d: {left: {}; right: {}}\n", i)
+			}
+			fmt.Fprintf(&source, "}\n%s: {first: {one}; second: {two}}", boardKind)
+			ast, ir := compileExpansionIR(t, source.String(), 8_192)
+
+			if _, err := compileIRContext(context.Background(), ast, ir); err != nil {
+				t.Fatalf("ordinary boards rejected: %v", err)
+			}
+
+			ast, ir = compileExpansionIR(t, source.String(), 8_192)
+			vars := ir.GetField(d2ast.FlatUnquotedString("vars")).Map()
+			shared := vars.GetField(d2ast.FlatUnquotedString("v0")).Composite
+			for i := 1; i <= 10; i++ {
+				level := vars.GetField(d2ast.FlatUnquotedString(fmt.Sprintf("v%d", i)))
+				level.Map().GetField(d2ast.FlatUnquotedString("left")).Composite = shared
+				level.Map().GetField(d2ast.FlatUnquotedString("right")).Composite = shared
+				shared = level.Composite
+			}
+			_, err := compileIRContext(context.Background(), ast, ir)
+			if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 8192 work units") {
+				t.Fatalf("compileIR error = %v, want expansion limit", err)
+			}
+		})
+	}
+}
+
+func TestCompileCancellationDuringGraphMaterialization(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&source, "object-%d\n", i)
+	}
+	ast, ir := compileExpansionIR(t, source.String(), 0)
+	ctx := &graphCancelAfterErrContext{Context: context.Background(), cancelAt: 16}
+	_, err := compileIRContext(ctx, ast, ir)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("compileIR error = %v, want context.Canceled", err)
+	}
+	if ctx.calls < ctx.cancelAt {
+		t.Fatalf("context Err called %d times, want at least %d", ctx.calls, ctx.cancelAt)
+	}
+}
+
+func TestClassLookupBuildsOneReusableIndex(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	source.WriteString("classes: {\n")
+	for i := 0; i < 2_048; i++ {
+		fmt.Fprintf(&source, "  class-%d: {style.fill: red}\n", i)
+	}
+	source.WriteString("}\n")
+	_, ir := compileExpansionIR(t, source.String(), 0)
+	c := &compiler{ctx: context.Background()}
+	for pass := 0; pass < 4; pass++ {
+		for i := 0; i < 2_048; i++ {
+			if got := c.getClassMap(ir, fmt.Sprintf("CLASS-%d", i)); got == nil {
+				t.Fatalf("class-%d not found", i)
+			}
+		}
+		if got := c.getClassMap(ir, fmt.Sprintf("missing-%d", pass)); got != nil {
+			t.Fatalf("missing class resolved to %p", got)
+		}
+	}
+	if got := len(c.classMapsByRoot); got != 1 {
+		t.Fatalf("class lookup built %d root indexes, want 1", got)
+	}
+}
+
+func TestClassLookupIndexConstructionIsCancelable(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	source.WriteString("classes: {\n")
+	for i := 0; i < 1_024; i++ {
+		fmt.Fprintf(&source, "  class-%d: {style.fill: red}\n", i)
+	}
+	source.WriteString("}\n")
+	_, ir := compileExpansionIR(t, source.String(), 0)
+	ctx := &graphCancelAfterErrContext{Context: context.Background(), cancelAt: 32}
+	c := &compiler{ctx: ctx}
+	if got := c.getClassMap(ir, "class-1023"); got != nil {
+		t.Fatalf("canceled class lookup returned %p", got)
+	}
+	if !errors.Is(c.fatalErr, context.Canceled) {
+		t.Fatalf("class lookup error = %v, want context.Canceled", c.fatalErr)
+	}
+	if len(c.classMapsByRoot) != 0 {
+		t.Fatal("canceled class lookup retained a partial index")
+	}
+}
+
+func compileExpansionIR(t *testing.T, source string, limit int64) (*d2ast.Map, *d2ir.Map) {
+	t.Helper()
+	ast, err := d2parser.Parse("expansion-internal.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir, _, err := d2ir.Compile(ast, &d2ir.CompileOptions{MaxVariableExpansion: limit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ast, ir
+}
+
+type graphCancelAfterErrContext struct {
+	context.Context
+	calls    int
+	cancelAt int
+}
+
+func (c *graphCancelAfterErrContext) Err() error {
+	c.calls++
+	if c.calls >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}

--- a/d2compiler/variable_expansion_test.go
+++ b/d2compiler/variable_expansion_test.go
@@ -1,0 +1,230 @@
+package d2compiler_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/d2lang/d2/d2compiler"
+)
+
+func TestVariableExpansionLimits(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		dsl   string
+		limit int64
+	}{
+		{
+			name:  "unquoted scalar bytes",
+			dsl:   "vars: {x: 12345678}\nout: ${x}${x}${x}${x}${x}",
+			limit: 32,
+		},
+		{
+			name:  "whole scalar bytes",
+			dsl:   "vars: {x: 12345678}\none: ${x}\ntwo: ${x}",
+			limit: 8,
+		},
+		{
+			name:  "quoted scalar bytes",
+			dsl:   "vars: {x: 12345678}\nout: \"${x}${x}${x}${x}${x}\"",
+			limit: 32,
+		},
+		{
+			name:  "Markdown scalar bytes",
+			dsl:   "vars: {x: 12345678}\nout: |md\n${x}${x}${x}${x}${x}\n|",
+			limit: 32,
+		},
+		{
+			name:  "array members",
+			dsl:   "vars: {x: [a; b; c; d]}\nout.class: [...${x}; ...${x}; ...${x}]",
+			limit: 8,
+		},
+		{
+			name:  "map spread copy",
+			dsl:   "vars: {x: {a; b; c; d}}\nout: {...${x}}",
+			limit: 4,
+		},
+		{
+			name:  "referenced composite DAG",
+			dsl:   compositeAliasSource(7, true, ""),
+			limit: 64,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := d2compiler.Compile("expansion.d2", strings.NewReader(tc.dsl), &d2compiler.CompileOptions{
+				MaxVariableExpansion: tc.limit,
+			})
+			assertVariableExpansionError(t, err, tc.limit)
+		})
+	}
+}
+
+func TestVariableExpansionDefaultLimit(t *testing.T) {
+	t.Parallel()
+
+	value := strings.Repeat("x", 32_769)
+	_, _, err := d2compiler.Compile(
+		"expansion-default.d2",
+		strings.NewReader(fmt.Sprintf("vars: {x: %s}\nout: ${x}${x}", value)),
+		nil,
+	)
+	assertVariableExpansionError(t, err, 65_536)
+}
+
+func TestVariableExpansionBoundaryAndValidation(t *testing.T) {
+	t.Parallel()
+
+	const source = "vars: {x: 12345678}\nout: ${x}${x}${x}${x}"
+	if _, _, err := d2compiler.Compile("expansion-boundary.d2", strings.NewReader(source), &d2compiler.CompileOptions{
+		MaxVariableExpansion: 32,
+	}); err != nil {
+		t.Fatalf("exact-boundary expansion rejected: %v", err)
+	}
+
+	_, _, err := d2compiler.Compile("expansion-negative.d2", strings.NewReader("x"), &d2compiler.CompileOptions{
+		MaxVariableExpansion: -1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "MaxVariableExpansion must not be negative") {
+		t.Fatalf("negative limit error = %v", err)
+	}
+}
+
+func TestUnusedCompositeAliasBoardCopiesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	for _, boardKind := range []string{"layers", "scenarios", "steps"} {
+		boardKind := boardKind
+		t.Run(boardKind, func(t *testing.T) {
+			t.Parallel()
+			boards := fmt.Sprintf("%s: {first: {a}; second: {b}}", boardKind)
+			_, _, err := d2compiler.Compile("board-control.d2", strings.NewReader(boards), &d2compiler.CompileOptions{
+				MaxVariableExpansion: 256,
+			})
+			if err != nil {
+				t.Fatalf("ordinary boards rejected: %v", err)
+			}
+
+			_, _, err = d2compiler.Compile(
+				"board-expansion.d2",
+				strings.NewReader(compositeAliasSource(8, false, boards)),
+				&d2compiler.CompileOptions{MaxVariableExpansion: 256},
+			)
+			assertVariableExpansionError(t, err, 256)
+		})
+	}
+}
+
+func TestClassApplicationCartesianExpansionIsBounded(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	source.WriteString("vars: {\n  a0: {class: c}\n")
+	for i := 1; i <= 5; i++ {
+		fmt.Fprintf(&source, "  a%d: {left: ${a%d}; right: ${a%d}}\n", i, i-1, i-1)
+	}
+	source.WriteString("  b0: {label: leaf}\n")
+	for i := 1; i <= 5; i++ {
+		fmt.Fprintf(&source, "  b%d: {left: ${b%d}; right: ${b%d}}\n", i, i-1, i-1)
+	}
+	source.WriteString("}\nclasses: {c: ${b5}}\nout: ${a5}\n")
+
+	_, _, err := d2compiler.Compile("class-expansion.d2", strings.NewReader(source.String()), &d2compiler.CompileOptions{
+		MaxVariableExpansion: 2_048,
+	})
+	assertVariableExpansionError(t, err, 2_048)
+}
+
+func TestMarkdownNestedVariableNamesAreBoundedBeforeFlattening(t *testing.T) {
+	t.Parallel()
+
+	longName := strings.Repeat("x", 64)
+	source := fmt.Sprintf("vars: {%s: {%s: {leaf: value}}}\nout: |md\n${%s.%s.leaf}\n|", longName, longName, longName, longName)
+	_, _, err := d2compiler.Compile("markdown-variable-name.d2", strings.NewReader(source), &d2compiler.CompileOptions{
+		MaxVariableExpansion: 64,
+	})
+	assertVariableExpansionError(t, err, 64)
+}
+
+func TestMarkdownVariableMatcherConstructionIsCumulativeAcrossBlocks(t *testing.T) {
+	t.Parallel()
+
+	var prefix strings.Builder
+	prefix.WriteString("vars: {\n")
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&prefix, "  variable-%03d: value\n", i)
+	}
+	prefix.WriteString("}\n")
+	compile := func(blocks int) error {
+		var source strings.Builder
+		source.WriteString(prefix.String())
+		for i := 0; i < blocks; i++ {
+			fmt.Fprintf(&source, "out-%d: |md\n${unknown}\n|\n", i)
+		}
+		_, _, err := d2compiler.Compile("markdown-matcher-work.d2", strings.NewReader(source.String()), &d2compiler.CompileOptions{
+			MaxVariableExpansion: 4_096,
+		})
+		return err
+	}
+	if err := compile(1); err != nil {
+		t.Fatalf("single Markdown block control rejected: %v", err)
+	}
+	err := compile(4)
+	assertVariableExpansionError(t, err, 4_096)
+
+	var noPlaceholders strings.Builder
+	noPlaceholders.WriteString(prefix.String())
+	for i := 0; i < 120; i++ {
+		fmt.Fprintf(&noPlaceholders, "plain-%d: |md\nno variables here\n|\n", i)
+	}
+	if _, _, err := d2compiler.Compile("markdown-no-matcher-work.d2", strings.NewReader(noPlaceholders.String()), &d2compiler.CompileOptions{
+		MaxVariableExpansion: 1,
+	}); err != nil {
+		t.Fatalf("Markdown without placeholders consumed matcher work: %v", err)
+	}
+}
+
+func TestMarkdownSubstitutionSupportsQuotedVariableNamesWithClosingBraces(t *testing.T) {
+	t.Parallel()
+
+	const source = "vars:{ \"a}b\": value }\nout: |md\n${a}b}\n|"
+	g, _, err := d2compiler.Compile("markdown-quoted-variable.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, ok := g.Root.HasChild([]string{"out"})
+	if !ok {
+		t.Fatal("compiled graph has no out object")
+	}
+	if got := strings.TrimSpace(out.Label.Value); got != "value" {
+		t.Fatalf("out label = %q, want %q", got, "value")
+	}
+}
+
+func compositeAliasSource(depth int, referenced bool, suffix string) string {
+	var source strings.Builder
+	source.WriteString("vars: {\n  v0: {leaf}\n")
+	for i := 1; i <= depth; i++ {
+		fmt.Fprintf(&source, "  v%d: {left: ${v%d}; right: ${v%d}}\n", i, i-1, i-1)
+	}
+	source.WriteString("}\n")
+	if referenced {
+		fmt.Fprintf(&source, "out: ${v%d}\n", depth)
+	}
+	if suffix != "" {
+		source.WriteString(suffix)
+		source.WriteByte('\n')
+	}
+	return source.String()
+}
+
+func assertVariableExpansionError(t *testing.T, err error, limit int64) {
+	t.Helper()
+	want := fmt.Sprintf("variable substitution expansion exceeds limit of %d work units", limit)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("Compile error = %v, want error containing %q", err, want)
+	}
+}

--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -2,6 +2,7 @@ package d2ir
 
 import (
 	"context"
+	"errors"
 	"html"
 	"io/fs"
 	"net/url"
@@ -30,8 +31,12 @@ type globContext struct {
 }
 
 type compiler struct {
-	err *d2parser.ParseError
-	ctx context.Context
+	err               *d2parser.ParseError
+	ctx               context.Context
+	contextErr        error
+	expansionErr      error
+	halted            bool
+	variableExpansion *variableExpansionBudget
 
 	fs      fs.FS
 	imports []string
@@ -69,10 +74,13 @@ type compiler struct {
 }
 
 type CompileOptions struct {
-	// Context stops parsing imported files when canceled. A nil Context is
+	// Context stops parsing and compilation when canceled. A nil Context is
 	// treated as context.Background().
 	Context  context.Context
 	UTF16Pos bool
+	// MaxVariableExpansion bounds work added by substitutions and automatic
+	// copies. Zero uses DefaultMaxVariableExpansion.
+	MaxVariableExpansion int64
 	// FS resolves imports. Nil disables imports. The lib/localfile package
 	// provides rooted and explicit unrestricted host-filesystem policies.
 	FS fs.FS
@@ -93,10 +101,15 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
+	variableExpansion, err := newVariableExpansionBudget(opts.MaxVariableExpansion)
+	if err != nil {
+		return nil, nil, err
+	}
 	c := &compiler{
-		err: &d2parser.ParseError{},
-		ctx: ctx,
-		fs:  opts.FS,
+		err:               &d2parser.ParseError{},
+		ctx:               ctx,
+		fs:                opts.FS,
+		variableExpansion: variableExpansion,
 
 		seenImports:             make(map[string]struct{}),
 		parsedImports:           make(map[string]*d2ast.Map),
@@ -106,6 +119,7 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 	}
 	m := &Map{}
 	m.initRoot()
+	m.variableExpansion = variableExpansion
 	m.parent.(*Field).References[0].Context_.Scope = ast
 	m.parent.(*Field).References[0].Context_.ScopeAST = ast
 
@@ -115,11 +129,41 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 	defer c.popImportStack()
 
 	c.compileMap(m, ast, ast)
+	if c.contextErr != nil {
+		return nil, nil, c.contextErr
+	}
 	c.compileSubstitutions(m, nil)
+	if c.contextErr != nil {
+		return nil, nil, c.contextErr
+	}
+	if c.expansionErr != nil {
+		if !c.err.Empty() {
+			return nil, nil, c.err
+		}
+		return nil, nil, c.expansionErr
+	}
 	c.overlayClasses(m)
+	if c.contextErr != nil {
+		return nil, nil, c.contextErr
+	}
+	if c.expansionErr != nil {
+		if !c.err.Empty() {
+			return nil, nil, c.err
+		}
+		return nil, nil, c.expansionErr
+	}
+	// Substitutions can grow shared nodes after an earlier alias inserted them
+	// (for example through a forward scalar chain in an array spread). Recheck
+	// the fully resolved IR before cleanup or any public caller can observe it.
+	if err := ReserveVariableExpansionAliases(ctx, m); err != nil {
+		return nil, nil, err
+	}
 	m.removeSuspendedFields()
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
+	}
+	if c.expansionErr != nil && c.err.Empty() {
+		return nil, nil, c.expansionErr
 	}
 	if !c.err.Empty() {
 		return nil, nil, c.err
@@ -128,6 +172,9 @@ func Compile(ast *d2ast.Map, opts *CompileOptions) (*Map, []string, error) {
 }
 
 func (c *compiler) overlayClasses(m *Map) {
+	if c.stopped() {
+		return
+	}
 	classes := m.getFieldIndexed(d2ast.FlatUnquotedString("classes"))
 	if classes == nil || classes.Map() == nil {
 		return
@@ -143,6 +190,9 @@ func (c *compiler) overlayClasses(m *Map) {
 	}
 
 	for _, lf := range layers.Fields {
+		if c.stopped() {
+			return
+		}
 		if lf.Map() == nil || lf.Primary() != nil {
 			continue
 		}
@@ -150,10 +200,19 @@ func (c *compiler) overlayClasses(m *Map) {
 		lClasses := l.getFieldIndexed(d2ast.FlatUnquotedString("classes"))
 
 		if lClasses == nil {
+			if !c.reserveVariableCopy(lf.LastRef().AST(), classes) {
+				return
+			}
 			lClasses = classes.Copy(l).(*Field)
 			l.appendField(lClasses)
 		} else if lClasses.Map() != nil {
+			if !c.reserveVariableCopy(lf.LastRef().AST(), classes) {
+				return
+			}
 			base := classes.Copy(l).(*Field)
+			if !c.reserveVariableCopy(lf.LastRef().AST(), lClasses.Map()) {
+				return
+			}
 			overlayMapIndexed(base.Map(), lClasses.Map())
 			l.DeleteField("classes")
 			l.appendField(base)
@@ -164,7 +223,20 @@ func (c *compiler) overlayClasses(m *Map) {
 }
 
 func (c *compiler) compileSubstitutions(m *Map, varsStack []*Map) {
+	c.compileSubstitutionsWalk(m, varsStack, make(map[Node]struct{}), nil)
+}
+
+func (c *compiler) compileSubstitutionsWalk(m *Map, varsStack []*Map, seen map[Node]struct{}, source d2ast.Node) {
+	if c.stopped() {
+		return
+	}
+	if !c.visitSubstitutionNode(m, source, seen) {
+		return
+	}
 	for _, f := range m.Fields {
+		if c.stopped() {
+			return
+		}
 		if f.Name == nil {
 			continue
 		}
@@ -173,15 +245,30 @@ func (c *compiler) compileSubstitutions(m *Map, varsStack []*Map) {
 		}
 	}
 	for i := 0; i < len(m.Fields); i++ {
+		if c.stopped() {
+			return
+		}
 		f := m.Fields[i]
+		if !c.visitSubstitutionNode(f, f.LastRef().AST(), seen) {
+			return
+		}
 		if f.Primary() != nil {
+			if !c.visitSubstitutionNode(f.Primary(), f.LastRef().AST(), seen) {
+				return
+			}
 			removed := c.resolveSubstitutions(varsStack, f)
 			if removed {
 				i--
 			}
 		}
 		if arr, ok := f.Composite.(*Array); ok {
+			if !c.visitSubstitutionNode(arr, f.LastRef().AST(), seen) {
+				return
+			}
 			for _, val := range arr.Values {
+				if !c.visitSubstitutionNode(val, f.LastRef().AST(), seen) {
+					return
+				}
 				if scalar, ok := val.(*Scalar); ok {
 					removed := c.resolveSubstitutions(varsStack, scalar)
 					if removed {
@@ -191,21 +278,41 @@ func (c *compiler) compileSubstitutions(m *Map, varsStack []*Map) {
 			}
 		} else if f.Map() != nil {
 			if f.Name != nil && f.Name.ScalarString() == "vars" && f.Name.IsUnquoted() {
-				c.compileSubstitutions(f.Map(), varsStack)
+				c.compileSubstitutionsWalk(f.Map(), varsStack, seen, f.LastRef().AST())
 				c.validateConfigs(f.Map().getFieldIndexed(d2ast.FlatUnquotedString("d2-config")))
 			} else {
-				c.compileSubstitutions(f.Map(), varsStack)
+				c.compileSubstitutionsWalk(f.Map(), varsStack, seen, f.LastRef().AST())
 			}
 		}
 	}
 	for _, e := range m.Edges {
+		if c.stopped() {
+			return
+		}
+		if !c.visitSubstitutionNode(e, e.LastRef().AST(), seen) {
+			return
+		}
 		if e.Primary() != nil {
+			if !c.visitSubstitutionNode(e.Primary(), e.LastRef().AST(), seen) {
+				return
+			}
 			c.resolveSubstitutions(varsStack, e)
 		}
 		if e.Map() != nil {
-			c.compileSubstitutions(e.Map(), varsStack)
+			c.compileSubstitutionsWalk(e.Map(), varsStack, seen, e.LastRef().AST())
 		}
 	}
+}
+
+func (c *compiler) visitSubstitutionNode(node Node, source d2ast.Node, seen map[Node]struct{}) bool {
+	if node == nil {
+		return true
+	}
+	if _, ok := seen[node]; ok {
+		return c.reserveVariableExpansion(source, variableExpansionNodeUnits(node))
+	}
+	seen[node] = struct{}{}
+	return true
 }
 
 func (c *compiler) validateConfigs(configs *Field) {
@@ -265,14 +372,23 @@ func (c *compiler) validateConfigs(configs *Field) {
 }
 
 func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedField bool) {
+	if c.stopped() {
+		return false
+	}
 	var subbed bool
 	var resolvedField *Field
 
 	switch s := node.Primary().Value.(type) {
 	case *d2ast.UnquotedString:
 		for i, box := range s.Value {
+			if c.stopped() {
+				return
+			}
 			if box.Substitution != nil {
 				for i, vars := range varsStack {
+					if c.stopped() {
+						return
+					}
 					resolvedField = c.resolveSubstitution(vars, node, box.Substitution, i == 0)
 					if resolvedField != nil {
 						if resolvedField.Primary() != nil {
@@ -307,6 +423,12 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 							continue
 						}
 						arr := n.parent.(*Array)
+						// The values remain shared in the IR, but public IR consumers may
+						// later copy or marshal every logical occurrence. Charge the full
+						// recursively reachable value cost before inserting the aliases.
+						if !c.reserveVariableCopy(box.Substitution, resolvedArr) {
+							return
+						}
 						for i, s := range arr.Values {
 							if s == n {
 								arr.Values = append(append(arr.Values[:i], resolvedArr.Values...), arr.Values[i+1:]...)
@@ -318,6 +440,9 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 						if resolvedField.Map() != nil {
 							if hasUnresolvedMapSpread(resolvedField.Map()) {
 								c.errorf(box.Substitution, `cannot spread composite variable "%s" before its spread substitutions are resolved`, strings.Join(box.Substitution.IDA(), "."))
+								return
+							}
+							if !c.reserveVariableCopy(box.Substitution, resolvedField.Map()) {
 								return
 							}
 							expandSubstitutionIndexed(m, resolvedField.Map(), n)
@@ -362,6 +487,9 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 					}
 				} else {
 					if i == 0 && len(s.Value) == 1 {
+						if !c.reserveVariableExpansion(box.Substitution, int64(len(resolvedField.Primary().Value.ScalarString()))) {
+							return
+						}
 						node.Primary().Value = resolvedField.Primary().Value
 					} else {
 						s.Value[i].String = go2.Pointer(resolvedField.Primary().Value.ScalarString())
@@ -383,12 +511,21 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 			}
 		}
 		if subbed {
+			if !c.reserveVariableExpansion(node.LastRef().AST(), interpolationBytes(s.Value)) {
+				return
+			}
 			s.Coalesce()
 		}
 	case *d2ast.DoubleQuotedString:
 		for i, box := range s.Value {
+			if c.stopped() {
+				return
+			}
 			if box.Substitution != nil {
 				for i, vars := range varsStack {
+					if c.stopped() {
+						return
+					}
 					resolvedField = c.resolveSubstitution(vars, node, box.Substitution, i == 0)
 					if resolvedField != nil {
 						break
@@ -407,19 +544,58 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) (removedFie
 			}
 		}
 		if subbed {
+			if !c.reserveVariableExpansion(node.LastRef().AST(), interpolationBytes(s.Value)) {
+				return
+			}
 			s.Coalesce()
 		}
 	case *d2ast.BlockString:
-		variables := make(map[string]string)
-		for _, vars := range varsStack {
-			c.collectVariables(vars, variables)
+		if !strings.Contains(s.Value, "${") {
+			return
 		}
-		preprocessedValue := textmeasure.ReplaceSubstitutionsMarkdown(s.Value, variables)
+		variables := make(map[string]string)
+		seen := make(map[Node]struct{})
+		for _, vars := range varsStack {
+			c.collectVariables(vars, variables, seen, node.LastRef().AST())
+		}
+		if c.stopped() {
+			return
+		}
+		preprocessedValue, expandedBytes, err := textmeasure.ReplaceSubstitutionsMarkdownBounded(c.ctx, s.Value, variables, c.variableExpansion.remaining())
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				c.contextErr = err
+				c.halted = true
+				return
+			}
+			c.errorf(node.LastRef().AST(), "variable substitution expansion exceeds limit of %d work units", c.variableExpansion.limit)
+			c.halted = true
+			return
+		}
+		if expandedBytes > 0 && !c.reserveVariableExpansion(node.LastRef().AST(), expandedBytes) {
+			return
+		}
 
 		// Update the block string value
 		s.Value = preprocessedValue
 	}
 	return removedField
+}
+
+func interpolationBytes(values []d2ast.InterpolationBox) int64 {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	var total int64
+	for _, box := range values {
+		if box.Substitution == nil || box.String == nil {
+			continue
+		}
+		n := int64(len(*box.String))
+		if n > maxInt64-total {
+			return maxInt64
+		}
+		total += n
+	}
+	return total
 }
 
 func (c *compiler) reportCompositeCycle(substitution *d2ast.Substitution) {
@@ -578,22 +754,62 @@ func walkComposite(composite Composite, visit func(Node) bool) bool {
 	return false
 }
 
-func (c *compiler) collectVariables(vars *Map, variables map[string]string) {
-	if vars == nil {
+func (c *compiler) collectVariables(vars *Map, variables map[string]string, seen map[Node]struct{}, source d2ast.Node) {
+	if vars == nil || c.stopped() {
+		return
+	}
+	if !c.visitSubstitutionNode(vars, source, seen) {
 		return
 	}
 	for _, f := range vars.Fields {
+		if c.stopped() {
+			return
+		}
+		if !c.visitSubstitutionNode(f, source, seen) {
+			return
+		}
 		if f.Primary() != nil {
-			variables[f.Name.ScalarString()] = f.Primary().Value.ScalarString()
+			name := f.Name.ScalarString()
+			if !c.reserveVariableExpansion(source, markdownVariablePatternBytes(int64(len(name)))) {
+				return
+			}
+			variables[name] = f.Primary().Value.ScalarString()
 		} else if f.Map() != nil {
 			nestedVars := make(map[string]string)
-			c.collectVariables(f.Map(), nestedVars)
-			for k, v := range nestedVars {
-				variables[f.Name.ScalarString()+"."+k] = v
+			c.collectVariables(f.Map(), nestedVars, seen, source)
+			if c.stopped() {
+				return
 			}
-			c.collectVariables(f.Map(), variables)
+			name := f.Name.ScalarString()
+			for k, v := range nestedVars {
+				if !c.reserveVariableExpansion(source, markdownVariablePatternBytes(joinedVariableNameBytes(name, k))) {
+					return
+				}
+				variables[name+"."+k] = v
+			}
+			c.collectVariables(f.Map(), variables, seen, source)
+			if c.stopped() {
+				return
+			}
 		}
 	}
+}
+
+func markdownVariablePatternBytes(nameBytes int64) int64 {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if nameBytes >= maxInt64-3 {
+		return maxInt64
+	}
+	return nameBytes + 3 // "${" + name + "}"
+}
+
+func joinedVariableNameBytes(prefix, suffix string) int64 {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	total := int64(len(prefix))
+	if total == maxInt64 || int64(len(suffix)) >= maxInt64-total {
+		return maxInt64
+	}
+	return total + 1 + int64(len(suffix))
 }
 
 func (c *compiler) resolveSubstitution(vars *Map, node Node, substitution *d2ast.Substitution, isCurrentScopeVars bool) *Field {
@@ -643,10 +859,16 @@ func (c *compiler) overlay(base *Map, f *Field) {
 		return
 	}
 
+	if !c.reserveVariableCopy(f.LastRef().AST(), base) {
+		return
+	}
 	base = base.CopyBase(f)
 	// Certain fields should never carry forward.
 	// If you give your scenario a label, you don't want all steps in a scenario to be labeled the same.
 	base.DeleteField("label")
+	if !c.reserveVariableCopy(f.LastRef().AST(), f.Map()) {
+		return
+	}
 	overlayMapIndexed(base, f.Map())
 	f.Composite = base
 }
@@ -706,6 +928,9 @@ func (c *compiler) ampersandFilterMap(dst *Map, ast, scopeAST *d2ast.Map) bool {
 }
 
 func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
+	if c.stopped() {
+		return
+	}
 	var globs []*globContext
 	if len(c.globContextStack) > 0 {
 		previousGlobs := c.globContexts()
@@ -763,6 +988,9 @@ func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
 	}
 
 	for _, n := range ast.Nodes {
+		if c.stopped() {
+			return
+		}
 		switch {
 		case n.MapKey != nil:
 			c.compileKey(&RefContext{
@@ -793,6 +1021,9 @@ func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
 			// Spread import
 			impn, ok := c._import(n.Import, dst)
 			if !ok {
+				if c.stopped() {
+					return
+				}
 				continue
 			}
 			if impn.Map() == nil {
@@ -802,6 +1033,9 @@ func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
 			impn.(Importable).SetImportAST(n.Import)
 
 			for _, gctx := range impn.Map().globs {
+				if c.stopped() {
+					return
+				}
 				if !gctx.refctx.Key.HasTripleGlob() {
 					continue
 				}
@@ -814,6 +1048,9 @@ func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
 			scenariosField := impn.Map().getFieldIndexed(d2ast.FlatUnquotedString("scenarios"))
 			if scenariosField != nil && scenariosField.Map() != nil {
 				for _, sf := range scenariosField.Map().Fields {
+					if c.stopped() {
+						return
+					}
 					c.overlay(dst, sf)
 				}
 			}
@@ -821,10 +1058,16 @@ func (c *compiler) compileMap(dst *Map, ast, scopeAST *d2ast.Map) {
 			stepsField := impn.Map().getFieldIndexed(d2ast.FlatUnquotedString("steps"))
 			if stepsField != nil && stepsField.Map() != nil {
 				for _, sf := range stepsField.Map().Fields {
+					if c.stopped() {
+						return
+					}
 					c.overlay(dst, sf)
 				}
 			}
 
+			if !c.reserveVariableCopy(n.Import, impn.Map()) {
+				return
+			}
 			overlayMapIndexed(dst, impn.Map())
 			impDir := n.Import.Dir()
 			c.extendLinks(dst, ParentField(dst), impDir)
@@ -870,6 +1113,9 @@ func (c *compiler) ensureGlobContext(refctx *RefContext) *globContext {
 }
 
 func (c *compiler) compileKey(refctx *RefContext) {
+	if c.stopped() {
+		return
+	}
 	postTargetStart := len(c.lazyPostTargets)
 	if refctx.Key.HasGlob() {
 		for _, refctx2 := range c.globRefContextStack {
@@ -994,11 +1240,17 @@ func (c *compiler) applyLazyGlobs(created []*Field) {
 	c.enqueueLazyGlobFields(created...)
 
 	for len(c.lazyGlobWorklist) > 0 {
+		if c.stopped() {
+			return
+		}
 		target := c.lazyGlobWorklist[0]
 		c.lazyGlobWorklist = c.lazyGlobWorklist[1:]
 
 		var edgeGlobs []*globContext
 		for _, gctx := range c.globContexts() {
+			if c.stopped() {
+				return
+			}
 			if len(gctx.refctx.Key.Edges) > 0 {
 				edgeGlobs = append(edgeGlobs, gctx)
 				continue
@@ -1016,8 +1268,14 @@ func (c *compiler) applyLazyGlobs(created []*Field) {
 		// already been applied to the precise changed fields above.
 		root := RootMap(target.parent.(*Map))
 		for len(edgeGlobs) > 0 {
+			if c.stopped() {
+				return
+			}
 			before := root.structureVersion
 			for _, gctx := range edgeGlobs {
+				if c.stopped() {
+					return
+				}
 				old := c.lazyGlobBeingApplied
 				c.lazyGlobBeingApplied = true
 				c.compileKey(gctx.refctx)
@@ -1031,6 +1289,9 @@ func (c *compiler) applyLazyGlobs(created []*Field) {
 }
 
 func (c *compiler) compileField(dst *Map, kp *d2ast.KeyPath, refctx *RefContext) {
+	if c.stopped() {
+		return
+	}
 	if refctx.Key.Ampersand || refctx.Key.NotAmpersand {
 		return
 	}
@@ -1042,6 +1303,9 @@ func (c *compiler) compileField(dst *Map, kp *d2ast.KeyPath, refctx *RefContext)
 	}
 
 	for _, f := range fa {
+		if c.stopped() {
+			return
+		}
 		c._compileField(f, refctx)
 	}
 }
@@ -1387,6 +1651,9 @@ func (c *compiler) _ampersandFilter(f *Field, refctx *RefContext) bool {
 }
 
 func (c *compiler) _compileField(f *Field, refctx *RefContext) {
+	if c.stopped() {
+		return
+	}
 	// In case of filters, we need to pass filters before continuing
 	if refctx.Key.Value.Map != nil && refctx.Key.Value.Map.HasFilter() {
 		if f.Map() == nil {
@@ -1397,6 +1664,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 		c.mapRefContextStack = append(c.mapRefContextStack, refctx)
 		ok := c.ampersandFilterMap(f.Map(), refctx.Key.Value.Map, refctx.ScopeAST)
 		c.mapRefContextStack = c.mapRefContextStack[:len(c.mapRefContextStack)-1]
+		if c.stopped() {
+			return
+		}
 		if !ok {
 			return
 		}
@@ -1437,6 +1707,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 			parent: f,
 		}
 		c.compileArray(a, refctx.Key.Value.Array, refctx.ScopeAST)
+		if c.stopped() {
+			return
+		}
 		f.Composite = a
 	} else if refctx.Key.Value.Map != nil {
 		scopeAST := refctx.Key.Value.Map
@@ -1447,6 +1720,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 			switch NodeBoardKind(f) {
 			case BoardScenario:
 				c.overlay(ParentBoard(f).Map(), f)
+				if c.stopped() {
+					return
+				}
 			case BoardStep:
 				stepsMap := ParentMap(f)
 				for i := range stepsMap.Fields {
@@ -1455,6 +1731,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 							c.overlay(ParentBoard(f).Map(), f)
 						} else {
 							c.overlay(stepsMap.Fields[i-1].Map(), f)
+						}
+						if c.stopped() {
+							return
 						}
 						break
 					}
@@ -1470,9 +1749,15 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 		c.mapRefContextStack = append(c.mapRefContextStack, refctx)
 		c.compileMap(f.Map(), refctx.Key.Value.Map, scopeAST)
 		c.mapRefContextStack = c.mapRefContextStack[:len(c.mapRefContextStack)-1]
+		if c.stopped() {
+			return
+		}
 		switch NodeBoardKind(f) {
 		case BoardScenario, BoardStep:
 			c.overlayClasses(f.Map())
+			if c.stopped() {
+				return
+			}
 		}
 	} else if refctx.Key.Value.Import != nil {
 		// Non-spread import
@@ -1485,6 +1770,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 		if f.Map() != nil {
 			existingEdges = f.Map().Edges
 		}
+		if !c.reserveVariableCopy(refctx.Key.Value.Import, f) {
+			return
+		}
 		originalF := f.Copy(refctx.ScopeMap).(*Field)
 		switch n := n.(type) {
 		case *Field:
@@ -1492,6 +1780,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 				f.Primary_ = n.Primary_.Copy(f).(*Scalar)
 			}
 			if n.Composite != nil {
+				if !c.reserveVariableCopy(refctx.Key.Value.Import, n.Composite) {
+					return
+				}
 				beforeFields, beforeEdges := structureCounts(f.Map())
 				f.Composite = n.Composite.Copy(f).(Composite)
 				markStructureCountDelta(ParentMap(f), beforeFields, beforeEdges, f.Map())
@@ -1503,6 +1794,9 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 			switch NodeBoardKind(f) {
 			case BoardScenario:
 				c.overlay(ParentBoard(f).Map(), f)
+				if c.stopped() {
+					return
+				}
 			case BoardStep:
 				stepsMap := ParentMap(f)
 				for i := range stepsMap.Fields {
@@ -1512,9 +1806,15 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 						} else {
 							c.overlay(stepsMap.Fields[i-1].Map(), f)
 						}
+						if c.stopped() {
+							return
+						}
 						break
 					}
 				}
+			}
+			if !c.reserveVariableCopy(refctx.Key.Value.Import, n) {
+				return
 			}
 			overlayMapIndexed(f.Map(), n)
 			impDir := refctx.Key.Value.Import.Dir()
@@ -1522,7 +1822,13 @@ func (c *compiler) _compileField(f *Field, refctx *RefContext) {
 			switch NodeBoardKind(f) {
 			case BoardScenario, BoardStep:
 				c.overlayClasses(f.Map())
+				if c.stopped() {
+					return
+				}
 			}
+		}
+		if !c.reserveVariableCopy(refctx.Key.Value.Import, originalF) {
+			return
 		}
 		overlayFieldIndexed(f, originalF)
 		if existingEdges != nil && f.Map() != nil {
@@ -1696,6 +2002,9 @@ func (c *compiler) compileLink(f *Field, refctx *RefContext) {
 }
 
 func (c *compiler) compileEdges(refctx *RefContext) {
+	if c.stopped() {
+		return
+	}
 	if refctx.Key.Key == nil {
 		c._compileEdges(refctx)
 		return
@@ -1707,6 +2016,9 @@ func (c *compiler) compileEdges(refctx *RefContext) {
 		return
 	}
 	for _, f := range fa {
+		if c.stopped() {
+			return
+		}
 		if _, ok := f.Composite.(*Array); ok {
 			c.errorf(refctx.Key.Key, "cannot index into array")
 			return
@@ -1723,8 +2035,14 @@ func (c *compiler) compileEdges(refctx *RefContext) {
 }
 
 func (c *compiler) _compileEdges(refctx *RefContext) {
+	if c.stopped() {
+		return
+	}
 	eida := NewEdgeIDs(refctx.Key)
 	for i, eid := range eida {
+		if c.stopped() {
+			return
+		}
 		if !eid.Glob && (refctx.Key.Primary.Null != nil || refctx.Key.Value.Null != nil) {
 			refctx.ScopeMap.DeleteEdge(eid)
 			continue
@@ -1743,6 +2061,9 @@ func (c *compiler) _compileEdges(refctx *RefContext) {
 				continue
 			}
 			for _, e := range ea {
+				if c.stopped() {
+					return
+				}
 				if refctx.Key.Primary.Null != nil || refctx.Key.Value.Null != nil {
 					refctx.ScopeMap.DeleteEdge(e.ID)
 					continue
@@ -1757,6 +2078,9 @@ func (c *compiler) _compileEdges(refctx *RefContext) {
 					c.mapRefContextStack = append(c.mapRefContextStack, refctx)
 					ok := c.ampersandFilterMap(e.Map_, refctx.Key.Value.Map, refctx.ScopeAST)
 					c.mapRefContextStack = c.mapRefContextStack[:len(c.mapRefContextStack)-1]
+					if c.stopped() {
+						return
+					}
 					if !ok {
 						continue
 					}
@@ -1774,6 +2098,9 @@ func (c *compiler) _compileEdges(refctx *RefContext) {
 							c.mapRefContextStack = append(c.mapRefContextStack, refctx)
 							ok := c.ampersandFilterMap(e.Map_, refctx.Key.Value.Map, refctx.ScopeAST)
 							c.mapRefContextStack = c.mapRefContextStack[:len(c.mapRefContextStack)-1]
+							if c.stopped() {
+								return
+							}
 							if !ok {
 								continue
 							}
@@ -1858,6 +2185,9 @@ func (c *compiler) _compileEdges(refctx *RefContext) {
 		}
 
 		for _, e := range ea {
+			if c.stopped() {
+				return
+			}
 			if refctx.Key.EdgeKey != nil {
 				if e.Map_ == nil {
 					e.Map_ = &Map{
@@ -1902,7 +2232,13 @@ func (c *compiler) _compileEdges(refctx *RefContext) {
 }
 
 func (c *compiler) compileArray(dst *Array, a *d2ast.Array, scopeAST *d2ast.Map) {
+	if c.stopped() {
+		return
+	}
 	for _, an := range a.Nodes {
+		if c.stopped() {
+			return
+		}
 		var irv Value
 		switch v := an.Unbox().(type) {
 		case *d2ast.Array:
@@ -1910,12 +2246,18 @@ func (c *compiler) compileArray(dst *Array, a *d2ast.Array, scopeAST *d2ast.Map)
 				parent: dst,
 			}
 			c.compileArray(ira, v, scopeAST)
+			if c.stopped() {
+				return
+			}
 			irv = ira
 		case *d2ast.Map:
 			irm := &Map{
 				parent: dst,
 			}
 			c.compileMap(irm, v, scopeAST)
+			if c.stopped() {
+				return
+			}
 			irv = irm
 		case d2ast.Scalar:
 			irv = &Scalar{
@@ -1925,6 +2267,9 @@ func (c *compiler) compileArray(dst *Array, a *d2ast.Array, scopeAST *d2ast.Map)
 		case *d2ast.Import:
 			n, ok := c._import(v, dst)
 			if !ok {
+				if c.stopped() {
+					return
+				}
 				continue
 			}
 			n.(Importable).SetImportAST(v)
@@ -1935,6 +2280,9 @@ func (c *compiler) compileArray(dst *Array, a *d2ast.Array, scopeAST *d2ast.Map)
 					if !ok {
 						c.errorf(v, "can only spread import array into array")
 						continue
+					}
+					if !c.reserveVariableCopy(v, a) {
+						return
 					}
 					dst.Values = append(dst.Values, a.Values...)
 					continue
@@ -1962,6 +2310,9 @@ func (c *compiler) compileArray(dst *Array, a *d2ast.Array, scopeAST *d2ast.Map)
 			continue
 		}
 
+		if c.stopped() {
+			return
+		}
 		dst.Values = append(dst.Values, irv)
 	}
 }

--- a/d2ir/d2ir.go
+++ b/d2ir/d2ir.go
@@ -171,8 +171,11 @@ func (s *Scalar) Equal(n2 Node) bool {
 type Map struct {
 	parent    Node
 	importAST d2ast.Node
-	Fields    []*Field `json:"fields"`
-	Edges     []*Edge  `json:"edges"`
+	// variableExpansion is shared across automatic copies created during one
+	// compilation. It is intentionally omitted from JSON output.
+	variableExpansion *variableExpansionBudget
+	Fields            []*Field `json:"fields"`
+	Edges             []*Edge  `json:"edges"`
 
 	globs []*globContext
 
@@ -422,6 +425,10 @@ func (m *Map) SetImportAST(node d2ast.Node) {
 }
 
 func (m *Map) Copy(newParent Node) Node {
+	var variableExpansion *variableExpansionBudget
+	if newParent == nil {
+		variableExpansion = variableExpansionBudgetFor(m)
+	}
 	tmp := *m
 	m = &tmp
 	m.fieldIndex = nil
@@ -441,6 +448,7 @@ func (m *Map) Copy(newParent Node) Node {
 		m.Edges[i] = m.Edges[i].Copy(m).(*Edge)
 	}
 	if m.parent == nil {
+		m.variableExpansion = variableExpansion
 		m.initRoot()
 	}
 	return m
@@ -1643,6 +1651,9 @@ func (m *Map) createEdgeForCompile(eid *EdgeID, refctx *RefContext, c *compiler)
 }
 
 func (m *Map) createEdgeMode(eid *EdgeID, refctx *RefContext, c *compiler, indexed bool) ([]*Edge, error) {
+	if c != nil && c.stopped() {
+		return nil, nil
+	}
 	var ea []*Edge
 	var gctx *globContext
 	if refctx != nil && refctx.Key.HasGlob() && c != nil {
@@ -1651,6 +1662,9 @@ func (m *Map) createEdgeMode(eid *EdgeID, refctx *RefContext, c *compiler, index
 	err := m.createEdge(eid, refctx, gctx, c, indexed, &ea)
 	if len(ea) > 0 && c != nil && len(c.globRefContextStack) == 0 {
 		for _, gctx2 := range c.globContexts() {
+			if c.stopped() {
+				return nil, nil
+			}
 			old := c.lazyGlobBeingApplied
 			c.lazyGlobBeingApplied = true
 			c.compileKey(gctx2.refctx)
@@ -1661,6 +1675,9 @@ func (m *Map) createEdgeMode(eid *EdgeID, refctx *RefContext, c *compiler, index
 }
 
 func (m *Map) createEdge(eid *EdgeID, refctx *RefContext, gctx *globContext, c *compiler, indexed bool, ea *[]*Edge) error {
+	if c != nil && c.stopped() {
+		return nil
+	}
 	if ParentEdge(m) != nil {
 		return d2parser.Errorf(refctx.Edge, "cannot create edge inside edge")
 	}
@@ -1686,6 +1703,9 @@ func (m *Map) createEdge(eid *EdgeID, refctx *RefContext, gctx *globContext, c *
 			return err
 		}
 		for _, f := range fa {
+			if c != nil && c.stopped() {
+				return nil
+			}
 			if _, ok := f.Composite.(*Array); ok {
 				return d2parser.Errorf(refctx.Edge.Src, "cannot index into array")
 			}
@@ -1731,6 +1751,9 @@ func (m *Map) createEdge(eid *EdgeID, refctx *RefContext, gctx *globContext, c *
 
 	for _, src := range srcFA {
 		for _, dst := range dstFA {
+			if c != nil && c.stopped() {
+				return nil
+			}
 			if src == dst && (refctx.Edge.Src.HasGlob() || refctx.Edge.Dst.HasGlob()) {
 				// Globs do not make self edges.
 				continue
@@ -1741,6 +1764,9 @@ func (m *Map) createEdge(eid *EdgeID, refctx *RefContext, gctx *globContext, c *
 				if c.IsContainer(src.Map()) {
 					continue
 				}
+				if c.stopped() {
+					return nil
+				}
 				if NodeBoardKind(src) != "" || ParentBoard(src) != ParentBoard(dst) {
 					continue
 				}
@@ -1749,6 +1775,9 @@ func (m *Map) createEdge(eid *EdgeID, refctx *RefContext, gctx *globContext, c *
 				// If dst has a double glob we only select leafs, those without children.
 				if c.IsContainer(dst.Map()) {
 					continue
+				}
+				if c.stopped() {
+					return nil
 				}
 				if NodeBoardKind(dst) != "" || ParentBoard(src) != ParentBoard(dst) {
 					continue

--- a/d2ir/expansion.go
+++ b/d2ir/expansion.go
@@ -1,0 +1,387 @@
+package d2ir
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/d2lang/d2/d2ast"
+)
+
+// DefaultMaxVariableExpansion is the maximum amount of work that variable
+// substitutions and the copies they induce may add to one compilation. One
+// work unit is one copied IR node or copied slice element, one inserted array
+// member, one produced string byte, one Markdown match candidate, or one byte
+// prepared for a Markdown variable lookup pattern.
+const DefaultMaxVariableExpansion int64 = 65_536
+
+type variableExpansionBudget struct {
+	limit int64
+	used  int64
+}
+
+type variableExpansionLimitError struct {
+	limit int64
+}
+
+func (e *variableExpansionLimitError) Error() string {
+	return fmt.Sprintf("variable substitution expansion exceeds limit of %d work units", e.limit)
+}
+
+func newVariableExpansionBudget(limit int64) (*variableExpansionBudget, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("MaxVariableExpansion must not be negative")
+	}
+	if limit == 0 {
+		limit = DefaultMaxVariableExpansion
+	}
+	return &variableExpansionBudget{limit: limit}, nil
+}
+
+func (b *variableExpansionBudget) remaining() int64 {
+	if b == nil || b.used >= b.limit {
+		return 0
+	}
+	return b.limit - b.used
+}
+
+func (b *variableExpansionBudget) reserve(units int64) error {
+	if units < 0 || units > b.limit-b.used {
+		return &variableExpansionLimitError{limit: b.limit}
+	}
+	b.used += units
+	return nil
+}
+
+func (c *compiler) stopped() bool {
+	if c.halted {
+		return true
+	}
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
+	if c.variableExpansion == nil {
+		c.variableExpansion = &variableExpansionBudget{limit: DefaultMaxVariableExpansion}
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.contextErr = err
+		c.halted = true
+		return true
+	}
+	return false
+}
+
+func (c *compiler) reserveVariableExpansion(n d2ast.Node, units int64) bool {
+	if c.stopped() {
+		return false
+	}
+	if err := c.variableExpansion.reserve(units); err != nil {
+		c.expansionErr = err
+		if n != nil {
+			c.errorf(n, "%v", err)
+		}
+		c.halted = true
+		return false
+	}
+	return true
+}
+
+func (c *compiler) reserveVariableCopy(n d2ast.Node, root Node) bool {
+	err := walkVariableExpansion(c.ctx, root, nil, func(units int64) error {
+		if !c.reserveVariableExpansion(n, units) {
+			if c.contextErr != nil {
+				return c.contextErr
+			}
+			return &variableExpansionLimitError{limit: c.variableExpansion.limit}
+		}
+		return nil
+	})
+	return c.handleVariableExpansionWalkError(err)
+}
+
+func (c *compiler) reserveVariableASTCopy(source d2ast.Node, root *d2ast.Map) bool {
+	ok := true
+	d2ast.Walk(root, func(node d2ast.Node) bool {
+		if !ok || c.stopped() {
+			ok = false
+			return false
+		}
+		ok = c.reserveVariableExpansion(source, variableExpansionASTNodeUnits(node))
+		return ok
+	})
+	return ok
+}
+
+func (c *compiler) handleVariableExpansionWalkError(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		c.contextErr = err
+		c.halted = true
+	}
+	return false
+}
+
+func variableExpansionBudgetFor(m *Map) *variableExpansionBudget {
+	if m == nil {
+		return nil
+	}
+	root := variableExpansionRoot(m)
+	return root.variableExpansion
+}
+
+func ensureVariableExpansionBudget(m *Map) *variableExpansionBudget {
+	root := variableExpansionRoot(m)
+	if root.variableExpansion == nil {
+		root.variableExpansion = &variableExpansionBudget{limit: DefaultMaxVariableExpansion}
+	}
+	return root.variableExpansion
+}
+
+func variableExpansionRoot(m *Map) *Map {
+	for m != nil {
+		parent := ParentMap(m)
+		if parent == nil {
+			return m
+		}
+		m = parent
+	}
+	return nil
+}
+
+// ReserveVariableExpansionAliases accounts for logical IR nodes reached more
+// than once through composite aliases. It must run before graph materialization,
+// which turns those shared references into distinct graph objects.
+func ReserveVariableExpansionAliases(ctx context.Context, m *Map) error {
+	if m == nil {
+		return fmt.Errorf("cannot reserve variable expansion for a nil IR map")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	budget := ensureVariableExpansionBudget(m)
+	seen := make(map[Node]struct{})
+	return walkVariableExpansion(ctx, m, seen, budget.reserve)
+}
+
+// ReserveVariableExpansionCopy accounts for the logical IR nodes an automatic
+// copy will materialize. It shares the same compilation-wide budget used by
+// substitutions and alias materialization.
+func ReserveVariableExpansionCopy(ctx context.Context, m *Map) error {
+	if m == nil {
+		return fmt.Errorf("cannot reserve variable expansion copy for a nil IR map")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	budget := ensureVariableExpansionBudget(m)
+	return walkVariableExpansion(ctx, m, nil, budget.reserve)
+}
+
+// walkVariableExpansion walks logical occurrences rather than unique pointers.
+// When seen is non-nil, only repeated occurrences consume budget.
+func walkVariableExpansion(ctx context.Context, root Node, seen map[Node]struct{}, reserve func(int64) error) error {
+	stack := []Node{root}
+	var seenScalarValues map[d2ast.Scalar]struct{}
+	if seen != nil {
+		seenScalarValues = make(map[d2ast.Scalar]struct{})
+	}
+	for len(stack) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+
+		charge := seen == nil
+		if seen != nil {
+			if _, ok := seen[n]; ok {
+				charge = true
+			} else {
+				seen[n] = struct{}{}
+			}
+		}
+		if charge {
+			if err := reserve(variableExpansionNodeUnits(n)); err != nil {
+				return err
+			}
+		}
+		if scalar, ok := n.(*Scalar); ok && scalar.Value != nil && seenScalarValues != nil {
+			if _, valueSeen := seenScalarValues[scalar.Value]; valueSeen {
+				// Whole-scalar substitutions can create distinct IR Scalar nodes
+				// that share one mutable AST value. If it grows later, pointer-only
+				// Node accounting misses the duplicated logical value.
+				if !charge {
+					if err := reserve(variableExpansionScalarValueUnits(scalar.Value)); err != nil {
+						return err
+					}
+				}
+			} else {
+				seenScalarValues[scalar.Value] = struct{}{}
+			}
+		}
+
+		switch n := n.(type) {
+		case *Map:
+			for i := len(n.Edges) - 1; i >= 0; i-- {
+				stack = append(stack, n.Edges[i])
+			}
+			for i := len(n.Fields) - 1; i >= 0; i-- {
+				stack = append(stack, n.Fields[i])
+			}
+		case *Field:
+			if n.Composite != nil {
+				stack = append(stack, n.Composite)
+			}
+			if n.Primary_ != nil {
+				stack = append(stack, n.Primary_)
+			}
+		case *Edge:
+			if n.Map_ != nil {
+				stack = append(stack, n.Map_)
+			}
+			if n.Primary_ != nil {
+				stack = append(stack, n.Primary_)
+			}
+		case *Array:
+			for i := len(n.Values) - 1; i >= 0; i-- {
+				stack = append(stack, n.Values[i])
+			}
+		}
+	}
+	return nil
+}
+
+func variableExpansionNodeUnits(n Node) int64 {
+	units := int64(1)
+
+	switch n := n.(type) {
+	case *Map:
+		addVariableExpansionUnits(&units, len(n.Fields))
+		addVariableExpansionUnits(&units, len(n.Edges))
+	case *Field:
+		addVariableExpansionUnits(&units, len(n.References))
+		if n.Name != nil {
+			addVariableExpansionUnits64(&units, variableExpansionScalarValueUnits(n.Name))
+		}
+	case *Edge:
+		addVariableExpansionUnits(&units, len(n.References))
+		if n.ID != nil {
+			addVariableExpansionUnits(&units, len(n.ID.SrcPath))
+			addVariableExpansionUnits(&units, len(n.ID.DstPath))
+			for _, part := range n.ID.SrcPath {
+				addVariableExpansionUnits64(&units, variableExpansionScalarValueUnits(part))
+			}
+			for _, part := range n.ID.DstPath {
+				addVariableExpansionUnits64(&units, variableExpansionScalarValueUnits(part))
+			}
+		}
+	case *Scalar:
+		addVariableExpansionUnits64(&units, variableExpansionScalarValueUnits(n.Value))
+	case *Array:
+		addVariableExpansionUnits(&units, len(n.Values))
+	}
+	return units
+}
+
+func variableExpansionScalarValueUnits(scalar d2ast.Scalar) int64 {
+	units := int64(0)
+	switch scalar := scalar.(type) {
+	case *d2ast.UnquotedString:
+		addVariableExpansionUnits(&units, len(scalar.Pattern))
+		addVariableExpansionUnits64(&units, interpolationCopyUnits(scalar.Value))
+	case *d2ast.DoubleQuotedString:
+		addVariableExpansionUnits64(&units, interpolationCopyUnits(scalar.Value))
+	case *d2ast.SingleQuotedString:
+		addVariableExpansionUnits(&units, len(scalar.Value))
+	case *d2ast.BlockString:
+		addVariableExpansionUnits(&units, len(scalar.Value))
+	case *d2ast.Number:
+		addVariableExpansionNumberUnits(&units, scalar)
+	}
+	return units
+}
+
+func variableExpansionASTNodeUnits(n d2ast.Node) int64 {
+	units := int64(1)
+	switch n := n.(type) {
+	case *d2ast.Map:
+		addVariableExpansionUnits(&units, len(n.Nodes))
+	case *d2ast.Array:
+		addVariableExpansionUnits(&units, len(n.Nodes))
+	case *d2ast.Key:
+		addVariableExpansionUnits(&units, len(n.Edges))
+	case *d2ast.KeyPath:
+		addVariableExpansionUnits(&units, len(n.Path))
+	case *d2ast.Substitution:
+		addVariableExpansionUnits(&units, len(n.Path))
+	case *d2ast.Import:
+		addVariableExpansionUnits(&units, len(n.Path))
+	case *d2ast.UnquotedString:
+		addVariableExpansionUnits(&units, len(n.Pattern))
+		addVariableExpansionUnits64(&units, interpolationCopyUnits(n.Value))
+	case *d2ast.DoubleQuotedString:
+		addVariableExpansionUnits64(&units, interpolationCopyUnits(n.Value))
+	case *d2ast.SingleQuotedString:
+		addVariableExpansionUnits(&units, len(n.Value))
+	case *d2ast.BlockString:
+		addVariableExpansionUnits(&units, len(n.Value))
+	case *d2ast.Number:
+		addVariableExpansionNumberUnits(&units, n)
+	}
+	return units
+}
+
+func addVariableExpansionNumberUnits(total *int64, number *d2ast.Number) {
+	addVariableExpansionUnits(total, len(number.Raw))
+	if number.Value == nil {
+		return
+	}
+	for _, bits := range []int{number.Value.Num().BitLen(), number.Value.Denom().BitLen()} {
+		bytes := int64(bits / 8)
+		if bits%8 != 0 {
+			bytes++
+		}
+		addVariableExpansionUnits64(total, bytes)
+	}
+}
+
+func interpolationCopyUnits(values []d2ast.InterpolationBox) int64 {
+	units := int64(0)
+	addVariableExpansionUnits(&units, len(values))
+	for _, value := range values {
+		if value.String != nil {
+			addVariableExpansionUnits(&units, len(*value.String))
+		}
+		if value.StringRaw != nil {
+			addVariableExpansionUnits(&units, len(*value.StringRaw))
+		}
+		if value.Substitution != nil {
+			addVariableExpansionUnits(&units, len(value.Substitution.Path))
+		}
+	}
+	return units
+}
+
+func addVariableExpansionUnits(total *int64, count int) {
+	if count <= 0 {
+		return
+	}
+	addVariableExpansionUnits64(total, int64(count))
+}
+
+func addVariableExpansionUnits64(total *int64, count int64) {
+	if count <= 0 {
+		return
+	}
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if count > maxInt64-*total {
+		*total = maxInt64
+		return
+	}
+	*total += count
+}

--- a/d2ir/expansion_test.go
+++ b/d2ir/expansion_test.go
@@ -1,0 +1,461 @@
+package d2ir
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/d2lang/util-go/mapfs"
+
+	"github.com/d2lang/d2/d2ast"
+	"github.com/d2lang/d2/d2parser"
+)
+
+func TestVariableExpansionBudget(t *testing.T) {
+	t.Parallel()
+
+	budget, err := newVariableExpansionBudget(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if budget.limit != DefaultMaxVariableExpansion {
+		t.Fatalf("zero-value limit = %d, want %d", budget.limit, DefaultMaxVariableExpansion)
+	}
+	if err := budget.reserve(DefaultMaxVariableExpansion); err != nil {
+		t.Fatal(err)
+	}
+	if err := budget.reserve(1); err == nil {
+		t.Fatal("reservation beyond limit succeeded")
+	}
+	if budget.used != DefaultMaxVariableExpansion {
+		t.Fatalf("failed reservation changed used budget to %d", budget.used)
+	}
+	if _, err := newVariableExpansionBudget(-1); err == nil {
+		t.Fatal("negative limit succeeded")
+	}
+	if err := ReserveVariableExpansionAliases(context.Background(), nil); err == nil {
+		t.Fatal("nil IR map reservation succeeded")
+	}
+	if err := ReserveVariableExpansionCopy(context.Background(), nil); err == nil {
+		t.Fatal("nil IR map copy reservation succeeded")
+	}
+}
+
+func TestVariableExpansionCopyUnitsIncludeSlices(t *testing.T) {
+	t.Parallel()
+
+	m := &Map{Fields: make([]*Field, 2), Edges: make([]*Edge, 3)}
+	if got := variableExpansionNodeUnits(m); got != 6 {
+		t.Fatalf("map copy units = %d, want 6", got)
+	}
+	array := &Array{Values: make([]Value, 4)}
+	if got := variableExpansionNodeUnits(array); got != 5 {
+		t.Fatalf("array copy units = %d, want 5", got)
+	}
+	field := &Field{Name: d2ast.FlatUnquotedString("name"), References: make([]*FieldReference, 3)}
+	if got := variableExpansionNodeUnits(field); got != 9 {
+		t.Fatalf("field copy units = %d, want 9", got)
+	}
+	edge := &Edge{
+		ID: &EdgeID{
+			SrcPath: make([]d2ast.String, 2),
+			DstPath: make([]d2ast.String, 3),
+		},
+		References: make([]*EdgeReference, 2),
+	}
+	if got := variableExpansionNodeUnits(edge); got != 8 {
+		t.Fatalf("edge copy units = %d, want 8", got)
+	}
+	number := &Scalar{Value: &d2ast.Number{Raw: strings.Repeat("9", 32)}}
+	if got := variableExpansionNodeUnits(number); got != 33 {
+		t.Fatalf("number copy units = %d, want 33", got)
+	}
+	value := "abcdefgh"
+	stringScalar := &Scalar{Value: &d2ast.UnquotedString{Value: []d2ast.InterpolationBox{{String: &value}}}}
+	if got := variableExpansionNodeUnits(stringScalar); got != 10 {
+		t.Fatalf("string copy units = %d, want 10", got)
+	}
+}
+
+func TestVariableExpansionCopyReservationsAreCumulative(t *testing.T) {
+	t.Parallel()
+
+	ast, err := d2parser.Parse("copy-budget.d2", strings.NewReader("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir, _, err := Compile(ast, &CompileOptions{MaxVariableExpansion: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ReserveVariableExpansionCopy(context.Background(), ir); err != nil {
+		t.Fatalf("first copy reservation: %v", err)
+	}
+	if err := ReserveVariableExpansionCopy(context.Background(), ir); err == nil {
+		t.Fatal("second copy reservation reset the compilation budget")
+	}
+}
+
+func TestVariableExpansionCustomLimitAboveDefault(t *testing.T) {
+	t.Parallel()
+
+	value := strings.Repeat("x", int(DefaultMaxVariableExpansion/2+1))
+	source := fmt.Sprintf("vars: {x: %s}\nout: ${x}${x}", value)
+	ast, err := d2parser.Parse("custom-limit.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Compile(ast, nil)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("limit of %d work units", DefaultMaxVariableExpansion)) {
+		t.Fatalf("default Compile error = %v, want default expansion limit", err)
+	}
+
+	const customLimit = DefaultMaxVariableExpansion + 2
+	ast, err = d2parser.Parse("custom-limit.d2", strings.NewReader(source), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Compile(ast, &CompileOptions{MaxVariableExpansion: customLimit}); err != nil {
+		t.Fatalf("custom limit %d rejected exact-boundary expansion: %v", customLimit, err)
+	}
+}
+
+func TestVariableExpansionStopsBeforeCleanup(t *testing.T) {
+	const helperEnv = "D2_TEST_VARIABLE_EXPANSION_CLEANUP_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		var source strings.Builder
+		source.WriteString("vars: {\n  v0: {leaf}\n")
+		for i := 1; i <= 28; i++ {
+			fmt.Fprintf(&source, "  v%d: {left: ${v%d}; right: ${v%d}}\n", i, i-1, i-1)
+		}
+		source.WriteString("}\nout: ${v28}\n")
+		ast, err := d2parser.Parse("cleanup-helper.d2", strings.NewReader(source.String()), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = Compile(ast, &CompileOptions{MaxVariableExpansion: 64})
+		if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 64 work units") {
+			t.Fatalf("Compile error = %v, want expansion limit", err)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestVariableExpansionStopsBeforeCleanup$")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("rejected expansion continued into exponential cleanup: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("cleanup helper failed: %v\n%s", err, output)
+	}
+}
+
+func TestCompileBoundsCopyCostOfRepeatedNumericAlias(t *testing.T) {
+	t.Parallel()
+
+	compile := func(number string) error {
+		var source strings.Builder
+		fmt.Fprintf(&source, "vars: {\n  v0: {number: %s}\n", number)
+		for i := 1; i <= 4; i++ {
+			fmt.Fprintf(&source, "  v%d: {left: ${v%d}; right: ${v%d}}\n", i, i-1, i-1)
+		}
+		source.WriteString("}\nout: ${v4}\n")
+		ast, err := d2parser.Parse("numeric-alias.d2", strings.NewReader(source.String()), nil)
+		if err != nil {
+			return err
+		}
+		_, _, err = Compile(ast, &CompileOptions{MaxVariableExpansion: 8_192})
+		return err
+	}
+	if err := compile("1"); err != nil {
+		t.Fatalf("small-number structural control rejected: %v", err)
+	}
+	err := compile(strings.Repeat("9", 256))
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 8192 work units") {
+		t.Fatalf("large-number Compile error = %v, want copy-cost expansion limit", err)
+	}
+}
+
+func TestCompileBoundsNestedCopyCostOfArraySpreadAliases(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	fmt.Fprintf(&source, "vars: {items: [{number: %s}]}\nout: [", strings.Repeat("9", 256))
+	for i := 0; i < 8; i++ {
+		source.WriteString("...${items}; ")
+	}
+	source.WriteString("]\n")
+	ast, err := d2parser.Parse("array-alias.d2", strings.NewReader(source.String()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Compile(ast, &CompileOptions{MaxVariableExpansion: 1_024})
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 1024 work units") {
+		t.Fatalf("Compile error = %v, want nested array-spread expansion limit", err)
+	}
+}
+
+func TestCompileRechecksArrayAliasesAfterForwardScalarGrowth(t *testing.T) {
+	t.Parallel()
+
+	compile := func(payload string) error {
+		var source strings.Builder
+		source.WriteString("vars: {\n  seed: ${bomb}\n  values: [${seed}]\n  copies: [")
+		for i := 0; i < 8; i++ {
+			source.WriteString("...${values}; ")
+		}
+		fmt.Fprintf(&source, "]\n  bomb: ${payload}${payload}\n  payload: %s\n}\n", payload)
+		ast, err := d2parser.Parse("forward-array-alias.d2", strings.NewReader(source.String()), nil)
+		if err != nil {
+			return err
+		}
+		_, _, err = Compile(ast, &CompileOptions{MaxVariableExpansion: 4_096})
+		return err
+	}
+	if err := compile("x"); err != nil {
+		t.Fatalf("small forward-growth control rejected: %v", err)
+	}
+	err := compile(strings.Repeat("x", 256))
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 4096 work units") {
+		t.Fatalf("large forward-growth Compile error = %v, want expansion limit", err)
+	}
+}
+
+func TestCompileRechecksDistinctScalarsSharingForwardGrownValue(t *testing.T) {
+	t.Parallel()
+
+	compile := func(payload string) error {
+		var source strings.Builder
+		source.WriteString("vars: {\n  seed: ${bomb}\n")
+		for i := 0; i < 8; i++ {
+			fmt.Fprintf(&source, "  copy-%d: ${seed}\n", i)
+		}
+		fmt.Fprintf(&source, "  bomb: ${payload}${payload}\n  payload: %s\n}\n", payload)
+		ast, err := d2parser.Parse("forward-scalar-alias.d2", strings.NewReader(source.String()), nil)
+		if err != nil {
+			return err
+		}
+		_, _, err = Compile(ast, &CompileOptions{MaxVariableExpansion: 4_096})
+		return err
+	}
+	if err := compile("x"); err != nil {
+		t.Fatalf("small shared-scalar control rejected: %v", err)
+	}
+	err := compile(strings.Repeat("x", 256))
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 4096 work units") {
+		t.Fatalf("large shared-scalar Compile error = %v, want expansion limit", err)
+	}
+}
+
+func TestCompileCancellationDuringIRConstruction(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&source, "object-%d\n", i)
+	}
+	ast, err := d2parser.Parse("canceled.d2", strings.NewReader(source.String()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &cancelAfterErrContext{Context: context.Background(), cancelAt: 16}
+	_, _, err = Compile(ast, &CompileOptions{Context: ctx})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Compile error = %v, want context.Canceled", err)
+	}
+	if ctx.calls < ctx.cancelAt {
+		t.Fatalf("context Err called %d times, want at least %d", ctx.calls, ctx.cancelAt)
+	}
+}
+
+func TestCompileArrayStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	values := strings.Repeat("value; ", 128)
+	ast, err := d2parser.Parse("array-canceled.d2", strings.NewReader("items: ["+values+"]"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	array := ast.Nodes[0].MapKey.Value.Array
+	dst := &Array{}
+	ctx := &cancelAfterErrContext{Context: context.Background(), cancelAt: 4}
+	c := &compiler{
+		ctx:               ctx,
+		variableExpansion: &variableExpansionBudget{limit: DefaultMaxVariableExpansion},
+	}
+	c.compileArray(dst, array, ast)
+	if !errors.Is(c.contextErr, context.Canceled) {
+		t.Fatalf("compileArray error = %v, want context.Canceled", c.contextErr)
+	}
+	if len(dst.Values) >= len(array.Nodes) {
+		t.Fatalf("compileArray materialized %d of %d values after cancellation", len(dst.Values), len(array.Nodes))
+	}
+}
+
+func TestCachedImportASTCloneStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	var source strings.Builder
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&source, "object-%d: {child: value}\n", i)
+	}
+	ast, err := d2parser.Parse("clone-canceled.d2", strings.NewReader(source.String()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &cancelAfterErrContext{Context: context.Background(), cancelAt: 16}
+	cloned, err := cloneASTMapContext(ctx, ast)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("clone error = %v, want context.Canceled", err)
+	}
+	if cloned != nil {
+		t.Fatal("canceled AST clone returned a partial tree")
+	}
+}
+
+func TestCachedImportASTArrayCloneCancellationNeverReturnsPartialValues(t *testing.T) {
+	t.Parallel()
+
+	ast, err := d2parser.Parse("array-clone-canceled.d2", strings.NewReader("items: [1; 2; 3; 4; 5; 6; 7; 8]"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedCancellation := false
+	for cancelAt := 1; cancelAt <= 64; cancelAt++ {
+		ctx := &cancelAfterErrContext{Context: context.Background(), cancelAt: cancelAt}
+		cloned, cloneErr := cloneASTMapContext(ctx, ast)
+		if errors.Is(cloneErr, context.Canceled) {
+			observedCancellation = true
+			if cloned != nil {
+				t.Fatalf("cancelAt %d returned a partial AST clone", cancelAt)
+			}
+			continue
+		}
+		if cloneErr != nil {
+			t.Fatalf("cancelAt %d clone error = %v", cancelAt, cloneErr)
+		}
+	}
+	if !observedCancellation {
+		t.Fatal("array AST clone never observed cancellation")
+	}
+}
+
+func TestImportedArraySpreadChargesInsertedMembers(t *testing.T) {
+	t.Parallel()
+
+	files, err := mapfs.New(map[string]string{
+		"library.d2": "items: [a; b; c; d]",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer files.Close()
+
+	compile := func(source string) *Map {
+		ast, err := d2parser.Parse("index.d2", strings.NewReader(source), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ir, _, err := Compile(ast, &CompileOptions{FS: files, MaxVariableExpansion: 1_024})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ir
+	}
+
+	nonSpread := compile("out: [@library.items]")
+	spread := compile("out: [...@library.items]")
+	nonSpreadUsed := variableExpansionBudgetFor(nonSpread).used
+	spreadUsed := variableExpansionBudgetFor(spread).used
+	if got := spreadUsed - nonSpreadUsed; got != 21 {
+		t.Fatalf("array import spread charged %d extra work units, want 21", got)
+	}
+}
+
+func TestImportedVariableExpansionUsesCompilationBudget(t *testing.T) {
+	t.Parallel()
+
+	var library strings.Builder
+	library.WriteString("vars: {\n  v0: {leaf}\n")
+	for i := 1; i <= 7; i++ {
+		fmt.Fprintf(&library, "  v%d: {left: ${v%d}; right: ${v%d}}\n", i, i-1, i-1)
+	}
+	library.WriteString("}\nout: ${v7}\n")
+	files, err := mapfs.New(map[string]string{
+		"index.d2":   "...@library",
+		"library.d2": library.String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer files.Close()
+	ast, err := d2parser.Parse("index.d2", strings.NewReader("...@library"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Compile(ast, &CompileOptions{FS: files, MaxVariableExpansion: 64})
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 64 work units") {
+		t.Fatalf("Compile error = %v, want shared import expansion limit", err)
+	}
+}
+
+func TestRepeatedImportPeeksUseCompilationBudget(t *testing.T) {
+	t.Parallel()
+
+	var library strings.Builder
+	for i := 0; i < 64; i++ {
+		fmt.Fprintf(&library, "child-%d\n", i)
+	}
+	files, err := mapfs.New(map[string]string{
+		"library.d2": library.String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer files.Close()
+
+	compile := func(source string) error {
+		ast, err := d2parser.Parse("index.d2", strings.NewReader(source), nil)
+		if err != nil {
+			return err
+		}
+		_, _, err = Compile(ast, &CompileOptions{FS: files, MaxVariableExpansion: 8_192})
+		return err
+	}
+	if err := compile("x: { ...@library }\nleaf\n"); err != nil {
+		t.Fatalf("ordinary import rejected: %v", err)
+	}
+
+	var source strings.Builder
+	source.WriteString("x: { ...@library }\n")
+	for i := 0; i < 24; i++ {
+		fmt.Fprintf(&source, "leaf-%d\n", i)
+	}
+	source.WriteString("** -> **\n")
+	err = compile(source.String())
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 8192 work units") {
+		t.Fatalf("repeated import peek error = %v, want expansion limit", err)
+	}
+}
+
+type cancelAfterErrContext struct {
+	context.Context
+	calls    int
+	cancelAt int
+}
+
+func (c *cancelAfterErrContext) Err() error {
+	c.calls++
+	if c.calls >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}

--- a/d2ir/import.go
+++ b/d2ir/import.go
@@ -84,6 +84,9 @@ func (c *compiler) selectImport(ir *Map, imp *d2ast.Import) (Node, bool) {
 }
 
 func (c *compiler) __import(imp *d2ast.Import, templateSafe, fieldImport bool) (Node, bool) {
+	if c.stopped() {
+		return nil, false
+	}
 	impPath, ok := c.pushImportStack(imp)
 	if !ok {
 		return nil, false
@@ -107,16 +110,22 @@ func (c *compiler) __import(imp *d2ast.Import, templateSafe, fieldImport bool) (
 					c.errorf(imp, "import key %q doesn't exist inside import", ida)
 					return nil, false
 				}
+				if !c.reserveVariableCopy(imp, selected) {
+					return nil, false
+				}
 				field := cloneImportField(selected)
 				nilScopeMap(field)
 				return field, true
+			}
+			if !c.reserveVariableCopy(imp, template.ir) {
+				return nil, false
 			}
 			return c.selectImport(cloneImportMap(template.ir), imp)
 		}
 	}
 
 	errCount := len(c.err.Errors)
-	ast, openErr, ok := c.loadImportAST(impPath, c.err)
+	ast, openErr, ok := c.loadImportAST(impPath, imp, c.err)
 	if !ok {
 		if openErr != nil {
 			c.errorf(imp, "failed to import %q: %v", impPath, openErr)
@@ -129,6 +138,9 @@ func (c *compiler) __import(imp *d2ast.Import, templateSafe, fieldImport bool) (
 	ir.parent.(*Field).References[0].Context_.Scope = ast
 
 	c.compileMap(ir, ast, ast)
+	if c.stopped() {
+		return nil, false
+	}
 
 	// We attempt to resolve variables in the imported file scope first
 	// But ignore errors, in case the variable is meant to be resolved at the
@@ -137,9 +149,15 @@ func (c *compiler) __import(imp *d2ast.Import, templateSafe, fieldImport bool) (
 	copy(savedErrors, c.err.Errors)
 	c.compileSubstitutions(ir, nil)
 	c.err.Errors = savedErrors
+	if c.stopped() {
+		return nil, false
+	}
 
 	c.seenImports[impPath] = struct{}{}
 	if cacheable && len(c.err.Errors) == errCount {
+		if !c.reserveVariableCopy(imp, ir) {
+			return nil, false
+		}
 		c.importTemplates[impPath] = &importTemplate{ir: cloneImportMap(ir)}
 	}
 
@@ -188,7 +206,7 @@ func (c *compiler) peekImport(imp *d2ast.Import) (*Map, bool) {
 
 	// Use a separate parse error to avoid polluting the main one
 	localErr := &d2parser.ParseError{}
-	ast, _, ok := c.loadImportAST(impPath, localErr)
+	ast, _, ok := c.loadImportAST(impPath, imp, localErr)
 	if !ok {
 		return nil, false
 	}
@@ -198,13 +216,24 @@ func (c *compiler) peekImport(imp *d2ast.Import) (*Map, bool) {
 	ir.parent.(*Field).References[0].Context_.Scope = ast
 
 	c.compileMap(ir, ast, ast)
+	if c.stopped() {
+		return nil, false
+	}
 
 	return ir, true
 }
 
-func (c *compiler) loadImportAST(impPath string, parseErr *d2parser.ParseError) (*d2ast.Map, error, bool) {
+func (c *compiler) loadImportAST(impPath string, source d2ast.Node, parseErr *d2parser.ParseError) (*d2ast.Map, error, bool) {
 	if ast := c.parsedImports[impPath]; ast != nil {
-		return cloneASTMap(ast), nil, true
+		if !c.reserveVariableASTCopy(source, ast) {
+			return nil, nil, false
+		}
+		cloned, err := cloneASTMapContext(c.ctx, ast)
+		if err != nil {
+			c.handleVariableExpansionWalkError(err)
+			return nil, nil, false
+		}
+		return cloned, nil, true
 	}
 
 	if c.fs == nil {
@@ -224,7 +253,15 @@ func (c *compiler) loadImportAST(impPath string, parseErr *d2parser.ParseError) 
 		return nil, nil, false
 	}
 	c.parsedImports[impPath] = ast
-	return cloneASTMap(ast), nil, true
+	if !c.reserveVariableASTCopy(source, ast) {
+		return nil, nil, false
+	}
+	cloned, err := cloneASTMapContext(c.ctx, ast)
+	if err != nil {
+		c.handleVariableExpansionWalkError(err)
+		return nil, nil, false
+	}
+	return cloned, nil, true
 }
 
 func nilScopeMap(n Node) {

--- a/d2ir/import_cache.go
+++ b/d2ir/import_cache.go
@@ -1,6 +1,7 @@
 package d2ir
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/d2lang/d2/d2ast"
@@ -10,11 +11,50 @@ import (
 // place. Import caches therefore retain an immutable parsed tree and compile a
 // deep clone for each importer context.
 func cloneASTMap(src *d2ast.Map) *d2ast.Map {
+	dst, _ := cloneASTMapContext(context.Background(), src)
+	return dst
+}
+
+type astCloner struct {
+	ctx context.Context
+	err error
+}
+
+func cloneASTMapContext(ctx context.Context, src *d2ast.Map) (*d2ast.Map, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c := &astCloner{ctx: ctx}
+	dst := c.cloneMap(src)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return dst, nil
+}
+
+func (c *astCloner) check() bool {
+	if c.err != nil {
+		return false
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.err = err
+		return false
+	}
+	return true
+}
+
+func (c *astCloner) cloneMap(src *d2ast.Map) *d2ast.Map {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.Map{Range: src.Range, Nodes: make([]d2ast.MapNodeBox, 0, len(src.Nodes))}
 	for _, box := range src.Nodes {
+		if !c.check() {
+			return nil
+		}
 		switch n := box.Unbox().(type) {
 		case *d2ast.Comment:
 			copy := *n
@@ -23,22 +63,43 @@ func cloneASTMap(src *d2ast.Map) *d2ast.Map {
 			copy := *n
 			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(&copy))
 		case *d2ast.Substitution:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloneASTSubstitution(n)))
+			cloned := c.cloneSubstitution(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloned))
 		case *d2ast.Import:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloneASTImport(n)))
+			cloned := c.cloneImport(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloned))
 		case *d2ast.Key:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloneASTKey(n)))
+			cloned := c.cloneKey(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeMapNodeBox(cloned))
+		}
+		if c.err != nil {
+			return nil
 		}
 	}
 	return dst
 }
 
-func cloneASTArray(src *d2ast.Array) *d2ast.Array {
+func (c *astCloner) cloneArray(src *d2ast.Array) *d2ast.Array {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.Array{Range: src.Range, Nodes: make([]d2ast.ArrayNodeBox, 0, len(src.Nodes))}
 	for _, box := range src.Nodes {
+		if !c.check() {
+			return nil
+		}
 		switch n := box.Unbox().(type) {
 		case *d2ast.Comment:
 			copy := *n
@@ -47,32 +108,61 @@ func cloneASTArray(src *d2ast.Array) *d2ast.Array {
 			copy := *n
 			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(&copy))
 		case *d2ast.Substitution:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloneASTSubstitution(n)))
+			cloned := c.cloneSubstitution(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloned))
 		case *d2ast.Import:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloneASTImport(n)))
+			cloned := c.cloneImport(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloned))
 		case *d2ast.Array:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloneASTArray(n)))
+			cloned := c.cloneArray(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloned))
 		case *d2ast.Map:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloneASTMap(n)))
+			cloned := c.cloneMap(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloned))
 		case d2ast.Scalar:
-			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloneASTScalar(n).(d2ast.ArrayNode)))
+			cloned := c.cloneScalar(n)
+			if c.err != nil {
+				return nil
+			}
+			dst.Nodes = append(dst.Nodes, d2ast.MakeArrayNodeBox(cloned.(d2ast.ArrayNode)))
+		}
+		if c.err != nil {
+			return nil
 		}
 	}
 	return dst
 }
 
-func cloneASTKey(src *d2ast.Key) *d2ast.Key {
+func (c *astCloner) cloneKey(src *d2ast.Key) *d2ast.Key {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.Key{
 		Range:        src.Range,
 		Ampersand:    src.Ampersand,
 		NotAmpersand: src.NotAmpersand,
-		Key:          cloneASTKeyPath(src.Key),
-		EdgeKey:      cloneASTKeyPath(src.EdgeKey),
-		Primary:      cloneASTScalarBox(src.Primary),
-		Value:        cloneASTValueBox(src.Value),
+		Key:          c.cloneKeyPath(src.Key),
+		EdgeKey:      c.cloneKeyPath(src.EdgeKey),
+		Primary:      c.cloneScalarBox(src.Primary),
+		Value:        c.cloneValueBox(src.Value),
+	}
+	if c.err != nil {
+		return nil
 	}
 	if src.EdgeIndex != nil {
 		index := *src.EdgeIndex
@@ -84,83 +174,147 @@ func cloneASTKey(src *d2ast.Key) *d2ast.Key {
 	}
 	dst.Edges = make([]*d2ast.Edge, len(src.Edges))
 	for i, edge := range src.Edges {
+		if !c.check() {
+			return nil
+		}
 		dst.Edges[i] = &d2ast.Edge{
 			Range:    edge.Range,
-			Src:      cloneASTKeyPath(edge.Src),
+			Src:      c.cloneKeyPath(edge.Src),
 			SrcArrow: edge.SrcArrow,
-			Dst:      cloneASTKeyPath(edge.Dst),
+			Dst:      c.cloneKeyPath(edge.Dst),
 			DstArrow: edge.DstArrow,
+		}
+		if c.err != nil {
+			return nil
 		}
 	}
 	return dst
 }
 
-func cloneASTKeyPath(src *d2ast.KeyPath) *d2ast.KeyPath {
+func (c *astCloner) cloneKeyPath(src *d2ast.KeyPath) *d2ast.KeyPath {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.KeyPath{Range: src.Range, Path: make([]*d2ast.StringBox, len(src.Path))}
 	for i, part := range src.Path {
-		dst.Path[i] = cloneASTStringBox(part)
+		if !c.check() {
+			return nil
+		}
+		dst.Path[i] = c.cloneStringBox(part)
 	}
 	return dst
 }
 
-func cloneASTStringBox(src *d2ast.StringBox) *d2ast.StringBox {
+func (c *astCloner) cloneStringBox(src *d2ast.StringBox) *d2ast.StringBox {
 	if src == nil || src.Unbox() == nil {
 		return nil
 	}
-	return d2ast.MakeValueBox(cloneASTScalar(src.Unbox())).StringBox()
+	if !c.check() {
+		return nil
+	}
+	cloned := c.cloneScalar(src.Unbox())
+	if c.err != nil {
+		return nil
+	}
+	return d2ast.MakeValueBox(cloned).StringBox()
 }
 
-func cloneASTSubstitution(src *d2ast.Substitution) *d2ast.Substitution {
+func (c *astCloner) cloneSubstitution(src *d2ast.Substitution) *d2ast.Substitution {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.Substitution{Range: src.Range, Spread: src.Spread, Path: make([]*d2ast.StringBox, len(src.Path))}
 	for i, part := range src.Path {
-		dst.Path[i] = cloneASTStringBox(part)
+		if !c.check() {
+			return nil
+		}
+		dst.Path[i] = c.cloneStringBox(part)
 	}
 	return dst
 }
 
-func cloneASTImport(src *d2ast.Import) *d2ast.Import {
+func (c *astCloner) cloneImport(src *d2ast.Import) *d2ast.Import {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	dst := &d2ast.Import{Range: src.Range, Spread: src.Spread, Pre: src.Pre, Path: make([]*d2ast.StringBox, len(src.Path))}
 	for i, part := range src.Path {
-		dst.Path[i] = cloneASTStringBox(part)
+		if !c.check() {
+			return nil
+		}
+		dst.Path[i] = c.cloneStringBox(part)
 	}
 	return dst
 }
 
-func cloneASTScalarBox(src d2ast.ScalarBox) d2ast.ScalarBox {
+func (c *astCloner) cloneScalarBox(src d2ast.ScalarBox) d2ast.ScalarBox {
 	if src.Unbox() == nil {
 		return d2ast.ScalarBox{}
 	}
-	return d2ast.MakeValueBox(cloneASTScalar(src.Unbox())).ScalarBox()
+	if !c.check() {
+		return d2ast.ScalarBox{}
+	}
+	cloned := c.cloneScalar(src.Unbox())
+	if c.err != nil {
+		return d2ast.ScalarBox{}
+	}
+	return d2ast.MakeValueBox(cloned).ScalarBox()
 }
 
-func cloneASTValueBox(src d2ast.ValueBox) d2ast.ValueBox {
+func (c *astCloner) cloneValueBox(src d2ast.ValueBox) d2ast.ValueBox {
+	if !c.check() {
+		return d2ast.ValueBox{}
+	}
 	switch value := src.Unbox().(type) {
 	case nil:
 		return d2ast.ValueBox{}
 	case *d2ast.Map:
-		return d2ast.MakeValueBox(cloneASTMap(value))
+		cloned := c.cloneMap(value)
+		if c.err != nil {
+			return d2ast.ValueBox{}
+		}
+		return d2ast.MakeValueBox(cloned)
 	case *d2ast.Array:
-		return d2ast.MakeValueBox(cloneASTArray(value))
+		cloned := c.cloneArray(value)
+		if c.err != nil {
+			return d2ast.ValueBox{}
+		}
+		return d2ast.MakeValueBox(cloned)
 	case *d2ast.Import:
-		return d2ast.MakeValueBox(cloneASTImport(value))
+		cloned := c.cloneImport(value)
+		if c.err != nil {
+			return d2ast.ValueBox{}
+		}
+		return d2ast.MakeValueBox(cloned)
 	case d2ast.Scalar:
-		return d2ast.MakeValueBox(cloneASTScalar(value))
+		cloned := c.cloneScalar(value)
+		if c.err != nil {
+			return d2ast.ValueBox{}
+		}
+		return d2ast.MakeValueBox(cloned)
 	default:
 		panic("unhandled AST value")
 	}
 }
 
 func cloneASTScalar(src d2ast.Scalar) d2ast.Scalar {
+	return (&astCloner{ctx: context.Background()}).cloneScalar(src)
+}
+
+func (c *astCloner) cloneScalar(src d2ast.Scalar) d2ast.Scalar {
 	if src == nil {
+		return nil
+	}
+	if !c.check() {
 		return nil
 	}
 	switch value := src.(type) {
@@ -178,15 +332,18 @@ func cloneASTScalar(src d2ast.Scalar) d2ast.Scalar {
 		if value.Value != nil {
 			copy.Value = new(big.Rat).Set(value.Value)
 		}
+		if !c.check() {
+			return nil
+		}
 		return &copy
 	case *d2ast.UnquotedString:
 		copy := *value
 		copy.Pattern = append([]string(nil), value.Pattern...)
-		copy.Value = cloneASTInterpolation(value.Value)
+		copy.Value = c.cloneInterpolation(value.Value)
 		return &copy
 	case *d2ast.DoubleQuotedString:
 		copy := *value
-		copy.Value = cloneASTInterpolation(value.Value)
+		copy.Value = c.cloneInterpolation(value.Value)
 		return &copy
 	case *d2ast.SingleQuotedString:
 		copy := *value
@@ -199,9 +356,15 @@ func cloneASTScalar(src d2ast.Scalar) d2ast.Scalar {
 	}
 }
 
-func cloneASTInterpolation(src []d2ast.InterpolationBox) []d2ast.InterpolationBox {
+func (c *astCloner) cloneInterpolation(src []d2ast.InterpolationBox) []d2ast.InterpolationBox {
+	if !c.check() {
+		return nil
+	}
 	dst := make([]d2ast.InterpolationBox, len(src))
 	for i, box := range src {
+		if !c.check() {
+			return nil
+		}
 		if box.String != nil {
 			value := *box.String
 			dst[i].String = &value
@@ -210,7 +373,10 @@ func cloneASTInterpolation(src []d2ast.InterpolationBox) []d2ast.InterpolationBo
 			value := *box.StringRaw
 			dst[i].StringRaw = &value
 		}
-		dst[i].Substitution = cloneASTSubstitution(box.Substitution)
+		dst[i].Substitution = c.cloneSubstitution(box.Substitution)
+		if c.err != nil {
+			return nil
+		}
 	}
 	return dst
 }

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -23,6 +23,9 @@ import (
 
 type CompileOptions struct {
 	UTF16Pos bool
+	// MaxVariableExpansion bounds work added by variable substitutions and the
+	// automatic copies they induce. Zero uses the secure compiler default.
+	MaxVariableExpansion int64
 	// FS is the file system used for resolving imports in the D2 text. Nil
 	// disables imports. Callers that accept untrusted input should prefer a
 	// filesystem constrained to the intended import root; lib/localfile provides
@@ -79,9 +82,10 @@ func compileInput(ctx context.Context, input string, compileOpts *CompileOptions
 	}
 
 	g, config, err := d2compiler.Compile(compileOpts.InputPath, strings.NewReader(input), &d2compiler.CompileOptions{
-		Context:  ctx,
-		UTF16Pos: compileOpts.UTF16Pos,
-		FS:       compileOpts.FS,
+		Context:              ctx,
+		UTF16Pos:             compileOpts.UTF16Pos,
+		MaxVariableExpansion: compileOpts.MaxVariableExpansion,
+		FS:                   compileOpts.FS,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/d2lib/d2_test.go
+++ b/d2lib/d2_test.go
@@ -28,6 +28,15 @@ func TestParseAndCompileHonorCanceledContext(t *testing.T) {
 	}
 }
 
+func TestCompilePropagatesVariableExpansionLimit(t *testing.T) {
+	_, _, err := Compile(context.Background(), "vars: {x: 12345678}\nout: ${x}${x}${x}${x}${x}", &CompileOptions{
+		MaxVariableExpansion: 32,
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "variable substitution expansion exceeds limit of 32 work units") {
+		t.Fatalf("Compile() error = %v, want variable expansion limit", err)
+	}
+}
+
 func TestNilFSDeniesImports(t *testing.T) {
 	directory := t.TempDir()
 	if err := os.WriteFile(filepath.Join(directory, "secret.d2"), []byte("disclosed"), 0o600); err != nil {

--- a/lib/textmeasure/substitutions.go
+++ b/lib/textmeasure/substitutions.go
@@ -1,6 +1,8 @@
 package textmeasure
 
 import (
+	"context"
+	"errors"
 	"sort"
 	"strings"
 
@@ -9,6 +11,33 @@ import (
 )
 
 func ReplaceSubstitutionsMarkdown(mdText string, variables map[string]string) string {
+	result, _, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), mdText, variables, int64(^uint64(0)>>1))
+	if err != nil {
+		return mdText
+	}
+	return result
+}
+
+// ReplaceSubstitutionsMarkdownBounded replaces variables outside Markdown code
+// spans and blocks while bounding candidate-match work and bytes inserted by
+// replacements. It checks the bound before each allocating replacement.
+func ReplaceSubstitutionsMarkdownBounded(ctx context.Context, mdText string, variables map[string]string, maxExpansion int64) (string, int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if maxExpansion < 0 {
+		return "", 0, errors.New("negative Markdown substitution expansion limit")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	if len(variables) == 0 || !strings.Contains(mdText, "${") {
+		return mdText, 0, nil
+	}
+	matcher, err := newMarkdownSubstitutionMatcher(ctx, variables)
+	if err != nil {
+		return "", 0, err
+	}
 	source := []byte(mdText)
 	reader := text.NewReader(source)
 	doc := markdownRenderer.Parser().Parse(reader)
@@ -19,8 +48,13 @@ func ReplaceSubstitutionsMarkdown(mdText string, variables map[string]string) st
 		newVal string
 	}
 	var substitutions []substitution
+	var expansion int64
+	var walkErr error
 
-	ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+	err = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if err := ctx.Err(); err != nil {
+			return ast.WalkStop, err
+		}
 		if !entering {
 			return ast.WalkContinue, nil
 		}
@@ -32,7 +66,12 @@ func ReplaceSubstitutionsMarkdown(mdText string, variables map[string]string) st
 		if textNode, ok := n.(*ast.Text); ok {
 			segment := textNode.Segment
 			originalText := string(segment.Value(source))
-			newText := replaceVariables(originalText, variables)
+			newText, used, err := matcher.replaceBounded(ctx, originalText, maxExpansion-expansion)
+			if err != nil {
+				walkErr = err
+				return ast.WalkStop, err
+			}
+			expansion += used
 
 			if originalText != newText {
 				substitutions = append(substitutions, substitution{
@@ -44,21 +83,36 @@ func ReplaceSubstitutionsMarkdown(mdText string, variables map[string]string) st
 		}
 		return ast.WalkContinue, nil
 	})
+	if err != nil {
+		if walkErr != nil {
+			return "", 0, walkErr
+		}
+		return "", 0, err
+	}
 
 	if len(substitutions) == 0 {
-		return mdText
+		return mdText, expansion, nil
 	}
 
 	sort.Slice(substitutions, func(i, j int) bool {
-		return substitutions[i].start > substitutions[j].start
+		return substitutions[i].start < substitutions[j].start
 	})
 
-	result := string(source)
+	resultLen := len(source)
 	for _, sub := range substitutions {
-		result = result[:sub.start] + sub.newVal + result[sub.stop:]
+		resultLen += len(sub.newVal) - (sub.stop - sub.start)
 	}
+	var result strings.Builder
+	result.Grow(resultLen)
+	start := 0
+	for _, sub := range substitutions {
+		result.Write(source[start:sub.start])
+		result.WriteString(sub.newVal)
+		start = sub.stop
+	}
+	result.Write(source[start:])
 
-	return result
+	return result.String(), expansion, nil
 }
 
 func isCodeNode(n ast.Node) bool {
@@ -69,9 +123,207 @@ func isCodeNode(n ast.Node) bool {
 	return false
 }
 
-func replaceVariables(s string, vars map[string]string) string {
-	for k, v := range vars {
-		s = strings.ReplaceAll(s, "${"+k+"}", v)
+type markdownSubstitutionState struct {
+	next          map[byte]int
+	fail          int
+	outputLink    int
+	terminal      bool
+	patternLength int
+	value         string
+}
+
+type markdownSubstitutionMatcher struct {
+	states []markdownSubstitutionState
+}
+
+func newMarkdownSubstitutionMatcher(ctx context.Context, vars map[string]string) (*markdownSubstitutionMatcher, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	return s
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	matcher := &markdownSubstitutionMatcher{
+		states: []markdownSubstitutionState{{outputLink: -1}},
+	}
+	// Build one byte-oriented Aho-Corasick matcher for the whole Markdown
+	// document. Complete ${key} patterns are necessary because quoted D2
+	// variable names may themselves contain a closing brace.
+	states := matcher.states
+	for key, value := range vars {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		pattern := "${" + key + "}"
+		state := 0
+		for i := 0; i < len(pattern); i++ {
+			if i&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+			}
+			next, ok := states[state].next[pattern[i]]
+			if !ok {
+				next = len(states)
+				if states[state].next == nil {
+					states[state].next = make(map[byte]int)
+				}
+				states[state].next[pattern[i]] = next
+				states = append(states, markdownSubstitutionState{outputLink: -1})
+			}
+			state = next
+		}
+		states[state].terminal = true
+		states[state].patternLength = len(pattern)
+		states[state].value = value
+	}
+
+	queue := make([]int, 0, len(states)-1)
+	for _, next := range states[0].next {
+		queue = append(queue, next)
+	}
+	for head := 0; head < len(queue); head++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		state := queue[head]
+		for b, next := range states[state].next {
+			failure := states[state].fail
+			for failure != 0 {
+				if _, ok := states[failure].next[b]; ok {
+					break
+				}
+				failure = states[failure].fail
+			}
+			if candidate, ok := states[failure].next[b]; ok {
+				states[next].fail = candidate
+			}
+			failure = states[next].fail
+			if states[failure].terminal {
+				states[next].outputLink = failure
+			} else {
+				states[next].outputLink = states[failure].outputLink
+			}
+			queue = append(queue, next)
+		}
+	}
+	matcher.states = states
+	return matcher, nil
+}
+
+func (matcher *markdownSubstitutionMatcher) replaceBounded(ctx context.Context, s string, maxExpansion int64) (string, int64, error) {
+	type replacement struct {
+		start int
+		stop  int
+		value string
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if maxExpansion < 0 {
+		return "", 0, errors.New("negative Markdown substitution expansion limit")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	if len(s) == 0 || matcher == nil || len(matcher.states) == 0 {
+		return s, 0, nil
+	}
+	states := matcher.states
+	var bestAtStart map[int]replacement
+	var used int64
+	state := 0
+	for i := 0; i < len(s); i++ {
+		if i&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				return "", 0, err
+			}
+		}
+		b := s[i]
+		for state != 0 {
+			if _, ok := states[state].next[b]; ok {
+				break
+			}
+			state = states[state].fail
+		}
+		if next, ok := states[state].next[b]; ok {
+			state = next
+		} else {
+			state = 0
+		}
+
+		for candidate := state; candidate != -1; candidate = states[candidate].outputLink {
+			match := states[candidate]
+			if !match.terminal {
+				continue
+			}
+			if used >= maxExpansion {
+				return "", 0, errors.New("Markdown substitution expansion limit exceeded")
+			}
+			used++
+			if used&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return "", 0, err
+				}
+			}
+			start := i + 1 - match.patternLength
+			if start < 0 {
+				continue
+			}
+			stop := i + 1
+			existing, ok := bestAtStart[start]
+			if !ok || stop-start > existing.stop-existing.start {
+				if bestAtStart == nil {
+					bestAtStart = make(map[int]replacement)
+				}
+				bestAtStart[start] = replacement{start: start, stop: stop, value: match.value}
+			}
+		}
+	}
+
+	var replacements []replacement
+	for i := 0; i < len(s); {
+		if i&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				return "", 0, err
+			}
+		}
+		replacement, ok := bestAtStart[i]
+		if !ok {
+			i++
+			continue
+		}
+		if int64(len(replacement.value)) > maxExpansion-used {
+			return "", 0, errors.New("Markdown substitution expansion limit exceeded")
+		}
+		used += int64(len(replacement.value))
+		replacements = append(replacements, replacement)
+		i = replacement.stop
+	}
+	if len(replacements) == 0 {
+		return s, 0, nil
+	}
+
+	resultLen := len(s)
+	const maxInt = int(^uint(0) >> 1)
+	for _, replacement := range replacements {
+		delta := len(replacement.value) - (replacement.stop - replacement.start)
+		if delta > 0 && resultLen > maxInt-delta {
+			return "", 0, errors.New("Markdown substitution result is too large")
+		}
+		resultLen += delta
+	}
+	var result strings.Builder
+	result.Grow(resultLen)
+	written := 0
+	for _, replacement := range replacements {
+		if err := ctx.Err(); err != nil {
+			return "", 0, err
+		}
+		result.WriteString(s[written:replacement.start])
+		result.WriteString(replacement.value)
+		written = replacement.stop
+	}
+	result.WriteString(s[written:])
+	return result.String(), used, nil
 }

--- a/lib/textmeasure/substitutions_test.go
+++ b/lib/textmeasure/substitutions_test.go
@@ -1,0 +1,232 @@
+package textmeasure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReplaceSubstitutionsMarkdownBounded(t *testing.T) {
+	t.Parallel()
+
+	input := "before ${x} `code ${x}`\n\n```\n${x}\n```\nafter ${x}"
+	want := "before value `code ${x}`\n\n```\n${x}\n```\nafter value"
+	got, used, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), input, map[string]string{"x": "value"}, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("replacement = %q, want %q", got, want)
+	}
+	if used != 12 {
+		t.Fatalf("replacement work = %d, want 12", used)
+	}
+
+	got, _, err = ReplaceSubstitutionsMarkdownBounded(context.Background(), "${x}", map[string]string{
+		"x": strings.Repeat("x", 1<<20),
+	}, 32)
+	if err == nil || got != "" {
+		t.Fatalf("oversized replacement = (%q, %v), want rejection before result", got, err)
+	}
+
+	got, used, err = ReplaceSubstitutionsMarkdownBounded(context.Background(), "${x} ${missing}", map[string]string{
+		"x": "${y}",
+		"y": "resolved",
+	}, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "${y} ${missing}" || used != 5 {
+		t.Fatalf("single-pass replacement = (%q, %d), want (%q, 5)", got, used, "${y} ${missing}")
+	}
+
+	got, used, err = ReplaceSubstitutionsMarkdownBounded(context.Background(), "${a}b}", map[string]string{
+		"a}b": "value",
+	}, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "value" || used != 6 {
+		t.Fatalf("quoted-key replacement = (%q, %d), want (%q, 6)", got, used, "value")
+	}
+
+	got, used, err = ReplaceSubstitutionsMarkdownBounded(context.Background(), "${a}b}", map[string]string{
+		"a":   "short",
+		"a}b": "long",
+	}, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "long" || used != 6 {
+		t.Fatalf("overlapping replacement = (%q, %d), want (%q, 6)", got, used, "long")
+	}
+}
+
+func TestMarkdownMatcherBoundsSuffixCandidateWork(t *testing.T) {
+	t.Parallel()
+
+	variables := make(map[string]string, 128)
+	for i := 1; i <= 128; i++ {
+		variables["a"+strings.Repeat("}${a", i-1)] = ""
+	}
+	input := strings.Repeat("${a}", 1_024)
+	_, _, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), input, variables, 512)
+	if err == nil || !strings.Contains(err.Error(), "Markdown substitution expansion limit exceeded") {
+		t.Fatalf("suffix candidate work error = %v, want expansion limit", err)
+	}
+
+	got, used, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), "${a}", map[string]string{"a": ""}, 1)
+	if err != nil {
+		t.Fatalf("exact candidate boundary rejected: %v", err)
+	}
+	if got != "" || used != 1 {
+		t.Fatalf("exact candidate boundary = (%q, %d), want empty output and 1 work unit", got, used)
+	}
+}
+
+func TestReplaceSubstitutionsMarkdownChargesIdentityReplacementWork(t *testing.T) {
+	t.Parallel()
+
+	got, used, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), "${x}", map[string]string{"x": "${x}"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "${x}" || used != 5 {
+		t.Fatalf("identity replacement = (%q, %d), want (%q, 5)", got, used, "${x}")
+	}
+	if _, _, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), "${x}", map[string]string{"x": "${x}"}, 4); err == nil {
+		t.Fatal("identity replacement succeeded below its work boundary")
+	}
+}
+
+func TestReplaceSubstitutionsMarkdownLeavesUnknownPlaceholdersUnchanged(t *testing.T) {
+	t.Parallel()
+
+	var input strings.Builder
+	for i := 0; i < 32; i++ {
+		fmt.Fprintf(&input, "${unknown-%d} ", i)
+	}
+	want := input.String()
+	got, used, err := ReplaceSubstitutionsMarkdownBounded(context.Background(), want, map[string]string{"known": "value"}, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want || used != 0 {
+		t.Fatalf("unknown placeholders = (%q, %d), want unchanged input", got, used)
+	}
+}
+
+func TestReplaceSubstitutionsMarkdownIgnoresUnreferencedVariablesInLinearTime(t *testing.T) {
+	t.Parallel()
+
+	variables := make(map[string]string, 10_000)
+	for i := 0; i < 10_000; i++ {
+		variables[fmt.Sprintf("unused-%d", i)] = ""
+	}
+	ctx := &markdownCancelAfterErrContext{Context: context.Background(), cancelAt: 100}
+	got, used, err := ReplaceSubstitutionsMarkdownBounded(ctx, "no substitutions here", variables, 32)
+	if err != nil {
+		t.Fatalf("unreferenced variables consumed scan work: %v", err)
+	}
+	if got != "no substitutions here" || used != 0 {
+		t.Fatalf("replacement = (%q, %d), want unchanged input", got, used)
+	}
+	if ctx.calls >= ctx.cancelAt {
+		t.Fatalf("context checked %d times for unreferenced variables, want fewer than %d", ctx.calls, ctx.cancelAt)
+	}
+}
+
+func TestMarkdownMatcherNoMatchStorageIsSparse(t *testing.T) {
+	matcher, err := newMarkdownSubstitutionMatcher(context.Background(), map[string]string{
+		"one":   "1",
+		"two":   "2",
+		"three": "3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range matcher.states {
+		if state.terminal && state.next != nil {
+			t.Fatal("terminal trie state eagerly allocated a transition map")
+		}
+	}
+
+	input := "${unknown} " + strings.Repeat("plain text without matches ", 1<<15)
+	allocations := testing.AllocsPerRun(5, func() {
+		got, used, err := matcher.replaceBounded(context.Background(), input, 32)
+		if err != nil || got != input || used != 0 {
+			panic("unexpected no-match result")
+		}
+	})
+	if allocations > 1 {
+		t.Fatalf("no-match scan allocated %.1f objects, want at most 1 independent of source length", allocations)
+	}
+}
+
+func TestReplaceSubstitutionsMarkdownBoundedCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx := &markdownCancelAfterErrContext{Context: context.Background(), cancelAt: 5}
+	_, _, err := ReplaceSubstitutionsMarkdownBounded(ctx, "${x}", map[string]string{"x": "value"}, 32)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("replacement error = %v, want context.Canceled", err)
+	}
+	if ctx.calls < ctx.cancelAt {
+		t.Fatalf("context Err called %d times, want at least %d", ctx.calls, ctx.cancelAt)
+	}
+}
+
+func TestReplaceSubstitutionsMarkdownMatchesManyPatternsInLinearTime(t *testing.T) {
+	const helperEnv = "D2_MARKDOWN_SUBSTITUTION_COMPLEXITY_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		const count = 10_000
+		variables := make(map[string]string, count)
+		var input strings.Builder
+		for i := 0; i < count; i++ {
+			variables[fmt.Sprintf("known-%d", i)] = "value"
+			fmt.Fprintf(&input, "${unknown-%d} *separator* ", i)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		want := input.String()
+		got, used, err := ReplaceSubstitutionsMarkdownBounded(ctx, want, variables, 32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want || used != 0 {
+			t.Fatalf("many-pattern replacement used %d bytes or changed unknown placeholders", used)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestReplaceSubstitutionsMarkdownMatchesManyPatternsInLinearTime$")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("many-pattern Markdown substitution exceeded bounded runtime: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("many-pattern Markdown substitution failed: %v\n%s", err, output)
+	}
+}
+
+type markdownCancelAfterErrContext struct {
+	context.Context
+	calls    int
+	cancelAt int
+}
+
+func (c *markdownCancelAfterErrContext) Err() error {
+	c.calls++
+	if c.calls >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}


### PR DESCRIPTION
## Human

---

## AI

### Summary

- enforce a compilation-wide 65,536-unit default budget before variable substitutions or automatic copies materialize
- cover scalar and Markdown output, array and map spreads, composite aliases, boards, imports, and classes
- honor context cancellation throughout IR and graph compilation

### Security

A few hundred bytes of D2 source could build a shared composite-variable DAG that materialized as hundreds of thousands of graph objects, exhausting more than a gigabyte of memory before cancellation could run. The compiler now accounts for every multiplicative occurrence and automatic copy before allocating it, while Markdown matching is linear in the input plus bounded match work.

### Compatibility

Explicitly authored graph nodes do not consume the new budget unless D2 automatically copies them for boards, imports, or classes. The default is 65,536 work units; trusted Go callers can raise it with MaxVariableExpansion. Negative limits are rejected.

### Testing

- full Go suite and focused race tests
- scalar, Markdown, array, map, composite, board, import, and class regression cases
- deterministic cancellation tests during IR and graph compilation
- adversarial reproductions for the prior composite, scalar, array, and class amplification paths